### PR TITLE
mococrw: Add SHA3 support

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -77,11 +77,50 @@ std::vector<uint8_t> sha512(const std::vector<uint8_t> &message) {
     return Hash::sha512().update(message).digest();
 }
 
+std::vector<uint8_t> sha3_256(const uint8_t* message, size_t length) {
+   return Hash::sha3_256().update(message, length).digest();
+}
+
+std::vector<uint8_t> sha3_256(const std::string &message) {
+    return Hash::sha3_256().update(message).digest();
+}
+
+std::vector<uint8_t> sha3_256(const std::vector<uint8_t> &message) {
+    return Hash::sha3_256().update(message).digest();
+}
+
+std::vector<uint8_t> sha3_384(const uint8_t* message, size_t length) {
+    return Hash::sha3_384().update(message, length).digest();
+}
+
+std::vector<uint8_t> sha3_384(const std::string &message) {
+    return Hash::sha3_384().update(message).digest();
+}
+
+std::vector<uint8_t> sha3_384(const std::vector<uint8_t> &message) {
+    return Hash::sha3_384().update(message).digest();
+}
+
+std::vector<uint8_t> sha3_512(const uint8_t* message, size_t length) {
+    return Hash::sha3_512().update(message, length).digest();
+}
+
+std::vector<uint8_t> sha3_512(const std::string &message) {
+    return Hash::sha3_512().update(message).digest();
+}
+
+std::vector<uint8_t> sha3_512(const std::vector<uint8_t> &message) {
+    return Hash::sha3_512().update(message).digest();
+}
+
 const std::map<DigestTypes, size_t> Hash::lengthInBytes = {
     { DigestTypes::SHA1, 160 / 8 },
     { DigestTypes::SHA256, 256 / 8 },
     { DigestTypes::SHA384, 384 / 8 },
-    { DigestTypes::SHA512, 512 / 8 }
+    { DigestTypes::SHA512, 512 / 8 },
+    { DigestTypes::SHA3_256, 256 / 8 },
+    { DigestTypes::SHA3_384, 384 / 8 },
+    { DigestTypes::SHA3_512, 512 / 8 }
 };
 
 Hash::Hash(const DigestTypes digestType) : _digestType(digestType) {
@@ -105,6 +144,18 @@ Hash Hash::sha384() {
 
 Hash Hash::sha512() {
     return Hash{DigestTypes::SHA512};
+}
+
+Hash Hash::sha3_256() {
+    return Hash{DigestTypes::SHA3_256};
+}
+
+Hash Hash::sha3_384() {
+    return Hash{DigestTypes::SHA3_384};
+}
+
+Hash Hash::sha3_512() {
+    return Hash{DigestTypes::SHA3_512};
 }
 
 std::vector<uint8_t> Hash::digest() {

--- a/src/mococrw/hash.h
+++ b/src/mococrw/hash.h
@@ -41,6 +41,18 @@ std::vector<uint8_t> sha512(const std::vector<uint8_t> &message);
 std::vector<uint8_t> sha512(const std::string &message);
 std::vector<uint8_t> sha512(const uint8_t* message, size_t messageLength);
 
+std::vector<uint8_t> sha3_256(const std::vector<uint8_t> &message);
+std::vector<uint8_t> sha3_256(const std::string &message);
+std::vector<uint8_t> sha3_256(const uint8_t* message, size_t messageLength);
+
+std::vector<uint8_t> sha3_384(const std::vector<uint8_t> &message);
+std::vector<uint8_t> sha3_384(const std::string &message);
+std::vector<uint8_t> sha3_384(const uint8_t* message, size_t messageLength);
+
+std::vector<uint8_t> sha3_512(const std::vector<uint8_t> &message);
+std::vector<uint8_t> sha3_512(const std::string &message);
+std::vector<uint8_t> sha3_512(const uint8_t* message, size_t messageLength);
+
 class Hash
 {
 public:
@@ -48,6 +60,9 @@ public:
     static Hash sha256();
     static Hash sha384();
     static Hash sha512();
+    static Hash sha3_256();
+    static Hash sha3_384();
+    static Hash sha3_512();
     std::vector<uint8_t> digest();
     Hash& update(const std::vector<uint8_t> &chunk);
     Hash& update(const std::string &chunk);

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -207,6 +207,9 @@ public:
     static const EVP_MD* SSL_EVP_sha256() noexcept;
     static const EVP_MD* SSL_EVP_sha384() noexcept;
     static const EVP_MD* SSL_EVP_sha512() noexcept;
+    static const EVP_MD* SSL_EVP_sha3_256() noexcept;
+    static const EVP_MD* SSL_EVP_sha3_384() noexcept;
+    static const EVP_MD* SSL_EVP_sha3_512() noexcept;
 
     /* X509_NAME */
     static X509_NAME* SSL_X509_NAME_new() noexcept;

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -549,6 +549,9 @@ enum class DigestTypes {
     SHA256, // @MARCUS: Shouldn't there be some value initialization with openssl consts here?
     SHA384,
     SHA512,
+    SHA3_256,
+    SHA3_384,
+    SHA3_512
 };
 
 /**

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -252,6 +252,12 @@ const EVP_MD* OpenSSLLib::SSL_EVP_sha384() noexcept { return EVP_sha384(); }
 
 const EVP_MD* OpenSSLLib::SSL_EVP_sha512() noexcept { return EVP_sha512(); }
 
+const EVP_MD* OpenSSLLib::SSL_EVP_sha3_256() noexcept { return EVP_sha3_256(); }
+
+const EVP_MD* OpenSSLLib::SSL_EVP_sha3_384() noexcept { return EVP_sha3_384(); }
+
+const EVP_MD* OpenSSLLib::SSL_EVP_sha3_512() noexcept { return EVP_sha3_512(); }
+
 int OpenSSLLib::SSL_PEM_write_bio_PKCS8PrivateKey(BIO* bp,
                                                   EVP_PKEY* x,
                                                   const EVP_CIPHER* enc,

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -422,6 +422,12 @@ const EVP_MD* _getMDPtrFromDigestType(DigestTypes type)
             return lib::OpenSSLLib::SSL_EVP_sha384();
         case DigestTypes::SHA512:
             return lib::OpenSSLLib::SSL_EVP_sha512();
+        case DigestTypes::SHA3_256:
+            return lib::OpenSSLLib::SSL_EVP_sha3_256();
+        case DigestTypes::SHA3_384:
+            return lib::OpenSSLLib::SSL_EVP_sha3_384();
+        case DigestTypes::SHA3_512:
+            return lib::OpenSSLLib::SSL_EVP_sha3_512();
         default:
             throw std::runtime_error("Unknown digest type");
     }

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -333,6 +333,21 @@ const EVP_MD* OpenSSLLib::SSL_EVP_sha512() noexcept
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha512();
 }
 
+const EVP_MD* OpenSSLLib::SSL_EVP_sha3_256() noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha3_256();
+}
+
+const EVP_MD* OpenSSLLib::SSL_EVP_sha3_384() noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha3_384();
+}
+
+const EVP_MD* OpenSSLLib::SSL_EVP_sha3_512() noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha3_512();
+}
+
 int OpenSSLLib::SSL_PEM_write_bio_PKCS8PrivateKey(BIO* bp,
                                                   EVP_PKEY* x,
                                                   const EVP_CIPHER* enc,

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -212,6 +212,9 @@ public:
     virtual const EVP_MD* SSL_EVP_sha256() = 0;
     virtual const EVP_MD* SSL_EVP_sha384() = 0;
     virtual const EVP_MD* SSL_EVP_sha512() = 0;
+    virtual const EVP_MD* SSL_EVP_sha3_256() = 0;
+    virtual const EVP_MD* SSL_EVP_sha3_384() = 0;
+    virtual const EVP_MD* SSL_EVP_sha3_512() = 0;
 
     /* X509 Certificate validation */
     virtual X509_STORE* SSL_X509_STORE_new() = 0;
@@ -392,6 +395,9 @@ public:
     MOCK_METHOD0(SSL_EVP_sha256, const EVP_MD*());
     MOCK_METHOD0(SSL_EVP_sha384, const EVP_MD*());
     MOCK_METHOD0(SSL_EVP_sha512, const EVP_MD*());
+    MOCK_METHOD0(SSL_EVP_sha3_256, const EVP_MD*());
+    MOCK_METHOD0(SSL_EVP_sha3_384, const EVP_MD*());
+    MOCK_METHOD0(SSL_EVP_sha3_512, const EVP_MD*());
     MOCK_METHOD7(SSL_PEM_write_bio_PKCS8PrivateKey,
                  int(BIO*, EVP_PKEY*, const EVP_CIPHER*, char*, int, pem_password_cb*, void*));
     MOCK_METHOD2(SSL_PEM_write_bio_PUBKEY, int(BIO*, EVP_PKEY*));

--- a/tests/unit/test_hash.cpp
+++ b/tests/unit/test_hash.cpp
@@ -49,6 +49,18 @@ const auto sha512_emptyString = "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715d
 const auto sha512_foo = "f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7";
 const auto sha512_foobar = "0a50261ebd1a390fed2bf326f2673c145582a6342d523204973d0219337f81616a8069b012587cf5635f6925f1b56c360230c19b273500ee013e030601bf2425";
 
+const auto sha3_256_emptyString = "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a";
+const auto sha3_256_foo = "76d3bc41c9f588f7fcd0d5bf4718f8f84b1c41b20882703100b9eb9413807c01";
+const auto sha3_256_foobar = "09234807e4af85f17c66b48ee3bca89dffd1f1233659f9f940a2b17b0b8c6bc5";
+
+const auto sha3_384_emptyString = "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004";
+const auto sha3_384_foo = "665551928d13b7d84ee02734502b018d896a0fb87eed5adb4c87ba91bbd6489410e11b0fbcc06ed7d0ebad559e5d3bb5";
+const auto sha3_384_foobar = "0fa8abfbdaf924ad307b74dd2ed183b9a4a398891a2f6bac8fd2db7041b77f068580f9c6c66f699b496c2da1cbcc7ed8";
+
+const auto sha3_512_emptyString = "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26";
+const auto sha3_512_foo = "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7";
+const auto sha3_512_foobar = "ff32a30c3af5012ea395827a3e99a13073c3a8d8410a708568ff7e6eb85968fccfebaea039bc21411e9d43fdb9a851b529b9960ffea8679199781b8f45ca85e2";
+
 TEST_F(HashTest, sha1EmptyString)
 {
     EXPECT_THAT(utility::toHex(Hash::sha1().digest()), Eq(sha1_emptyString));
@@ -69,6 +81,21 @@ TEST_F(HashTest, sha512EmptyString)
     EXPECT_THAT(utility::toHex(Hash::sha512().digest()), Eq(sha512_emptyString));
 }
 
+TEST_F(HashTest, sha3_256EmptyString)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_256().digest()), Eq(sha3_256_emptyString));
+}
+
+TEST_F(HashTest, sha3_384EmptyString)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_384().digest()), Eq(sha3_384_emptyString));
+}
+
+TEST_F(HashTest, sha3_512EmptyString)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_512().digest()), Eq(sha3_512_emptyString));
+}
+
 TEST_F(HashTest, sha1SingleUpdateString)
 {
     EXPECT_THAT(utility::toHex(Hash::sha1().update("foo").digest()), Eq(sha1_foo));
@@ -87,6 +114,21 @@ TEST_F(HashTest, sha384SingleUpdateString)
 TEST_F(HashTest, sha512SingleUpdateString)
 {
     EXPECT_THAT(utility::toHex(Hash::sha512().update("foo").digest()), Eq(sha512_foo));
+}
+
+TEST_F(HashTest, sha3_256SingleUpdateString)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_256().update("foo").digest()), Eq(sha3_256_foo));
+}
+
+TEST_F(HashTest, sha3_384SingleUpdateString)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_384().update("foo").digest()), Eq(sha3_384_foo));
+}
+
+TEST_F(HashTest, sha3_512SingleUpdateString)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_512().update("foo").digest()), Eq(sha3_512_foo));
 }
 
 TEST_F(HashTest, sha1MultipleUpdatesString)
@@ -113,6 +155,24 @@ TEST_F(HashTest, sha512MultipleUpdatesString)
                 Eq(sha512_foobar));
 }
 
+TEST_F(HashTest, sha3_256MultipleUpdatesString)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_256().update("foo").update("bar").digest()),
+                Eq(sha3_256_foobar));
+}
+
+TEST_F(HashTest, sha3_384MultipleUpdatesString)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_384().update("foo").update("bar").digest()),
+                Eq(sha3_384_foobar));
+}
+
+TEST_F(HashTest, sha3_512MultipleUpdatesString)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_512().update("foo").update("bar").digest()),
+                Eq(sha3_512_foobar));
+}
+
 TEST_F(HashTest, sha1SingleUpdateBinaryArray)
 {
     EXPECT_THAT(utility::toHex(Hash::sha1().update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3).digest()),
@@ -135,6 +195,24 @@ TEST_F(HashTest, sha512SingleUpdateBinaryArray)
 {
     EXPECT_THAT(utility::toHex(Hash::sha512().update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3).digest()),
                 Eq(sha512_foo));
+}
+
+TEST_F(HashTest, sha3_256SingleUpdateBinaryArray)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_256().update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3).digest()),
+                Eq(sha3_256_foo));
+}
+
+TEST_F(HashTest, sha3_384SingleUpdateBinaryArray)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_384().update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3).digest()),
+                Eq(sha3_384_foo));
+}
+
+TEST_F(HashTest, sha3_512SingleUpdateBinaryArray)
+{
+    EXPECT_THAT(utility::toHex(Hash::sha3_512().update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3).digest()),
+                Eq(sha3_512_foo));
 }
 
 TEST_F(HashTest, sha1SingleUpdateVector)
@@ -169,6 +247,30 @@ TEST_F(HashTest, sha512SingleUpdateVector)
     EXPECT_THAT(utility::toHex(value), Eq(sha512_foo));
 }
 
+TEST_F(HashTest, sha3_256SingleUpdateVector)
+{
+    std::string chunk = "foo";
+    std::vector<uint8_t> chunk2conv(chunk.begin(), chunk.end());
+    std::vector<uint8_t> value = Hash::sha3_256().update(chunk2conv).digest();
+    EXPECT_THAT(utility::toHex(value), Eq(sha3_256_foo));
+}
+
+TEST_F(HashTest, sha3_384SingleUpdateVector)
+{
+    std::string chunk = "foo";
+    std::vector<uint8_t> chunk2conv(chunk.begin(), chunk.end());
+    std::vector<uint8_t> value = Hash::sha3_384().update(chunk2conv).digest();
+    EXPECT_THAT(utility::toHex(value), Eq(sha3_384_foo));
+}
+
+TEST_F(HashTest, sha3_512SingleUpdateVector)
+{
+    std::string chunk = "foo";
+    std::vector<uint8_t> chunk2conv(chunk.begin(), chunk.end());
+    std::vector<uint8_t> value = Hash::sha3_512().update(chunk2conv).digest();
+    EXPECT_THAT(utility::toHex(value), Eq(sha3_512_foo));
+}
+
 TEST_F(HashTest, sha1StandaloneFunctionVectorVersion)
 {
     std::string message = "foo";
@@ -201,6 +303,30 @@ TEST_F(HashTest, sha512StandaloneFunctionVectorVersion)
     EXPECT_THAT(utility::toHex(digest), Eq(sha512_foo));
 }
 
+TEST_F(HashTest, sha3_256StandaloneFunctionVectorVersion)
+{
+    std::string message = "foo";
+    std::vector<uint8_t> messageConv(message.begin(), message.end());
+    std::vector<uint8_t> digest = sha3_256(messageConv);
+    EXPECT_THAT(utility::toHex(digest), Eq(sha3_256_foo));
+}
+
+TEST_F(HashTest, sha3_384StandaloneFunctionVectorVersion)
+{
+    std::string message = "foo";
+    std::vector<uint8_t> messageConv(message.begin(), message.end());
+    std::vector<uint8_t> digest = sha3_384(messageConv);
+    EXPECT_THAT(utility::toHex(digest), Eq(sha3_384_foo));
+}
+
+TEST_F(HashTest, sha3_512StandaloneFunctionVectorVersion)
+{
+    std::string message = "foo";
+    std::vector<uint8_t> messageConv(message.begin(), message.end());
+    std::vector<uint8_t> digest = sha3_512(messageConv);
+    EXPECT_THAT(utility::toHex(digest), Eq(sha3_512_foo));
+}
+
 TEST_F(HashTest, sha1StandaloneFunctionBinaryVersion)
 {
     std::string message = "foo";
@@ -229,6 +355,27 @@ TEST_F(HashTest, sha512StandaloneFunctionBinaryVersion)
     EXPECT_THAT(utility::toHex(digest), Eq(sha512_foo));
 }
 
+TEST_F(HashTest, sha3_256StandaloneFunctionBinaryVersion)
+{
+    std::string message = "foo";
+    std::vector<uint8_t> digest = sha3_256(reinterpret_cast<const uint8_t*>(message.c_str()), message.length());
+    EXPECT_THAT(utility::toHex(digest), Eq(sha3_256_foo));
+}
+
+TEST_F(HashTest, sha3_384StandaloneFunctionBinaryVersion)
+{
+    std::string message = "foo";
+    std::vector<uint8_t> digest = sha3_384(reinterpret_cast<const uint8_t*>(message.c_str()), message.length());
+    EXPECT_THAT(utility::toHex(digest), Eq(sha3_384_foo));
+}
+
+TEST_F(HashTest, sha3_512StandaloneFunctionBinaryVersion)
+{
+    std::string message = "foo";
+    std::vector<uint8_t> digest = sha3_512(reinterpret_cast<const uint8_t*>(message.c_str()), message.length());
+    EXPECT_THAT(utility::toHex(digest), Eq(sha3_512_foo));
+}
+
 TEST_F(HashTest, sha1StandaloneFunctionStringVersion)
 {
     std::vector<uint8_t> digest = sha1("foo");
@@ -251,6 +398,24 @@ TEST_F(HashTest, sha512StandaloneFunctionStringVersion)
 {
     std::vector<uint8_t> digest = sha512("foo");
     EXPECT_THAT(utility::toHex(digest), Eq(sha512_foo));
+}
+
+TEST_F(HashTest, sha3_256StandaloneFunctionStringVersion)
+{
+    std::vector<uint8_t> digest = sha3_256("foo");
+    EXPECT_THAT(utility::toHex(digest), Eq(sha3_256_foo));
+}
+
+TEST_F(HashTest, sha3_384StandaloneFunctionStringVersion)
+{
+    std::vector<uint8_t> digest = sha3_384("foo");
+    EXPECT_THAT(utility::toHex(digest), Eq(sha3_384_foo));
+}
+
+TEST_F(HashTest, sha3_512StandaloneFunctionStringVersion)
+{
+    std::vector<uint8_t> digest = sha3_512("foo");
+    EXPECT_THAT(utility::toHex(digest), Eq(sha3_512_foo));
 }
 
 TEST_F(HashTest, returnsDigestIfCalledTwice) {


### PR DESCRIPTION
Add wrapper functions for generating SHA3 hashes.