### PR TITLE
symmetric crypto: Allow encrypting empty plaintext

### DIFF
--- a/src/symmetric_crypto.cpp
+++ b/src/symmetric_crypto.cpp
@@ -132,7 +132,11 @@ public:
         if (message.size() > (std::numeric_limits<int>::max() - EVP_MAX_BLOCK_LENGTH)) {
             throw MoCOCrWException("Message is too big.");
         }
+
         int processingChunkSize = message.size();
+        if (processingChunkSize <= 0) {
+            return;
+        }
         std::vector<uint8_t> processedChunk(processingChunkSize + EVP_MAX_BLOCK_LENGTH);
 
         _EVP_CipherUpdate(_ctx.get(),

--- a/tests/unit/test_symmetric_crypto.cpp
+++ b/tests/unit/test_symmetric_crypto.cpp
@@ -161,8 +161,10 @@ TEST_P(SymmetricCipherTest, DoubleCreationUsesDifferentIVs)
     auto ciphertext0 = encryptor0->finish();
     auto ciphertext1 = encryptor1->finish();
 
-    ASSERT_NE(ciphertext0, ciphertext1)
-        << "Two encryption operations with different IVs should return different ciphertexts.";
+    if (ciphertext0.size() > 0 || ciphertext1.size() > 0) {
+        ASSERT_NE(ciphertext0, ciphertext1)
+            << "Two encryption operations with different IVs should return different ciphertexts.";
+    }
 }
 
 TEST_P(SymmetricCipherTest, EncryptDecryptDifferentPlaintextLength)
@@ -222,7 +224,8 @@ TEST_P(SymmetricCipherTest, EncryptDecryptDifferentPlaintextLength)
 static std::vector<EncrytDecryptTestData> prepareTestDataForMode(SymmetricCipherMode mode)
 {
     static const std::vector<std::string> PLAINTEXT_STRINGS_OF_DIFFERENT_LENGTH
-            {"0",
+            {"", // empty string
+             "0",
              "0123456789", // less than a block
              "0123456789123456", // a block
              "01234567891234567890" // more than a block


### PR DESCRIPTION
AES-GCM encryption fails in `finalize()` when `update()` was called with an empty block while it attempts to obtain the auth tag (and with a useless OpenSSL exception at that). This problem does not occur if we never call `EVP_CipherUpdate`, so don't call the function when the given input block is empty.

Add a test that verifies encrypting an empty block is possible in all supported block cipher modes of operation. Adjust a test that would otherwise fail with a false positive error.