### PR TITLE
Silence -Wnoexcept-type, Fix -Wsign-compare

### DIFF
--- a/src/cppc/checkcall.hpp
+++ b/src/cppc/checkcall.hpp
@@ -34,15 +34,15 @@ template <class T>
 using EnableIfIsPrecallFunc = std::enable_if_t<std::is_same<T, void()>::value>;
 
 template <class T, class = EnableIfIsPrecallFunc<decltype(T::preCall)>>
-inline void _callIf(void*) {
+static inline void _callIf(void*) {
     T::preCall();
 }
 
 template <class... Ts>
-inline void _callIf(Ts*...) {}
+static inline void _callIf(Ts*...) {}
 
 template <class T>
-inline void callPrecCallIfPresent() {
+static inline void callPrecCallIfPresent() {
     _callIf<T>(nullptr);
 }
 
@@ -179,7 +179,7 @@ template <class R = DefaultReturnCheckPolicy,
           class E = DefaultErrorPolicy,
           class Callable = std::function<void(void)>,
           class... Args>
-inline auto callChecked(Callable&& callable, Args&&... args) {
+static inline auto callChecked(Callable&& callable, Args&&... args) {
     ::cppc::_auxiliary::callPrecCallIfPresent<R>();
     const auto retVal = callable(std::forward<Args>(args)...);
     return _auxiliary::ReturnCheckWrapper<R, E, decltype(retVal)>::policyHandeledReturnValue(

--- a/src/cppc/checkcall.hpp
+++ b/src/cppc/checkcall.hpp
@@ -212,6 +212,8 @@ private:
     FunctorOrFuncRefType _functor;
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnoexcept-type"
 template <class ReturnCheckPolicy = DefaultReturnCheckPolicy,
           class ErrorPolicy = DefaultErrorPolicy>
 class CallCheckContext {
@@ -222,5 +224,6 @@ public:
                 std::forward<Callable>(callable), std::forward<Args>(args)...);
     }
 };
+#pragma GCC diagnostic pop
 
 }  // namespace cppc

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -251,10 +251,10 @@ TEST(KeySpecTest, testGeneratingEccKeyWithDefaultParameters)
 TEST(KeySpecTest, testThatDefaultParametersAreSane)
 {
     RSASpec spec{};
-    ASSERT_THAT(spec.numberOfBits(), Eq(2048));
+    ASSERT_EQ(spec.numberOfBits(), 2048);
 
     RSASpec nonDefault{1024};
-    ASSERT_THAT(nonDefault.numberOfBits(), Eq(1024));
+    ASSERT_EQ(nonDefault.numberOfBits(), 1024);
 
     ECCSpec defaultEccSpec{};
     ASSERT_EQ(defaultEccSpec.curve(), openssl::ellipticCurveNid::PRIME_256v1);


### PR DESCRIPTION
The `-Wnoexcept-type` warning generated by gcc in checkcall does not apply, because the checkcall functionality is only used internally and not exposed to users of MoCOCrW. Silence the warning so other messages do not drown in the number of `-Wnoexcept-type` messages.

While at it, avoid generating symbols for inline functions. Specifying a function as inline but without static will in any case generate a symbol and a non-inlined version of said function. This is in most cases not what we want, if we want the function to be inlined. Add the static keyword to all functions specified as inline to avoid this.

Fix a `-Wsign-compare` warning in the tests by switching to `ASSERT_EQ`.