### PR TITLE
tests: Support CROSSCOMPILING_EMULATOR ∀ tests, Do not build SDK test during lib build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_subdirectory(unit)
-add_subdirectory(sdk)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -114,19 +114,40 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     target_link_libraries(asymencryptiontests ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
     target_link_libraries(rsa_padding_mode_tests   ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
 
-    add_test(OpenSSLTest openssltest)
+    add_test(
+        NAME OpenSSLTest
+        COMMAND openssltest
+    )
 
-    add_test(Asn1TimeTests asn1timetests)
-    add_test(HashTests hashtests)
-    add_test(UtilTests utiltests)
-    add_test(KeyTest keytests)
-    add_test(CsrTests csrtests)
+    add_test(
+        NAME Asn1TimeTests
+        COMMAND asn1timetests
+    )
+    add_test(
+        NAME HashTests
+        COMMAND hashtests
+    )
+    add_test(
+        NAME UtilTests
+        COMMAND utiltests
+    )
+    add_test(
+        NAME KeyTest
+        COMMAND keytests
+    )
+    add_test(
+        NAME CsrTests
+        COMMAND csrtests
+    )
     add_test(
         NAME BioTests
         COMMAND biotests
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/test-certs"
     )
-    add_test(DistinguishedNameTests dntests)
+    add_test(
+        NAME DistinguishedNameTests
+        COMMAND dntests
+    )
     add_test(
         NAME X509Tests
         COMMAND x509tests


### PR DESCRIPTION
There is a shorthand and a verbose syntax for `add_test()` in CMake, but only the verbose syntax supports running tests under a `CMAKE_CROSSCOMPILING_EMULATOR` when it is set.

The SDK test is meant to be executed inside of an SDK to verify that MoCOCrW was correctly packaged and installed in the SDK. Consequently, it does not make sense to run this test during the build of the library, because this build might happen in an SDK (or other environment) that does not have MoCOCrW installed.
