### PR TITLE
Added support to create ECC asymmetric keys

### DIFF
--- a/src/ca.cpp
+++ b/src/ca.cpp
@@ -49,6 +49,12 @@ X509Certificate CertificateAuthority::createRootCertificate(const AsymmetricKeyp
                                           const CertificateSigningParameters &signParams)
 {
     auto basicConstraints = signParams.extension<BasicConstraintsExtension>();
+
+    /* Temporary guard, ECC support will be added in the near future*/
+    if (privateKey.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("CA creation is only supported with RSA keys");
+    }
+
     if (basicConstraints == nullptr) {
         throw MoCOCrWException("Signing parameters for a CA must include X509v3 basic extension");
     }

--- a/src/csr.cpp
+++ b/src/csr.cpp
@@ -29,6 +29,11 @@ CertificateSigningRequest::CertificateSigningRequest(const DistinguishedName &dn
                                                      const AsymmetricKeypair &keypair)
         : _req{openssl::_X509_REQ_new()}
 {
+    /* Temporary guard, ECC support will be added in the near future*/
+    if(keypair.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("CSR is only supported using RSA keys");
+    }
+
     /* setup x509 version number */
     _X509_REQ_set_version(_req.get(), 0L);
 

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -33,6 +33,7 @@ extern "C" {
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
+#include <openssl/ec.h>
 }
 
 namespace mococrw
@@ -121,6 +122,14 @@ public:
     static void SSL_EVP_PKEY_CTX_free(EVP_PKEY_CTX* ptr) noexcept;
     static int SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits) noexcept;
     static int SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) noexcept;
+    static int SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) noexcept;
+    static int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) noexcept;
+    static const EC_GROUP *SSL_EC_KEY_get0_group(const EC_KEY *key) noexcept;
+    static int SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) noexcept;
+    static int SSL_EVP_PKEY_type(int type) noexcept;
+    static int SSL_EVP_PKEY_size(EVP_PKEY *pkey) noexcept;
 
     /* Reference counting magic */
     static int SSL_CRYPTO_add(int *pointer, int amount, int type) noexcept;

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -254,6 +254,67 @@ void _EVP_PKEY_keygen_init(EVP_PKEY_CTX* ctx);
  */
 void _EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits);
 
+/**
+ * Initializes the key context so we can set the appropriate parameters for the key generation
+ * @param ctx [out] initialized context
+ * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+ */
+void _EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx);
+
+/**
+ * Generates the parameters to be used on the key generation.
+ * @param ctx context for parameter generation
+ * @return the generated parameters to be used on the key generation
+ * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+ */
+SSL_EVP_PKEY_Ptr _EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx);
+
+ /**
+  * Set the the elliptic curve used to generate the key pair
+  *
+  * @param ctx [in, out] pkey context created to generate the the key.
+  * @param nid [in] Identifier of the curve to be used.
+  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+  */
+void _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);
+
+ /**
+  * Sets the the elliptic curve parameter encoding when generating
+  * EC parameters or an EC key
+  *
+  * @param ctx [in, out] pkey EC parameter or key context
+  * @param param_enc [in] Type of parameter encoding to be used
+  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+  */
+void _EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc);
+
+/**
+ * Gets the EC group of a given EC key
+ */
+const EC_GROUP* _EC_KEY_get0_group(const EC_KEY *key);
+
+/**
+ * Gets the NID of the elliptic curve used to generate the EC key.
+ */
+int _EC_GROUP_get_curve_name(const EC_GROUP *group);
+
+/**
+ * Gets the type of a give PKey oject.
+ *
+ * @param key to retrieve the type from
+ * @return Returns the PKEY type being used
+ * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+ */
+int _EVP_PKEY_type(const EVP_PKEY* key);
+
+/**
+ * Gets the size in bytes of a pkey object
+ * @param pkey key to get size from
+ * @return the size of provided key
+ * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+ */
+int _EVP_PKEY_size(EVP_PKEY *pkey);
+
 /*
  * Thread safe modification of OpenSSL object reference counters.
  *
@@ -1082,6 +1143,23 @@ int _EVP_MD_size(const EVP_MD *md);
 void* _OPENSSL_malloc(int num);
 
 void _CRYPTO_malloc_init();
+
+enum class ellipticCurveNid
+{
+    PRIME_192v1 = NID_X9_62_prime192v1,
+    PRIME_256v1 = NID_X9_62_prime256v1,
+
+    SECP_224r1 = NID_secp224r1,
+    SECP_384r1 = NID_secp384r1,
+    SECP_521r1 = NID_secp521r1,
+
+    SECT_283k1 = NID_sect283k1,
+    SECT_283r1 = NID_sect283r1,
+    SECT_409k1 = NID_sect409k1,
+    SECT_409r1 = NID_sect409r1,
+    SECT_571k1 = NID_sect571k1,
+    SECT_571r1 = NID_sect571r1,
+};
 
 }  //::openssl
 }  //::mococrw

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -108,6 +108,45 @@ int OpenSSLLib::SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) noexcept
     return EVP_PKEY_cmp(a,b);
 }
 
+int OpenSSLLib::SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) noexcept
+{
+    return EVP_PKEY_paramgen_init(ctx);
+}
+int OpenSSLLib::SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept
+{
+    return EVP_PKEY_paramgen(ctx, ppkey);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept
+{
+    return EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) noexcept
+{
+    return EVP_PKEY_CTX_set_ec_param_enc(ctx, param_enc);
+}
+
+const EC_GROUP* OpenSSLLib::SSL_EC_KEY_get0_group(const EC_KEY *key) noexcept
+{
+    return EC_KEY_get0_group(key);
+}
+
+int OpenSSLLib::SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) noexcept
+{
+    return EC_GROUP_get_curve_name(group);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept
+{
+    return EVP_PKEY_type(type);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_size(EVP_PKEY *pkey) noexcept
+{
+    return EVP_PKEY_size(pkey);
+}
+
 /* Reference counting magic */
 int OpenSSLLib::SSL_CRYPTO_add(int *pointer, int amount, int type) noexcept {
     return CRYPTO_add(pointer, amount, type);

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -202,6 +202,50 @@ void _EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits)
     OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_keygen_bits, ctx, mbits);
 }
 
+void _EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx)
+{
+    OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_paramgen_init, ctx);
+}
+
+SSL_EVP_PKEY_Ptr _EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx)
+{
+    EVP_PKEY* ptr{nullptr};
+    OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_paramgen, ctx, &ptr);
+    return SSL_EVP_PKEY_Ptr{ptr};
+}
+
+void _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid)
+{
+    OpensslCallIsNonNegative::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid,
+                                          ctx, nid);
+}
+
+void _EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc)
+{
+    OpensslCallIsNonNegative::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc,
+                                          ctx, param_enc);
+}
+
+const EC_GROUP* _EC_KEY_get0_group(const EC_KEY *key)
+{
+    return OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_EC_KEY_get0_group, key);
+}
+
+int _EC_GROUP_get_curve_name(const EC_GROUP *group)
+{
+    return OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_EC_GROUP_get_curve_name, group);
+}
+
+int _EVP_PKEY_type(const EVP_PKEY* key)
+{
+    return OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_type, key->type);
+}
+
+int _EVP_PKEY_size(EVP_PKEY *pkey)
+{
+    return OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_size, pkey);
+}
+
 bool _EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 {
     int result = lib::OpenSSLLib::SSL_EVP_PKEY_cmp(a,b);

--- a/src/signature.cpp
+++ b/src/signature.cpp
@@ -32,6 +32,10 @@ std::vector<uint8_t> SignatureUtils::create(AsymmetricPrivateKey &privateKey,
 {
     std::vector<uint8_t> messageDigest;
 
+    if(privateKey.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("Functionality is only supported for RSA keys");
+    }
+
     try {
         messageDigest = digestMessage(message, getHashing(padding));
     }
@@ -50,6 +54,10 @@ std::vector<uint8_t> SignatureUtils::create(AsymmetricPrivateKey &privateKey,
     const auto keyCtx = _EVP_PKEY_CTX_new(privateKey.internal());
     std::unique_ptr<unsigned char, SSLFree<unsigned char>> sig;
     size_t siglen;
+
+    if(privateKey.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("Functionality is only supported for RSA keys");
+    }
 
     try {
         if (!keyCtx.get()) {
@@ -87,6 +95,10 @@ void SignatureUtils::verify(AsymmetricPublicKey &publicKey,
 {
     std::vector<uint8_t> messageDigest;
 
+    if(publicKey.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("Functionality is only supported for RSA keys");
+    }
+
     try {
         messageDigest = digestMessage(message, getHashing(padding));
         verify(publicKey, padding, signature, messageDigest);
@@ -102,6 +114,10 @@ void SignatureUtils::verify(AsymmetricPublicKey &publicKey,
                             const std::vector<uint8_t> messageDigest)
 {
     const auto keyCtx = _EVP_PKEY_CTX_new(publicKey.internal());
+
+    if(publicKey.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("Functionality is only supported for RSA keys");
+    }
 
     try {
         _EVP_PKEY_verify_init(keyCtx.get());

--- a/tests/sdk/main.cpp
+++ b/tests/sdk/main.cpp
@@ -67,7 +67,7 @@ int main(int, char **)
                       .stateOrProvinceName("nebenan")
                       .serialNumber("08E36DD501941432358AFE8256BC6EFD")
                       .build();
-    auto keypair = AsymmetricKeypair::generate();
+    auto keypair = AsymmetricKeypair::generateRSA();
     CertificateSigningRequest csr{dn, keypair};
     auto pemString = csr.toPem();
     auto publicKey = csr.getPublicKey();

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -156,6 +156,47 @@ int OpenSSLLib::SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) noexcept
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_cmp(a,b);
 }
 
+int OpenSSLLib::SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_paramgen_init(ctx);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_paramgen(ctx, ppkey);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx,
+                                                                                                nid);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_ec_param_enc(ctx, param_enc);
+}
+
+const EC_GROUP* OpenSSLLib::SSL_EC_KEY_get0_group(const EC_KEY *key) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EC_KEY_get0_group(key);
+}
+
+int OpenSSLLib::SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EC_GROUP_get_curve_name(group);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_type(type);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_size(EVP_PKEY *pkey) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_size(pkey);
+}
+
 /* Reference counting magic */
 int OpenSSLLib::SSL_CRYPTO_add(int *pointer, int amount, int type) noexcept {
     return OpenSSLLibMockManager::getMockInterface().SSL_CRYPTO_add(pointer, amount, type);

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -105,6 +105,15 @@ public:
 
     virtual int SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) = 0;
 
+    virtual int SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) = 0;
+    virtual int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) = 0;
+    virtual const EC_GROUP* SSL_EC_KEY_get0_group(const EC_KEY *key) = 0;
+    virtual int SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) = 0;
+    virtual int SSL_EVP_PKEY_type(int type) = 0;
+    virtual int SSL_EVP_PKEY_size(EVP_PKEY *pkey) = 0;
+
     /* Reference counting magic */
     virtual int SSL_CRYPTO_add(int *pointer, int amount, int type) = 0;
 
@@ -339,6 +348,16 @@ public:
 
     MOCK_METHOD2(SSL_EVP_PKEY_cmp, int(const EVP_PKEY*, const EVP_PKEY *));
 
+    MOCK_METHOD1(SSL_EVP_PKEY_paramgen_init, int(EVP_PKEY_CTX*));
+    MOCK_METHOD2(SSL_EVP_PKEY_paramgen, int(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid, int(EVP_PKEY_CTX *ctx, int nid));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_ec_param_enc, int(EVP_PKEY_CTX *ctx, int param_enc));
+    MOCK_METHOD1(SSL_EC_KEY_get0_group, EC_GROUP*(const EC_KEY *key));
+    MOCK_METHOD1(SSL_EC_GROUP_get_curve_name, int(const EC_GROUP *group));
+
+    MOCK_METHOD1(SSL_EVP_PKEY_type, int(int type));
+    MOCK_METHOD1(SSL_EVP_PKEY_size, int(EVP_PKEY *pkey));
+
     MOCK_METHOD3(SSL_CRYPTO_add, int(int*, int, int));
 
     MOCK_METHOD0(SSL_ERR_get_error, unsigned long());
@@ -454,6 +473,7 @@ public:
     MOCK_METHOD2(SSL_EVP_PKEY_CTX_get_rsa_oaep_label, int(EVP_PKEY_CTX *ctx, unsigned char *l));
     MOCK_METHOD1(SSL_RSA_size, int(const RSA *r));
     MOCK_METHOD1(SSL_EVP_MD_size, int(const EVP_MD *md));
+
 };
 
 /**

--- a/tests/unit/test_asymmetric_encryption.cpp
+++ b/tests/unit/test_asymmetric_encryption.cpp
@@ -491,6 +491,7 @@ INSTANTIATE_TEST_CASE_P(testSuccessfulEncryption, AsymmetricEncryptionTest,
  *
  * The following use cases are covered:
  * - unsupported padding (PSS)
+ * - ECC Key
  */
 TEST_F(AsymmetricEncryptionTest, testEncryptionInvalidParameters)
 {
@@ -504,6 +505,12 @@ TEST_F(AsymmetricEncryptionTest, testEncryptionInvalidParameters)
                                                unsupportedPaddingMode,
                                                nominalDataSet[0]._message),
                  MoCOCrWException);
+
+    auto eccKey = AsymmetricKeypair::generateECC();
+    EXPECT_THROW(AsymmetricEncryption::encrypt(eccKey,
+                                               OAEPPadding{},
+                                               nominalDataSet[0]._message),
+                 MoCOCrWException);
 }
 
 /**
@@ -511,6 +518,7 @@ TEST_F(AsymmetricEncryptionTest, testEncryptionInvalidParameters)
  *
  * The following use cases are covered:
  * - unsupported padding (PSS)
+ * - ECC key
  */
 TEST_F(AsymmetricEncryptionTest, testDecryptionInvalidParameters)
 {
@@ -524,6 +532,12 @@ TEST_F(AsymmetricEncryptionTest, testDecryptionInvalidParameters)
 
     EXPECT_THROW(AsymmetricEncryption::decrypt(privateKey,
                                                unsupportedPaddingMode,
+                                               nominalDataSet[0]._encrypted),
+                 MoCOCrWException);
+
+    auto eccKey = AsymmetricKeypair::generateECC();
+    EXPECT_THROW(AsymmetricEncryption::decrypt(eccKey,
+                                               OAEPPadding{},
                                                nominalDataSet[0]._encrypted),
                  MoCOCrWException);
 }
@@ -604,6 +618,7 @@ struct MessageSizeDataSet
     openssl::DigestTypes _masking;
     std::vector<uint8_t> _label;
     // expected outputs
+    std::string _exceptionText;
     bool _expectThrow;
 };
 
@@ -626,6 +641,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // PKCS, 1024-bit key, max message size (117)
@@ -639,6 +655,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // PKCS, 1024-bit key, max message size + 1 (118)
@@ -652,6 +669,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // PKCS, 2048-bit key, empty message
@@ -663,6 +681,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // PKCS, 2048-bit key, max message size (245)
@@ -678,6 +697,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // PKCS, 2048-bit key, max message size + 1 (246)
@@ -693,6 +713,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // OAEP, 1024-bit key, hashing SHA256, masking SHA256, empty message
@@ -704,6 +725,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // OAEP, 1024-bit key, hashing SHA256, masking SHA256, max message size (62)
@@ -716,6 +738,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // OAEP, 1024-bit key, hashing SHA256, masking SHA256, max message size + 1 (63)
@@ -728,6 +751,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // OAEP, 1024-bit key, hashing SHA512, masking SHA256, max message size (-2)
@@ -739,6 +763,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA512,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // OAEP, 2048-bit key, hashing SHA256, masking SHA256, empty message
@@ -750,6 +775,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // OAEP, 2048-bit key, hashing SHA256, masking SHA256, max message size (190)
@@ -764,6 +790,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // OAEP, 2048-bit key, hashing SHA256, masking SHA256, max message size + 1 (191)
@@ -778,6 +805,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // OAEP, 2048-bit key, hashing SHA512, masking SHA256, max message size (126)
@@ -791,6 +819,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA512,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // OAEP, 2048-bit key, hashing SHA512, masking SHA256, max message size + 1 (127)
@@ -804,6 +833,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA512,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // NO PADDING, 1024-bit key, max message size - 1 (127)
@@ -817,6 +847,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message size is different from the key size",
         true
     },
     // NO PADDING, 1024-bit key, max message size (128)
@@ -830,6 +861,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // NO PADDING, 1024-bit key, max message size + 1 (129)
@@ -843,6 +875,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message size is different from the key size",
         true
     },
     // NO PADDING, 2048-bit key, max message size - 1 (255)
@@ -859,6 +892,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message size is different from the key size",
         true
     },
     // NO PADDING, 2048-bit key, max message size (256)
@@ -875,6 +909,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // NO PADDING, 2048-bit key, max message size + 1 (257)
@@ -891,6 +926,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message size is different from the key size",
         true
     },
 
@@ -931,8 +967,15 @@ TEST_P(AsymmetricEncryptionSizeTest, testMessageSize)
                                                             data._masking,
                                                             data._label);
     if (data._expectThrow) {
-        EXPECT_THROW(AsymmetricEncryption::encrypt(publicKey, *(padding.get()), data._message),
-                         MoCOCrWException);
+        EXPECT_THROW({
+            try {
+                AsymmetricEncryption::encrypt(publicKey, *(padding.get()), data._message);
+            }
+            catch (const MoCOCrWException &e) {//this tests that it has the correct message
+                EXPECT_STREQ(data._exceptionText.c_str(), e.what());
+                throw;
+            }
+            }, MoCOCrWException);
     } else {
         EXPECT_NO_THROW(AsymmetricEncryption::encrypt(publicKey, *(padding.get()), data._message));
     }
@@ -940,3 +983,21 @@ TEST_P(AsymmetricEncryptionSizeTest, testMessageSize)
 
 INSTANTIATE_TEST_CASE_P(testMessageSize, AsymmetricEncryptionSizeTest,
                         testing::ValuesIn(AsymmetricEncryptionSizeTest::messageSizeDataSet));
+
+TEST_F(AsymmetricEncryptionSizeTest, testGetMessageSize)
+{
+    auto key1024 = mococrw::AsymmetricKeypair::readPublicKeyFromPEM(keyPairs1024bit._publicKey);
+    auto key2048 = mococrw::AsymmetricKeypair::readPublicKeyFromPEM(keyPairs2048bit._publicKey);
+
+    OAEPPadding oeapPad{};
+    EXPECT_EQ(oeapPad.getDataBlockSize(key1024), 62);
+    EXPECT_EQ(oeapPad.getDataBlockSize(key2048), 190);
+
+    PKCSPadding pkcsPadding{};
+    EXPECT_EQ(pkcsPadding.getDataBlockSize(key1024), 1024/8 - 11);
+    EXPECT_EQ(pkcsPadding.getDataBlockSize(key2048), 2048/8 - 11);
+
+    NoPadding noPadding{};
+    EXPECT_EQ(noPadding.getDataBlockSize(key1024), 1024/8);
+    EXPECT_EQ(noPadding.getDataBlockSize(key2048), 2048/8);
+}

--- a/tests/unit/test_ca.cpp
+++ b/tests/unit/test_ca.cpp
@@ -62,7 +62,7 @@ protected:
 
 void CATest::SetUp()
 {
-    _rootKey = std::make_unique<AsymmetricKeypair>(AsymmetricKeypair::generate());
+    _rootKey = std::make_unique<AsymmetricKeypair>(AsymmetricKeypair::generateRSA());
 
     _certDetails = std::make_unique<DistinguishedName>(DistinguishedName::Builder{}
                  .organizationalUnitName("Car IT")
@@ -240,7 +240,7 @@ TEST_F(CATest, testCAContents)
 
 TEST_F(CATest, testSignedCSRHasCorrectFields)
 {
-    CertificateSigningRequest csr{*_certDetails, AsymmetricKeypair::generate()};
+    CertificateSigningRequest csr{*_certDetails, AsymmetricKeypair::generateRSA()};
     X509Certificate cert = _ca->signCSR(csr);
     testValiditySpan(cert, _signParams.certificateValidity(), Asn1Time::now());
     EXPECT_EQ(csr.getPublicKey(), cert.getPublicKey());
@@ -254,36 +254,36 @@ TEST_F(CATest, testCanSignCACertificates)
     //Adjust CA to generate CA certificates
     _ca = std::make_unique<CertificateAuthority>(_caSignParams, 0, *_rootCert, *_rootKey);
 
-    auto keypair = AsymmetricKeypair::generate();
+    auto keypair = AsymmetricKeypair::generateRSA();
     CertificateSigningRequest csr{*_certDetails, keypair};
     X509Certificate cert = _ca->signCSR(csr);
     CertificateAuthority newCA(_signParams, 0, cert, keypair);
-    csr = CertificateSigningRequest{*_secondaryCertDetails, AsymmetricKeypair::generate()};
+    csr = CertificateSigningRequest{*_secondaryCertDetails, AsymmetricKeypair::generateRSA()};
     X509Certificate secondaryCert = newCA.signCSR(csr);
     ASSERT_NO_THROW(secondaryCert.verify({*_rootCert}, {cert}));
 }
 
 TEST_F(CATest, testSignedNoCACertificatesCantSignOtherCertificates)
 {
-    auto keypair = AsymmetricKeypair::generate();
+    auto keypair = AsymmetricKeypair::generateRSA();
     CertificateSigningRequest csr{*_certDetails, keypair};
     X509Certificate cert = _ca->signCSR(csr);
     // The newly created certificate has CA=false
     CertificateAuthority newCA(_signParams, 0, cert, keypair);
-    csr = CertificateSigningRequest{*_certDetails, AsymmetricKeypair::generate()};
+    csr = CertificateSigningRequest{*_certDetails, AsymmetricKeypair::generateRSA()};
     // The signing fails because the certificate has CA=false
     ASSERT_THROW(newCA.signCSR(csr), MoCOCrWException);
 }
 
 TEST_F(CATest, testInitializeCAWithNonMatchingKey)
 {
-    EXPECT_THROW(CertificateAuthority(_signParams, 0, *_rootCert, AsymmetricKeypair::generate()),
+    EXPECT_THROW(CertificateAuthority(_signParams, 0, *_rootCert, AsymmetricKeypair::generateRSA()),
                  MoCOCrWException);
 }
 
 TEST_F(CATest, testVerifyCAAgainstPureOpenSslOutput)
 {
-    auto keypair = AsymmetricKeypair::generate();
+    auto keypair = AsymmetricKeypair::generateRSA();
     CertificateSigningRequest csr{*_certDetails, keypair};
     X509Certificate cert = _ca->signCSR(csr);
 
@@ -327,7 +327,7 @@ TEST_F(CATest, testIssueLongLivedCertificate)
     _ca = std::make_unique<CertificateAuthority>(_signParams, 0, *_rootCert, *_rootKey);
 
     X509Certificate cert = _ca->signCSR(CertificateSigningRequest{*_certDetails,
-                                                       AsymmetricKeypair::generate()});
+                                                       AsymmetricKeypair::generateRSA()});
 
     testValiditySpan(cert, validityTime, Asn1Time::now());
 
@@ -350,7 +350,7 @@ TEST_F(CATest, DISABLED_testIssueCertificateInFarFuture)
     _ca = std::make_unique<CertificateAuthority>(_signParams, 0, *_rootCert, *_rootKey);
 
     X509Certificate cert = _ca->signCSR(CertificateSigningRequest{*_certDetails,
-                                                       AsymmetricKeypair::generate()});
+                                                       AsymmetricKeypair::generateRSA()});
 
     testValiditySpan(cert, validityTime, validFrom);
 

--- a/tests/unit/test_csr.cpp
+++ b/tests/unit/test_csr.cpp
@@ -51,7 +51,7 @@ void CSRTest::SetUp()
                                         .stateOrProvinceName("nebenan")
                                         .serialNumber("08E36DD501941432358AFE8256BC6EFD")
                                         .build());
-    _keypair = std::make_unique<AsymmetricKeypair>(AsymmetricKeypair::generate());
+    _keypair = std::make_unique<AsymmetricKeypair>(AsymmetricKeypair::generateRSA());
 }
 
 void CSRTest::TearDown()

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -29,72 +29,220 @@ class KeyHandlingTests : public ::testing::Test
 {
 public:
     void SetUp() override;
+
+    static std::string _pemEccPrivKeySect409k1;
+    static std::string _pemEccPubKeySect409k1;
 protected:
-    mococrw::AsymmetricKeypair _keyPair = AsymmetricKeypair::generate();
-    mococrw::AsymmetricKeypair _keyPair2 = AsymmetricKeypair::generate();
+    mococrw::AsymmetricKeypair _rsaKeyPair = AsymmetricKeypair::generateRSA();
+    mococrw::AsymmetricKeypair _rsaKeyPair2 = AsymmetricKeypair::generateRSA();
+    mococrw::AsymmetricKeypair _eccKeyPairDefault = AsymmetricKeypair::generateECC();
+    mococrw::AsymmetricKeypair _eccKeyPairDefault2 = AsymmetricKeypair::generateECC();
+    mococrw::AsymmetricKeypair _eccKeyPairSect571r1 = AsymmetricKeypair::generateECC();
+    mococrw::AsymmetricKeypair _eccKeyPairSecp521r1 = AsymmetricKeypair::generateECC();
 };
 
 void KeyHandlingTests::SetUp() {
-    _keyPair = AsymmetricKeypair::generate();
-    _keyPair2 = AsymmetricKeypair::generate();
+    _rsaKeyPair = AsymmetricKeypair::generateRSA();
+    _rsaKeyPair2 = AsymmetricKeypair::generateRSA();
+
+    _eccKeyPairDefault = AsymmetricKeypair::generateECC();
+    _eccKeyPairDefault2 = AsymmetricKeypair::generateECC();
+
+    _eccKeyPairSect571r1 = AsymmetricKeypair::generate(mococrw::ECCSpec{openssl::ellipticCurveNid::SECT_571r1});
+    _eccKeyPairSecp521r1 = AsymmetricKeypair::generate(mococrw::ECCSpec{openssl::ellipticCurveNid::SECP_521r1});
 }
+
+std::string KeyHandlingTests::_pemEccPrivKeySect409k1{R"(-----BEGIN PRIVATE KEY-----
+MIHCAgEAMBAGByqGSM49AgEGBSuBBAAkBIGqMIGnAgEBBDQAF2zFhKyxJiI7bGvG
+Mw9rq7DUvrqTDJMHeRttpsZc0i9tFbvmaT2J5U39/RkseDha2b87oWwDagAEAAdj
+oVwkpy9CPA8RU3sd0aXV/XnHw5nE7HgINd6ApxCaknRebk4Vgbgz04588YqjqQpQ
+TAA+hxkUt1ZInurAHTt/ECQpvt1YOTBgNigakbLzq1LsbbyLWJsH5diall6Is+lg
+y2Mu1EA=
+-----END PRIVATE KEY-----)"};
+
+std::string KeyHandlingTests::_pemEccPubKeySect409k1{R"(-----BEGIN PUBLIC KEY-----
+MH4wEAYHKoZIzj0CAQYFK4EEACQDagAEAAdjoVwkpy9CPA8RU3sd0aXV/XnHw5nE
+7HgINd6ApxCaknRebk4Vgbgz04588YqjqQpQTAA+hxkUt1ZInurAHTt/ECQpvt1Y
+OTBgNigakbLzq1LsbbyLWJsH5diall6Is+lgy2Mu1EA=
+-----END PUBLIC KEY-----)"};
 
 TEST_F(KeyHandlingTests, testGeneratedKeyIsNotNull)
 {
-    ASSERT_THAT(_keyPair.internal(), NotNull());
+    ASSERT_THAT(_rsaKeyPair.internal(), NotNull());
+    ASSERT_THAT(_rsaKeyPair2.internal(), NotNull());
+
+    ASSERT_THAT(_eccKeyPairDefault.internal(), NotNull());
+    ASSERT_THAT(_eccKeyPairDefault2.internal(), NotNull());
+
+    ASSERT_THAT(_eccKeyPairSecp521r1.internal(), NotNull());
+    ASSERT_THAT(_eccKeyPairSect571r1.internal(), NotNull());
+
 }
 
 TEST_F(KeyHandlingTests, testPublicKeyPemIsReproducible)
 {
-    const auto pemOfKey = _keyPair.publicKeyToPem();
-    const auto pemOfKey2 = _keyPair.publicKeyToPem();
+    const auto pemOfKey = _rsaKeyPair.publicKeyToPem();
+    const auto pemOfKey2 = _rsaKeyPair.publicKeyToPem();
+
+    const auto pemOfEccKey = _eccKeyPairDefault.publicKeyToPem();
+    const auto pemOfEccKey2 = _eccKeyPairDefault.publicKeyToPem();
+
+    const auto pemOfSectEccKey = _eccKeyPairSect571r1.publicKeyToPem();
+    const auto pemOfSectEccKey2 = _eccKeyPairSect571r1.publicKeyToPem();
 
     ASSERT_EQ(pemOfKey, pemOfKey2);
+    ASSERT_EQ(pemOfEccKey, pemOfEccKey2);
+    ASSERT_EQ(pemOfSectEccKey, pemOfSectEccKey2);
 }
 
 TEST_F(KeyHandlingTests, testPubKeyFromSavedPemIsSameAsOriginalInOpenSSLObject)
 {
-    const auto pemOfPubkey = _keyPair.publicKeyToPem();
+    const auto pemOfPubkey = _rsaKeyPair.publicKeyToPem();
+    const auto pemOfEccPubkey = _eccKeyPairDefault.publicKeyToPem();
+    const auto pemOfSecpEccPubkey = _eccKeyPairSecp521r1.publicKeyToPem();
 
+    auto rsaParsedKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfPubkey);
+    auto eccParsedKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfEccPubkey);
+    auto eccSecpParsedKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfSecpEccPubkey);
+
+    ASSERT_EQ(_rsaKeyPair, rsaParsedKey);
+    ASSERT_EQ(_eccKeyPairDefault, eccParsedKey);
+    ASSERT_EQ(_eccKeyPairSecp521r1, eccSecpParsedKey);
+    ASSERT_NE(_eccKeyPairSecp521r1, _rsaKeyPair);
+
+}
+
+TEST_F(KeyHandlingTests, testReadExternalEccPEMKey)
+{
+    /*Read private and public key from pem string*/
+    auto eccPrivKey = mococrw::AsymmetricKeypair::readPrivateKeyFromPEM(
+                                                  KeyHandlingTests::_pemEccPrivKeySect409k1, "");
+    auto eccPubKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(
+                                                   KeyHandlingTests::_pemEccPubKeySect409k1);
+
+    /*Check key type and curve*/
+    EXPECT_EQ(eccPrivKey.getType(), AsymmetricKey::KeyTypes::ECC);
+    EXPECT_EQ(eccPubKey.getType(), AsymmetricKey::KeyTypes::ECC);
+
+    auto privSpec = eccPrivKey.getKeySpec();
+    auto pubSpec = eccPubKey.getKeySpec();
+    EXPECT_EQ(dynamic_cast<ECCSpec*>(privSpec.get())->curve(), openssl::ellipticCurveNid::SECT_409k1);
+    EXPECT_EQ(dynamic_cast<ECCSpec*>(pubSpec.get())->curve(), openssl::ellipticCurveNid::SECT_409k1);
+
+    /*Write key to a new pem file and read back to compare with original*/
+    /*Public key*/
+    const auto pemOfPubkey = eccPubKey.publicKeyToPem();
     auto parsedKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfPubkey);
-    ASSERT_EQ(_keyPair, parsedKey);
+    ASSERT_EQ(eccPubKey, parsedKey);
+    /*Private key*/
+    const auto pemOfPrivateKey = eccPrivKey.privateKeyToPem("secret");
+    auto retrievedKeyPair = AsymmetricKeypair::readPrivateKeyFromPEM(pemOfPrivateKey, "secret");
+    ASSERT_EQ(eccPrivKey, retrievedKeyPair);
 }
 
 TEST_F(KeyHandlingTests, testPubkeyFromSavedPemIsSameAsOriginalInPEM)
 {
-    const auto pemOfKey = _keyPair.publicKeyToPem();
+    const auto pemOfKey = _rsaKeyPair.publicKeyToPem();
+    const auto pemOfEccKey = _eccKeyPairDefault.publicKeyToPem();
+    const auto pemOfSectEccKey = _eccKeyPairSect571r1.publicKeyToPem();
 
-    auto parsedKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfKey);
-    ASSERT_EQ(pemOfKey, parsedKey.publicKeyToPem());
+    auto parsedRsaKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfKey);
+    auto parsedEccKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfEccKey);
+    auto parsedSectEccKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfSectEccKey);
+
+    ASSERT_EQ(pemOfKey, parsedRsaKey.publicKeyToPem());
+    ASSERT_EQ(pemOfEccKey, parsedEccKey.publicKeyToPem());
+    ASSERT_EQ(pemOfSectEccKey, parsedSectEccKey.publicKeyToPem());
 }
 
 TEST_F(KeyHandlingTests, testPrivKeyFromSavedPemIsSameAsOriginal)
 {
-    const auto pemOfPubKey = _keyPair.publicKeyToPem();
-    const auto pemOfPrivateKey = _keyPair.privateKeyToPem("secret");
+    const auto pemOfPubKey = _rsaKeyPair.publicKeyToPem();
+    const auto pemOfPrivateKey = _rsaKeyPair.privateKeyToPem("secret");
 
     auto retrievedKeyPair = AsymmetricKeypair::readPrivateKeyFromPEM(pemOfPrivateKey, "secret");
     ASSERT_EQ(pemOfPubKey, retrievedKeyPair.publicKeyToPem());
+
+    const auto pemOfEccPubKey = _eccKeyPairDefault.publicKeyToPem();
+    const auto pemOfEccPrivateKey = _eccKeyPairDefault.privateKeyToPem("password");
+
+    auto retrievedEccKeyPair = AsymmetricKeypair::readPrivateKeyFromPEM(pemOfEccPrivateKey, "password");
+    ASSERT_EQ(pemOfEccPubKey, retrievedEccKeyPair.publicKeyToPem());
+
+    const auto pemOfSectEccPubKey = _eccKeyPairSect571r1.publicKeyToPem();
+    const auto pemOfSectEccPrivateKey = _eccKeyPairSect571r1.privateKeyToPem("santa");
+
+    auto retrievedSectEccKeyPair = AsymmetricKeypair::readPrivateKeyFromPEM(pemOfSectEccPrivateKey, "santa");
+    ASSERT_EQ(pemOfSectEccPubKey, retrievedSectEccKeyPair.publicKeyToPem());
 }
 
 TEST_F(KeyHandlingTests, testBothGeneratedKeysNotTheSame)
 {
-    ASSERT_NE(_keyPair, _keyPair2);
+    ASSERT_NE(_rsaKeyPair, _rsaKeyPair2);
+
+    ASSERT_NE(_eccKeyPairDefault, _eccKeyPairDefault2);
 }
 
 TEST_F(KeyHandlingTests, testThrowsWhenReadingPrivateKeyUsingWrongKey)
 {
-    const auto pemOfPrivateKey = _keyPair.privateKeyToPem("secret");
+    const auto pemOfPrivateKey = _rsaKeyPair.privateKeyToPem("secret");
     ASSERT_THROW(AsymmetricKeypair::readPrivateKeyFromPEM(pemOfPrivateKey, "wrongkey"),
+                 mococrw::OpenSSLException);
+
+    const auto pemOfEccPrivateKey = _eccKeyPairDefault.privateKeyToPem("secret");
+    ASSERT_THROW(AsymmetricKeypair::readPrivateKeyFromPEM(pemOfEccPrivateKey, "wrongkey"),
+                 mococrw::OpenSSLException);
+
+    const auto pemOfSecpEccPrivateKey = _eccKeyPairSecp521r1.privateKeyToPem("secret");
+    ASSERT_THROW(AsymmetricKeypair::readPrivateKeyFromPEM(pemOfSecpEccPrivateKey, "santa"),
                  mococrw::OpenSSLException);
 }
 
+TEST_F(KeyHandlingTests, testKeyTypeChecking)
+{
+    EXPECT_EQ(_eccKeyPairDefault.getType(), AsymmetricKey::KeyTypes::ECC);
+    EXPECT_EQ(_rsaKeyPair.getType(), AsymmetricKey::KeyTypes::RSA);
+    EXPECT_EQ(_eccKeyPairSecp521r1.getType(), AsymmetricKey::KeyTypes::ECC);
+    EXPECT_EQ(_eccKeyPairSect571r1.getType(), AsymmetricKey::KeyTypes::ECC);
+}
+
+TEST_F(KeyHandlingTests, testGetKeySpec)
+{
+    auto defaultSpec =_eccKeyPairDefault.getKeySpec();
+    auto Sect571r1Spec = _eccKeyPairSect571r1.getKeySpec();
+    auto Secp521Spec = _eccKeyPairSecp521r1.getKeySpec();
+
+    EXPECT_EQ(dynamic_cast<ECCSpec*>(defaultSpec.get())->curve(), openssl::ellipticCurveNid::PRIME_256v1);
+    EXPECT_EQ(dynamic_cast<ECCSpec*>(Sect571r1Spec.get())->curve(), openssl::ellipticCurveNid::SECT_571r1);
+    EXPECT_EQ(dynamic_cast<ECCSpec*>(Secp521Spec.get())->curve(), openssl::ellipticCurveNid::SECP_521r1);
+
+    auto defaultRSASpec = dynamic_cast<RSASpec*>(_rsaKeyPair.getKeySpec().get());
+    EXPECT_EQ(defaultRSASpec->numberOfBits(), 2048);
+}
+
+TEST_F(KeyHandlingTests, testGetSize)
+{
+    EXPECT_EQ(_rsaKeyPair.getKeySize(), 2048);
+    EXPECT_EQ(_eccKeyPairDefault.getKeySize(), 256);
+    EXPECT_EQ(_eccKeyPairSecp521r1.getKeySize(), 521);
+    EXPECT_EQ(_eccKeyPairSect571r1.getKeySize(), 570);
+    auto rsaKey1024 = AsymmetricKeypair::generate(mococrw::RSASpec{1024});
+    EXPECT_EQ(rsaKey1024.getKeySize(), 1024);
+}
 
 /* Test the KeySpec and the generation of keys that way */
-
 TEST(KeySpecTest, testGeneratingRSAKeyWithDefaultParameters)
 {
     RSASpec spec{};
+
+    auto keypair = spec.generate();
+    ASSERT_THAT(keypair.internal(), NotNull());
+}
+
+/* Test the KeySpec and the generation of keys that way */
+TEST(KeySpecTest, testGeneratingEccKeyWithDefaultParameters)
+{
+    ECCSpec spec{};
 
     auto keypair = spec.generate();
     ASSERT_THAT(keypair.internal(), NotNull());
@@ -107,5 +255,11 @@ TEST(KeySpecTest, testThatDefaultParametersAreSane)
 
     RSASpec nonDefault{1024};
     ASSERT_THAT(nonDefault.numberOfBits(), Eq(1024));
+
+    ECCSpec defaultEccSpec{};
+    ASSERT_EQ(defaultEccSpec.curve(), openssl::ellipticCurveNid::PRIME_256v1);
+
+    ECCSpec nonDefaultEccSpec{openssl::ellipticCurveNid::SECT_283k1};
+    ASSERT_EQ(nonDefaultEccSpec.curve(), openssl::ellipticCurveNid::SECT_283k1);
 }
 

--- a/tests/unit/test_signature.cpp
+++ b/tests/unit/test_signature.cpp
@@ -64,7 +64,7 @@ protected:
 
 void SignatureTest::SetUp()
 {
-    _keyPair = std::make_unique<AsymmetricKeypair>(mococrw::AsymmetricKeypair::generate());
+    _keyPair = std::make_unique<AsymmetricKeypair>(mococrw::AsymmetricKeypair::generateRSA());
 
     _root1_pubkey = std::make_unique<AsymmetricPublicKey>(loadPubkeyFromFile("root1.pubkey.pem"));
     _root1_cert = std::make_unique<X509Certificate>(loadCertFromFile("signCertificate.pem"));


### PR DESCRIPTION
- Extended AsymmetricPublicKey and AsymmetricKeyPair to support
ECC keys
- Updated unit tests
- Added guards to functionality that currently only supports RSA
- Fixed issue found on the OEAPpadding mode class, used for the
  Asymmetric encryption functionality