### PR TITLE
Adopt verbose add_test syntax in cmake

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -178,7 +178,11 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
         COMMAND asymencryptiontests
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/test-certs"
     )
-    add_test(RSAPaddingModeTests rsa_padding_mode_tests)
+    add_test(
+        NAME RSAPaddingModeTests
+        COMMAND rsa_padding_mode_tests
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/test-certs"
+    )
 
     # Configure valgrind
     find_program(MEMORYCHECK_COMMAND NAMES valgrind)


### PR DESCRIPTION
Change all unit tests to use the new/verbose add_test syntax
as this respects the CMAKE_CROSSCOMPILING_EMULATOR variable,
which is needed if the unit tests use a different architecture
than the build machine.

Change-Id: I4a0b5441bb415d158d11a55fd47d61c5e083f748