### PR TITLE
Various small fixes for issues reported by clang-tidy

### DIFF
--- a/src/bio.cpp
+++ b/src/bio.cpp
@@ -59,7 +59,7 @@ std::string BioObject::flushToString()
         if (count > buffsize) {
             // _BIO_gets() reads at most buffer.size() bytes out of a bio so if count is bigger
             // than buffsize, it indicates a bug in OpenSSL or some other severe problem.
-            throw new std::runtime_error(
+            throw std::runtime_error(
                     "OpenSSL corrupted the memory. Your best option now is to terminate.");
         }
         ostream << std::string{buffer.begin(), buffer.begin() + count};
@@ -87,7 +87,7 @@ std::vector<uint8_t> BioObject::flushToVector()
             break;
         }
         if (static_cast<std::size_t>(count) > buffSize) {
-            throw new std::runtime_error(
+            throw std::runtime_error(
                     "OpenSSL corrupted the memory. Your best option now is to terminate.");
         }
         outputBuffer.insert(outputBuffer.end(), tmpBuffer.begin(), tmpBuffer.end());

--- a/src/mococrw/key_usage.h
+++ b/src/mococrw/key_usage.h
@@ -166,15 +166,15 @@ public:
     }
 
 private:
-    bool _decipherOnly;
-    bool _encipherOnly;
-    bool _cRLSign;
-    bool _keyCertSign;
-    bool _keyAgreement;
-    bool _dataEncipherment;
-    bool _keyEncipherment;
-    bool _nonRepudiation;
-    bool _digitalSignature;
+    bool _decipherOnly = false;
+    bool _encipherOnly = false;
+    bool _cRLSign = false;
+    bool _keyCertSign = false;
+    bool _keyAgreement = false;
+    bool _dataEncipherment = false;
+    bool _keyEncipherment = false;
+    bool _nonRepudiation = false;
+    bool _digitalSignature = false;
 };
 
 class KeyUsageExtension::Builder

--- a/src/mococrw/sign_params.h
+++ b/src/mococrw/sign_params.h
@@ -162,13 +162,15 @@ public:
         static_assert(std::is_base_of<ExtensionBase, T>::value,
                       "Extension is not derived from ExtensionBase");
 
-        _sp._extensions[extension.getNid()] = std::make_shared<T>(std::move(extension));
+        auto nid = extension.getNid();
+        _sp._extensions[nid] = std::make_shared<T>(std::move(extension));
         return *this;
     }
 
     Builder& addExtension(std::shared_ptr<ExtensionBase> extension)
     {
-        _sp._extensions[extension->getNid()] = std::move(extension);
+        auto nid = extension->getNid();
+        _sp._extensions[nid] = std::move(extension);
         return *this;
     }
 


### PR DESCRIPTION
- Avoid calling `getNid()` on `std::move()`'d objects
- Initialize KeyUsageExtension member variables
- bio: throw exceptions, not pointers to exceptions