### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+services:
+ - docker
+
+before_install:
+ - docker pull neverpanic/mococrw-build-env
+ - docker images
+
+script:
+  - mkdir build
+  - docker run --rm -t -v "$(readlink -f .):/src" -v "$(readlink -f build):/build" --workdir /build neverpanic/mococrw-build-env cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_TESTING=On /src
+  - docker run --rm -t -v "$(readlink -f .):/src" -v "$(readlink -f build):/build" --workdir /build neverpanic/mococrw-build-env make -j2
+  - docker run --rm -t -v "$(readlink -f .):/src" -v "$(readlink -f build):/build" --workdir /build neverpanic/mococrw-build-env ctest -j2 --output-on-failure

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,8 +2,18 @@ project(mococrw)
 
 if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     if(NOT GMOCK_BOTH_LIBRARIES)
-        find_package(GMock REQUIRED CONFIG)
-        include_directories(SYSTEM ${GMOCK_INCLUDE_DIRS})
+        find_path(GMOCK_SRC_DIR
+            NAMES src/gmock-all.cc
+            PATHS /usr/src/gmock /usr/src/googletest/googlemock
+            NO_DEFAULT_PATH
+            ONLY_CMAKE_FIND_ROOT_PATH)
+        if(GMOCK_SRC_DIR)
+            message(STATUS "Found GMock sources in ${GMOCK_SRC_DIR}")
+            add_subdirectory("${GMOCK_SRC_DIR}" gmock)
+            set(GMOCK_BOTH_LIBRARIES "gmock_main")
+        else()
+            message(FATAL_ERROR "GMock sources not found build -DBUILD_TESTING=On requested!")
+        endif()
     endif()
 
     #TODO: clean this up

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -48,6 +48,12 @@ void OpenSSLLibMockManager::resetMock()
     _mock = std::make_unique<OpenSSLLibMock>();
 }
 
+void OpenSSLLibMockManager::destroy()
+{
+    std::lock_guard<std::mutex> _lock(_mutex);
+    _mock.reset();
+}
+
 namespace lib
 {
 /**

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -27,13 +27,13 @@ namespace mococrw
 {
 namespace openssl
 {
-std::unique_ptr<OpenSSLLibMock> OpenSSLLibMockManager::_mock{nullptr};
+std::unique_ptr<::testing::NiceMock<OpenSSLLibMock>> OpenSSLLibMockManager::_mock{nullptr};
 std::mutex OpenSSLLibMockManager::_mutex{};
 
 /*
  * If there is no mock yet, we create a new one.
  */
-OpenSSLLibMock& OpenSSLLibMockManager::getMockInterface()
+testing::NiceMock<OpenSSLLibMock>& OpenSSLLibMockManager::getMockInterface()
 {
     if (!_mock) {
         resetMock();
@@ -45,7 +45,7 @@ OpenSSLLibMock& OpenSSLLibMockManager::getMockInterface()
 void OpenSSLLibMockManager::resetMock()
 {
     std::lock_guard<std::mutex> _lock(_mutex);
-    _mock = std::make_unique<OpenSSLLibMock>();
+    _mock = std::make_unique<::testing::NiceMock<OpenSSLLibMock>>();
 }
 
 void OpenSSLLibMockManager::destroy()

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -405,7 +405,7 @@ public:
      * Access the OpenSSLLibMock instance currently
      * maintained. Create a new one, if none is present.
      */
-    static OpenSSLLibMock& getMockInterface();
+    static ::testing::NiceMock<OpenSSLLibMock>& getMockInterface();
 
     /**
      * Reset the current OpenSSLLibMock instance
@@ -419,7 +419,7 @@ public:
     static void destroy();
 
 private:
-    static std::unique_ptr<OpenSSLLibMock> _mock;
+    static std::unique_ptr<::testing::NiceMock<OpenSSLLibMock>> _mock;
 
     /* Unsure how much parallization happens with regard to the tests
      * but let's be safe

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -413,6 +413,11 @@ public:
      */
     static void resetMock();
 
+    /**
+     * Destroy current mock object to trigger gmock call analysis
+     */
+    static void destroy();
+
 private:
     static std::unique_ptr<OpenSSLLibMock> _mock;
 

--- a/tests/unit/test_opensslwrapper.cpp
+++ b/tests/unit/test_opensslwrapper.cpp
@@ -47,6 +47,7 @@ class OpenSSLWrapperTest : public ::testing::Test
 {
 public:
     void SetUp() override;
+    void TearDown() override;
 
 protected:
     std::string _defaultErrorMessage{"bla bla bla"};
@@ -75,6 +76,11 @@ void OpenSSLWrapperTest::SetUp()
     ON_CALL(_mock(), SSL_ERR_error_string(_, nullptr))
             .WillByDefault(Return(const_cast<char *>(_defaultErrorMessage.c_str())));
     // TODO: Get rid of the uninteresting calls by default here somehow...
+}
+
+void OpenSSLWrapperTest::TearDown()
+{
+    OpenSSLLibMockManager::destroy();
 }
 
 /*


### PR DESCRIPTION
This commit series adds Travis CI support for MoCOCrW. To make the tests pass, the following additional changes were required:

 - Building GMock from source
 - Change `test_ca` to work with unwritable working directories
 - Clean up the OpenSSL lib mock object after tests

Note that this currently uses the docker container from https://github.com/neverpanic/mococrw-build-env, which is automatically built on Docker Hub. We may eventually want to move this to a more official location.

A successful build can be seen at https://travis-ci.com/neverpanic/MoCOCrW.