### PR TITLE
openssl1.1: mococrw: Add X509Certificate::toDER

### DIFF
--- a/src/mococrw/x509.h
+++ b/src/mococrw/x509.h
@@ -18,7 +18,9 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <type_traits>
+#include <vector>
 
 #include "asn1time.h"
 #include "distinguished_name.h"
@@ -41,6 +43,11 @@ public:
      * Return a PEM representation of this certificate.
      */
     std::string toPEM() const;
+
+    /**
+     * Return a DER representation of this certificate.
+     */
+    std::vector<uint8_t> toDER() const;
 
     /**
      * Get the distinguished name of this certificate.

--- a/src/x509.cpp
+++ b/src/x509.cpp
@@ -66,6 +66,13 @@ std::string X509Certificate::toPEM() const
     return bio.flushToString();
 }
 
+std::vector<uint8_t> X509Certificate::toDER() const
+{
+    BioObject bio{BioObject::Types::MEM};
+    _i2d_X509_bio(bio.internal(), const_cast<X509*>(internal()));
+    return bio.flushToVector();
+}
+
 void X509Certificate::VerificationContext::validityCheck() const
 {
     if (_enforceCrlForWholeChain && !_enforceSelfSignedRootCertificate) {

--- a/tests/unit/test_x509.cpp
+++ b/tests/unit/test_x509.cpp
@@ -468,6 +468,28 @@ TEST_F(X509Test, testLoadDERCert)
     });
 }
 
+TEST_F(X509Test, testExportDER)
+{
+    using ::testing::NotNull;
+    ASSERT_NO_THROW({
+        auto bytes = bytesFromFile<uint8_t>("root1.der");
+        auto cert = X509Certificate::fromDER(bytes);
+        ASSERT_THAT(cert.internal(), NotNull());
+        auto der = cert.toDER();
+        ASSERT_EQ(bytes, der);
+    });
+}
+
+TEST_F(X509Test, testReimportExportedDER)
+{
+    using ::testing::NotNull;
+    ASSERT_NO_THROW({
+        auto der = _cert.toDER();
+        auto cert = X509Certificate::fromDER(der);
+        ASSERT_THAT(cert.internal(), NotNull());
+    });
+}
+
 TEST_F(X509Test, testLoadDERCertFromFileDirectly)
 {
     using ::testing::NotNull;


### PR DESCRIPTION
This allows exporting certificates into a DER encoding, which may be useful for some clients, e.g. if a remote endpoint expects certificates in the DER format (or a format derived from DER).

(cherry picked from commit 3ad1c3b197f78f29795010aa58cd515f47d2a2a4)
See also #26.