### PR TITLE
Check OpenSSL version in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ if(APPLE)
     find_package(OpenSSL REQUIRED)
 else()
     pkg_search_module(OPENSSL REQUIRED openssl)
+    pkg_check_modules(OPENSSL openssl<=1.1)
 endif()
 
 if(OPENSSL_FOUND)


### PR DESCRIPTION
Since we wrap specific version of OpenSSL it is worth checking which on
is installed. If user has a newer (or older) version of OpenSSL than we
support it may result into compilation errors/warning or misbehaviours.