### PR TITLE
Cherry-pick a few commits to openssl1.1

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_subdirectory(unit)
-add_subdirectory(sdk)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
             ONLY_CMAKE_FIND_ROOT_PATH)
         if(GMOCK_SRC_DIR)
             message(STATUS "Found GMock sources in ${GMOCK_SRC_DIR}")
+            set(INSTALL_GTEST OFF CACHE BOOL "Enable installation of googletest." FORCE)
             add_subdirectory("${GMOCK_SRC_DIR}" gmock)
             set(GMOCK_BOTH_LIBRARIES "gmock_main")
         else()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -104,19 +104,40 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     target_link_libraries(signaturetests      ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
     target_link_libraries(asymencryptiontests ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
 
-    add_test(OpenSSLTest openssltest)
+    add_test(
+        NAME OpenSSLTest
+        COMMAND openssltest
+    )
 
-    add_test(Asn1TimeTests asn1timetests)
-    add_test(HashTests hashtests)
-    add_test(UtilTests utiltests)
-    add_test(KeyTest keytests)
-    add_test(CsrTests csrtests)
+    add_test(
+        NAME Asn1TimeTests
+        COMMAND asn1timetests
+    )
+    add_test(
+        NAME HashTests
+        COMMAND hashtests
+    )
+    add_test(
+        NAME UtilTests
+        COMMAND utiltests
+    )
+    add_test(
+        NAME KeyTest
+        COMMAND keytests
+    )
+    add_test(
+        NAME CsrTests
+        COMMAND csrtests
+    )
     add_test(
         NAME BioTests
         COMMAND biotests
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/test-certs"
     )
-    add_test(DistinguishedNameTests dntests)
+    add_test(
+        NAME DistinguishedNameTests
+        COMMAND dntests
+    )
     add_test(
         NAME X509Tests
         COMMAND x509tests


### PR DESCRIPTION
```
37f8be1 tests: Support CROSSCOMPILING_EMULATOR ∀ tests
6d9d9ad tests: Do not build SDK test during lib build
b93c882 tests: Disable installing googletest & googlemock
```