### PR TITLE
CSR: Additional features

### DIFF
--- a/src/mococrw/csr.h
+++ b/src/mococrw/csr.h
@@ -39,8 +39,31 @@ public:
                                        const AsymmetricKeypair &key);
 
     /**
+     * Construct a new CertificateSigningRequest for the given distinguished name.
+     * The given public key is integrated in the CSR whereas the given private key
+     * is used to sign the CertificateSigningRequest. The signature uses the provided
+     * digestFunction.
+     */
+    explicit CertificateSigningRequest(const DistinguishedName &distinguishedName,
+                                       const AsymmetricKeypair &key,
+                                       const openssl::DigestTypes digestFunction);
+
+    /**
      * Return the PEM for this CSR as a string.
      */
+    std::string toPEM() const;
+
+    /**
+     * Return the DER for this CSR.
+     */
+    std::vector<uint8_t> toDER() const;
+
+
+    /**
+     * Return the PEM for this CSR as a string.
+     * @deprecated - inconsistent capitalization with rest of lib
+     */
+    [[deprecated]]
     std::string toPem() const;
 
     /**
@@ -52,6 +75,16 @@ public:
      * Convert a CSR in PEM format from a file to a CertificateSigningRequest.
      */
     static CertificateSigningRequest fromPEMFile(const std::string &filename);
+
+    /**
+     * Convert a CSR in DER format to a CertificateSigningRequest.
+     */
+    static CertificateSigningRequest fromDER(const std::vector<uint8_t> &derData);
+
+    /**
+     * Convert a CSR in DER format from a file to a CertificateSigningRequest.
+     */
+    static CertificateSigningRequest fromDERFile(const std::string &filename);
 
     /**
      * Get the public key for this CertificateSigningRequest.

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -56,6 +56,8 @@ namespace lib
 class OpenSSLLib
 {
 public:
+    static int SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) noexcept;
+    static X509_REQ* SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) noexcept;
     static int SSL_EVP_MD_CTX_reset(EVP_MD_CTX* ctx) noexcept;
     static int SSL_EVP_DigestFinal_ex(EVP_MD_CTX* ctx, unsigned char* md, unsigned int* s) noexcept;
     static int SSL_EVP_DigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt) noexcept;

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -528,12 +528,27 @@ int _BIO_read(BIO* bio, std::vector<uint8_t> &buf, std::size_t numBytes);
  * @throw OpenSSLException if an OpenSSL internal error occurs.
  */
 SSL_X509_Ptr _d2i_X509_bio(BIO* bp);
+
+/*
+ * Read a DER encoded X509 certificate request from a bio
+ *
+ * @throw OpenSSLException if an OpenSSL internal error occurs.
+ */
+SSL_X509_REQ_Ptr _d2i_X509_REQ_bio(BIO* bp);
+
 /*
  * Write an X509 certificate in DER encoded form to a bio
  *
  * @throw OpenSSLException if an OpenSSL internal error occurs.
  */
 void _i2d_X509_bio(BIO* bp, X509* x);
+
+/*
+ * Write an X509 certification request in DER encoded form to a bio
+ *
+ * @throw OpenSSLException if an OpenSSL internal error occurs.
+ */
+void _i2d_X509_REQ_bio(BIO* bp, X509_REQ* x);
 
 /**
  * Sign an X509_REQ to obtain a complete CSR.

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -849,6 +849,14 @@ int OpenSSLLib::SSL_EVP_DigestVerify(EVP_MD_CTX* ctx,
 {
     return EVP_DigestVerify(ctx, sigret, siglen, tbs, tbslen);
 }
+X509_REQ* OpenSSLLib::SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) noexcept
+{
+    return d2i_X509_REQ_bio(bp, req);
+}
+int OpenSSLLib::SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) noexcept
+{
+    return i2d_X509_REQ_bio(bp, req);
+}
 }  //::lib
 }  //::openssl
 }  //::mococrw

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -399,12 +399,21 @@ SSL_X509_Ptr _d2i_X509_bio(BIO* bp)
     return SSL_X509_Ptr{OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_d2i_X509_bio, bp, nullptr)};
 }
 
+SSL_X509_REQ_Ptr _d2i_X509_REQ_bio(BIO* bp)
+{
+    return SSL_X509_REQ_Ptr{OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_d2i_X509_REQ_bio, bp, nullptr)};
+}
+
 
 void _i2d_X509_bio(BIO* bp, X509* x)
 {
     OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_i2d_X509_bio, bp, x);
 }
 
+void _i2d_X509_REQ_bio(BIO* bp, X509_REQ* x)
+{
+    OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_i2d_X509_REQ_bio, bp, x);
+}
 
 void _X509_REQ_sign_ctx(X509_REQ* req, EVP_MD_CTX* ctx)
 {

--- a/tests/unit/ExecUtil.h
+++ b/tests/unit/ExecUtil.h
@@ -1,0 +1,16 @@
+#include <array>
+#include <stdio.h>
+
+std::string exec(const char* cmd) {
+    std::array<char, 128> buffer;
+    std::string result;
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+    if (!pipe) throw std::runtime_error("popen() failed!");
+    while (!feof(pipe.get())) {
+        if (fgets(buffer.data(), 128, pipe.get()) != NULL) {
+               result += buffer.data();
+        }
+
+    }
+    return result;
+}

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -867,6 +867,14 @@ int OpenSSLLib::SSL_EVP_DigestVerify(EVP_MD_CTX* ctx,
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_DigestVerify(ctx, sigret, siglen, tbs, tbslen);
 }
+X509_REQ* OpenSSLLib::SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_d2i_X509_REQ_bio(bp, req);
+}
+int OpenSSLLib::SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_i2d_X509_REQ_bio(bp, req);
+}
 }  //::lib
 }  //::openssl
 }  //::mococrw

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -35,6 +35,8 @@ namespace openssl
 class OpenSSLLibMockInterface
 {
 public:
+    virtual int SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) = 0;
+    virtual X509_REQ* SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) = 0;
     virtual int SSL_EVP_MD_CTX_reset(EVP_MD_CTX* ctx) = 0;
     virtual int SSL_EVP_DigestFinal_ex(EVP_MD_CTX* ctx, unsigned char* md, unsigned int* s) = 0;
     virtual int SSL_EVP_DigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt) = 0;
@@ -292,6 +294,8 @@ public:
 class OpenSSLLibMock : public OpenSSLLibMockInterface
 {
 public:
+    MOCK_METHOD2(SSL_i2d_X509_REQ_bio, int(BIO*, X509_REQ*));
+    MOCK_METHOD2(SSL_d2i_X509_REQ_bio, X509_REQ*(BIO*, X509_REQ**));
     MOCK_METHOD1(SSL_EVP_MD_CTX_reset, int(EVP_MD_CTX*));
     MOCK_METHOD3(SSL_EVP_DigestFinal_ex, int(EVP_MD_CTX*, unsigned char*, unsigned int*));
     MOCK_METHOD3(SSL_EVP_DigestUpdate, int(EVP_MD_CTX*, const void*, size_t));

--- a/tests/unit/test_ca.cpp
+++ b/tests/unit/test_ca.cpp
@@ -28,6 +28,8 @@
 #include "mococrw/error.h"
 #include "mococrw/key_usage.h"
 
+#include "ExecUtil.h"
+
 using namespace mococrw;
 using namespace std::string_literals;
 
@@ -175,20 +177,6 @@ void CATest::SetUp()
 
 }
 
-
-std::string exec(const char* cmd) {
-    std::array<char, 128> buffer;
-    std::string result;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
-    if (!pipe) throw std::runtime_error("popen() failed!");
-    while (!feof(pipe.get())) {
-        if (fgets(buffer.data(), 128, pipe.get()) != NULL) {
-               result += buffer.data();
-        }
-
-    }
-    return result;
-}
 
 void testValiditySpan(const X509Certificate &cert,
                       Asn1Time::Seconds validitySpan,


### PR DESCRIPTION
- Add interfaces to read/write DER in addition to PEM format
- Add option to choose the digest function that used in the
  signature of the CSR.

[ This change has currently breaking tests due to an expired certificate in another test. However, it can be individually reviewed ]