### PR TITLE
cmake: Add support for various sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,16 @@ if(CMAKE_BUILD_TYPE STREQUAL Coverage)
     find_package(Coverage REQUIRED)
 endif()
 
+if(CMAKE_BUILD_TYPE STREQUAL ASAN)
+    include(AddressSanitizerTarget)
+endif()
+if(CMAKE_BUILD_TYPE STREQUAL UBSAN)
+    include(UBSanitizerTarget)
+endif()
+if(CMAKE_BUILD_TYPE STREQUAL TSAN)
+    include(ThreadSanitizerTarget)
+endif()
+
 ###############################################################################
 # Documentation
 ###############################################################################

--- a/cmake/AddressSanitizerTarget.cmake
+++ b/cmake/AddressSanitizerTarget.cmake
@@ -1,0 +1,130 @@
+#
+# #%L
+# %%
+# Copyright (C) 2018 BMW Car IT GmbH
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+#
+
+# AddressSanitizerTarget
+# ======================
+#
+# Sets up an ``asan`` target that automates executing tests with
+# `AddressSanitizer <https://github.com/google/sanitizers/wiki/AddressSanitizer>`_
+# (ASan) - a memory error detector for C/C++.
+#
+# Usage
+# -----
+#
+# Add the following lines to your project's ``CMakeLists.txt``:
+#
+# .. code-block:: cmake
+#
+#  if(CMAKE_BUILD_TYPE STREQUAL ASAN)
+#      include(AddressSanitizerTarget)
+#  endif()
+#
+# Then execute CMake with:
+#
+# .. code-block:: sh
+#
+#  CXX=clang++ cmake -DCMAKE_BUILD_TYPE=ASAN $SOURCE_DIR
+#
+# and generate the ASan report for CTest based tests with:
+#
+# .. code-block:: sh
+#
+#  cmake --build . --target asan
+#
+# If necessary CTest parameters can be passed in the ARGS env variable:
+#
+# .. code-block:: sh
+#
+#  ARGS="-VV --repeat-until-fail 10" cmake --build . --target asan
+#
+# Configuration
+# -------------
+#
+# This module reads the following configuration variables:
+#
+# ``ASAN_OPTIONS``
+#  `Run-time flags <https://github.com/google/sanitizers/wiki/AddressSanitizerFlags#run-time-flags>`__
+#  for the AddressSanitizer.
+#
+# ``LSAN_OPTIONS``
+#  `Run-time flags <https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#flags>`__
+#  for the LeakSanitizer (LSan).
+#
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL ASAN)
+    message(FATAL_ERROR "AddressSanitizerTarget.cmake requires CMake to be "
+                        "called with -DCMAKE_BUILD_TYPE=ASAN")
+endif()
+
+# ASAN build type
+set(_ASAN_FLAGS "-fsanitize=address -fno-omit-frame-pointer")
+set(_ASAN_FLAGS "${_ASAN_FLAGS} -fsanitize-address-use-after-scope")
+set(_ASAN_FLAGS "${_ASAN_FLAGS} -g -O1")
+set(CMAKE_CXX_FLAGS_ASAN ${_ASAN_FLAGS} CACHE STRING
+    "Flags used by the C++ compiler during ASAN builds." FORCE
+)
+set(CMAKE_C_FLAGS_ASAN ${_ASAN_FLAGS} CACHE STRING
+    "Flags used by the C compiler during ASAN builds." FORCE
+)
+set(CMAKE_EXE_LINKER_FLAGS_ASAN ${_ASAN_FLAGS} CACHE STRING
+    "Flags used for linking binaries during ASAN builds." FORCE
+)
+set(CMAKE_SHARED_LINKER_FLAGS_ASAN ${_ASAN_FLAGS} CACHE STRING
+    "Flags used for linking shared libraries during ASAN builds." FORCE
+)
+mark_as_advanced(
+    CMAKE_CXX_FLAGS_ASAN CMAKE_C_FLAGS_ASAN CMAKE_EXE_LINKER_FLAGS_ASAN
+    CMAKE_SHARED_LINKER_FLAGS_ASAN CMAKE_STATIC_LINKER_FLAGS_ASAN
+)
+unset(_ASAN_FLAGS)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    find_library(ASAN_LIBRARY asan)
+
+    set(ASAN_FIND_REQUIRED TRUE)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(ASAN
+        REQUIRED_VARS ASAN_LIBRARY
+    )
+    mark_as_advanced(ASAN_LIBRARY)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+    # TODO: Setup proper check for the asan lib (part of compiler-rt-staticdev)
+    set(ASAN_FOUND TRUE)
+endif()
+
+# Add asan target.
+string(CONCAT _asan_options
+    "detect_odr_violation=0,max_free_fill_size=65535,"
+    "detect_stack_use_after_return=true,"
+    "${ASAN_OPTIONS}"
+)
+add_custom_target(asan
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}
+
+    # working escaping for make: \${ARGS} \$\${ARGS}
+    # working escaping for ninja: \$\${ARGS}
+    # No luck with VERBATIM option.
+    COMMAND ${CMAKE_COMMAND} -E env
+                ASAN_OPTIONS=${_asan_options} LSAN_OPTIONS=${LSAN_OPTIONS}
+            ${CMAKE_CTEST_COMMAND} --output-on-failure "\$\${ARGS}"
+
+    COMMENT "Generate ASan report"
+    USES_TERMINAL # Ensure ninja outputs to stdout.
+)
+unset(_asan_options)

--- a/cmake/ThreadSanitizerTarget.cmake
+++ b/cmake/ThreadSanitizerTarget.cmake
@@ -1,0 +1,120 @@
+#
+# #%L
+# %%
+# Copyright (C) 2018 BMW Car IT GmbH
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+#
+
+# ThreadSanitizerTarget
+# =====================
+#
+# Sets up an ``tsan`` target that automates executing tests with
+# `ThreadSanitizer <https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual>`_
+# (TSan) - Data race detector for C/C++ .
+#
+# Usage
+# -----
+#
+# Add the following lines to your project's ``CMakeLists.txt``:
+#
+# .. code-block:: cmake
+#
+#  if(CMAKE_BUILD_TYPE STREQUAL TSAN)
+#      include(ThreadSanitizerTarget)
+#  endif()
+#
+# Then execute CMake with:
+#
+# .. code-block:: sh
+#
+#  CXX=clang++ cmake -DCMAKE_BUILD_TYPE=TSAN $SOURCE_DIR
+#
+# and generate the TSan report for CTest based tests with:
+#
+# .. code-block:: sh
+#
+#  cmake --build . --target tsan
+#
+# If necessary CTest parameters can be passed in the ARGS env variable:
+#
+# .. code-block:: sh
+#
+#  ARGS="-VV --repeat-until-fail 10" cmake --build . --target tsan
+#
+# Configuration
+# -------------
+#
+# This module reads the following configuration variables:
+#
+# ``TSAN_OPTIONS``
+#  `Run-time flags <https://github.com/google/sanitizers/wiki/ThreadSanitizerFlags#thread-sanitizer-flags>`__
+#  for the ThreadSanitizer.
+#
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL TSAN)
+    message(FATAL_ERROR "ThreadSanitizerTarget.cmake requires CMake to be "
+                        "called with -DCMAKE_BUILD_TYPE=TSAN")
+endif()
+
+# TSAN build type
+set(_TSAN_FLAGS "-fsanitize=thread -fno-omit-frame-pointer")
+set(_TSAN_FLAGS "${_TSAN_FLAGS} -g -O2")
+set(CMAKE_CXX_FLAGS_TSAN ${_TSAN_FLAGS} CACHE STRING
+    "Flags used by the C++ compiler during TSAN builds." FORCE
+)
+set(CMAKE_C_FLAGS_TSAN ${_TSAN_FLAGS} CACHE STRING
+    "Flags used by the C compiler during TSAN builds." FORCE
+)
+set(CMAKE_EXE_LINKER_FLAGS_TSAN ${_TSAN_FLAGS} CACHE STRING
+    "Flags used for linking binaries during TSAN builds." FORCE
+)
+set(CMAKE_SHARED_LINKER_FLAGS_TSAN ${_TSAN_FLAGS} CACHE STRING
+    "Flags used for linking shared libraries during TSAN builds." FORCE
+)
+mark_as_advanced(
+    CMAKE_CXX_FLAGS_TSAN CMAKE_C_FLAGS_TSAN CMAKE_EXE_LINKER_FLAGS_TSAN
+    CMAKE_SHARED_LINKER_FLAGS_TSAN CMAKE_STATIC_LINKER_FLAGS_TSAN
+)
+unset(_TSAN_FLAGS)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    find_library(TSAN_LIBRARY tsan)
+
+    set(TSAN_FIND_REQUIRED TRUE)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(TSAN
+        REQUIRED_VARS TSAN_LIBRARY
+    )
+    mark_as_advanced(TSAN_LIBRARY)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+    # TODO: Setup proper check for the tsan lib (part of compiler-rt-staticdev)
+    set(TSAN_FOUND TRUE)
+endif()
+
+# Add tsan target.
+add_custom_target(tsan
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}
+
+    # working escaping for make: \${ARGS} \$\${ARGS}
+    # working escaping for ninja: \$\${ARGS}
+    # No luck with VERBATIM option.
+    #
+    COMMAND ${CMAKE_COMMAND} -E env
+                TSAN_OPTIONS=${TSAN_OPTIONS}
+            ${CMAKE_CTEST_COMMAND} --output-on-failure "\$\${ARGS}"
+
+    COMMENT "Generate TSan report"
+    USES_TERMINAL # Ensure ninja outputs to stdout.
+)

--- a/cmake/UBSanitizerTarget.cmake
+++ b/cmake/UBSanitizerTarget.cmake
@@ -1,0 +1,125 @@
+#
+# #%L
+# %%
+# Copyright (C) 2018 BMW Car IT GmbH
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+#
+
+# UBSanitizerTarget
+# ======================
+#
+# Sets up an ``ubsan`` target that automates executing tests with
+# `UndefinedBehaviorSanitizer <https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html>`_
+# (UBSan) - a fast undefined behavior detector for C/C++.
+#
+# Usage
+# -----
+#
+# Add the following lines to your project's ``CMakeLists.txt``:
+#
+# .. code-block:: cmake
+#
+#  if(CMAKE_BUILD_TYPE STREQUAL UBSAN)
+#      include(UBSanitizerTarget)
+#  endif()
+#
+# Then execute CMake with:
+#
+# .. code-block:: sh
+#
+#  CXX=clang++ cmake -DCMAKE_BUILD_TYPE=UBSAN $SOURCE_DIR
+#
+# and generate the UBSan report for CTest based tests with:
+#
+# .. code-block:: sh
+#
+#  cmake --build . --target ubsan
+#
+# If necessary CTest parameters can be passed in the ARGS env variable:
+#
+# .. code-block:: sh
+#
+#  ARGS="-VV --repeat-until-fail 10" cmake --build . --target ubsan
+#
+# Configuration
+# -------------
+#
+# This module reads the following configuration variables:
+#
+# ``UBSAN_OPTIONS``
+#  `Run-time flags <https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html>`__
+#  for the UndefinedBehaviorSanitizer.
+#
+
+if(NOT CMAKE_BUILD_TYPE STREQUAL UBSAN)
+    message(FATAL_ERROR "UBSanitizerTarget.cmake requires CMake to be "
+                        "called with -DCMAKE_BUILD_TYPE=UBSAN")
+endif()
+
+# UBSAN build type
+set(_UBSAN_FLAGS "-fsanitize=undefined -fno-omit-frame-pointer")
+set(_UBSAN_FLAGS "${_UBSAN_FLAGS} -fno-sanitize-recover=all")
+set(_UBSAN_FLAGS "${_UBSAN_FLAGS} -g -O1")
+set(CMAKE_CXX_FLAGS_UBSAN ${_UBSAN_FLAGS} CACHE STRING
+    "Flags used by the C++ compiler during UBSAN builds." FORCE
+)
+set(CMAKE_C_FLAGS_UBSAN ${_UBSAN_FLAGS} CACHE STRING
+    "Flags used by the C compiler during UBSAN builds." FORCE
+)
+set(CMAKE_EXE_LINKER_FLAGS_UBSAN ${_UBSAN_FLAGS} CACHE STRING
+    "Flags used for linking binaries during UBSAN builds." FORCE
+)
+set(CMAKE_SHARED_LINKER_FLAGS_UBSAN ${_UBSAN_FLAGS} CACHE STRING
+    "Flags used for linking shared libraries during UBSAN builds." FORCE
+)
+mark_as_advanced(
+    CMAKE_CXX_FLAGS_UBSAN CMAKE_C_FLAGS_UBSAN CMAKE_EXE_LINKER_FLAGS_UBSAN
+    CMAKE_SHARED_LINKER_FLAGS_UBSAN CMAKE_STATIC_LINKER_FLAGS_UBSAN
+)
+unset(_UBSAN_FLAGS)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    find_library(UBSAN_LIBRARY ubsan)
+
+    set(UBSAN_FIND_REQUIRED TRUE)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(UBSAN
+        REQUIRED_VARS UBSAN_LIBRARY
+    )
+    mark_as_advanced(UBSAN_LIBRARY)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+    # TODO: Setup proper check for the ubsan lib (part of compiler-rt-staticdev)
+    set(UBSAN_FOUND TRUE)
+endif()
+
+# Add ubsan target.
+string(CONCAT _ubsan_options
+    "print_stacktrace=1,"
+    "${UBSAN_OPTIONS}"
+)
+add_custom_target(ubsan
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}
+
+    # working escaping for make: \${ARGS} \$\${ARGS}
+    # working escaping for ninja: \$\${ARGS}
+    # No luck with VERBATIM option.
+    COMMAND ${CMAKE_COMMAND} -E env
+                UBSAN_OPTIONS=${_ubsan_options}
+            ${CMAKE_CTEST_COMMAND} --output-on-failure "\$\${ARGS}"
+
+    COMMENT "Generate UBSan report"
+    USES_TERMINAL # Ensure ninja outputs to stdout.
+)
+unset(_ubsan_options)


### PR DESCRIPTION
Add address sanitizer, undefined behavior sanitizer and thread sanitizer that can be enabled by switching the `CMAKE_BUILD_TYPE` variable on the CMake command line.