### PR TITLE
ECDSA: Support verification from IEEE1363 format

### DIFF
--- a/src/mococrw/asymmetric_crypto_ctx.h
+++ b/src/mococrw/asymmetric_crypto_ctx.h
@@ -501,11 +501,40 @@ public:
      */
     ~ECDSASignaturePublicKeyCtx();
 
+    /**
+     * Verifies an ECSDA signature against the given digest hash.
+     * It expects the ECSDA signature in the common ASN.1 encoding
+     * format SEQUENCE (INT r , INT s)
+     */
     void verifyDigest(const std::vector<uint8_t> &signature,
                       const std::vector<uint8_t> &digest) override;
 
+    /**
+     * Verifies an ECSDA signature against the given message
+     * It expects the ECSDA signature in the common ASN.1 encoding
+     * format SEQUENCE (INT r , INT s)
+     */
     void verifyMessage(const std::vector<uint8_t> &signature,
                        const std::vector<uint8_t> &message) override;
+
+
+    /**
+     * Verifies an ECSDA signature against the given digest hash.
+     * It expects the ECSDA signature in the IEEE 1363 format in which
+     * the two integers r and s are padded to the length of the ECC key
+     * and then just (binary)-concatenated together
+     */
+    void verifyDigestIEEE1363(const std::vector<uint8_t> &signature,
+                              const std::vector<uint8_t> &digest);
+
+    /**
+     * Verifies an ECSDA signature against the given message.
+     * It expects the ECSDA signature in the IEEE 1363 format in which
+     * the two (unsigned) integers r and s are padded to the length of
+     * the ECC key and then just (binary)-concatenated together
+     */
+    void verifyMessageIEEE1363(const std::vector<uint8_t> &signature,
+                               const std::vector<uint8_t> &message);
 
 private:
     /**

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -57,6 +57,11 @@ namespace lib
 class OpenSSLLib
 {
 public:
+    static int SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char ** pp) noexcept;
+    static int SSL_ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s) noexcept;
+    static void SSL_ECDSA_SIG_free(ECDSA_SIG* sig) noexcept;
+    static ECDSA_SIG* SSL_ECDSA_SIG_new() noexcept;
+    static BIGNUM* SSL_BN_bin2bn(const unsigned char* s, int len, BIGNUM*  ret) noexcept;
     static int SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) noexcept;
     static X509_REQ* SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) noexcept;
     static int SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX * c, int pad) noexcept;

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -170,6 +170,9 @@ using SSL_STACK_X509_CRL_Ptr =
                         SSLDeleter<STACK_OF(X509_CRL), lib::OpenSSLLib::SSL_sk_X509_CRL_free>>;
 using SSL_STACK_X509_CRL_SharedPtr = utility::SharedPtrTypeFromUniquePtr<SSL_STACK_X509_CRL_Ptr>;
 
+using SSL_ECDSA_SIG_Ptr = std::unique_ptr<ECDSA_SIG, SSLDeleter<ECDSA_SIG, lib::OpenSSLLib::SSL_ECDSA_SIG_free>>;
+using SSL_ECDSA_SIG_SharedPtr = utility::SharedPtrTypeFromUniquePtr<SSL_ECDSA_SIG_Ptr>;
+
 using time_point = std::chrono::system_clock::time_point;
 
 /* Below are is the "wrapped" OpenSSL library. By convetion, all functions start with an
@@ -1386,5 +1389,28 @@ std::vector<uint8_t> _EC_KEY_key2buf(const EVP_PKEY* evp, point_conversion_form_
  * @return The new public key
  */
 std::vector<uint8_t> _EVP_derive_key(const EVP_PKEY *peerkey, const EVP_PKEY *key);
+
+/* ECDSA Special */
+/**
+ * Set the r and s signature components from r and s a bignums
+ */
+void _ECDSA_SIG_set0(ECDSA_SIG* sig, SSL_BIGNUM_Ptr r, SSL_BIGNUM_Ptr s);
+
+/**
+ * Get the serialized ECSDA signature in ASN.1 format from ECSDA_SIG object
+ */
+std::vector<uint8_t> _i2d_ECSDA_SIG(const ECDSA_SIG*);
+
+/* Bignum related */
+
+/**
+ * Generate an OpenSSL bignum from the big-endian plain bytes representation
+ * of an unsigned integer.
+ *
+ * @return A smart pointer to the bignum object
+ * @throw OpenSSLException is a problem occurs during the conversion
+ */
+SSL_BIGNUM_Ptr _BN_bin2bn(const uint8_t* data, size_t dataLen);
+
 }  //::openssl
 }  //::mococrw

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -987,6 +987,27 @@ int OpenSSLLib::SSL_EVP_PKEY_derive(EVP_PKEY_CTX* ctx, unsigned char* key, size_
 {
     return EVP_PKEY_derive(ctx, key, keylen);
 }
+BIGNUM* OpenSSLLib::SSL_BN_bin2bn(const unsigned char* s, int len, BIGNUM*  ret) noexcept
+{
+    return BN_bin2bn(s, len, ret);
+}
+
+ECDSA_SIG* OpenSSLLib::SSL_ECDSA_SIG_new() noexcept
+{
+    return ECDSA_SIG_new();
+}
+void OpenSSLLib::SSL_ECDSA_SIG_free(ECDSA_SIG* sig) noexcept
+{
+    ECDSA_SIG_free(sig);
+}
+int OpenSSLLib::SSL_ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s) noexcept
+{
+    return ECDSA_SIG_set0(sig, r, s);
+}
+int OpenSSLLib::SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char ** pp) noexcept
+{
+    return i2d_ECDSA_SIG(sig, pp);
+}
 }  //::lib
 }  //::openssl
 }  //::mococrw

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -988,6 +988,26 @@ int OpenSSLLib::SSL_EVP_PKEY_derive(EVP_PKEY_CTX* ctx, unsigned char* key, size_
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_derive(ctx, key, keylen);
 }
+BIGNUM* OpenSSLLib::SSL_BN_bin2bn(const unsigned char* s, int len, BIGNUM*  ret) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_BN_bin2bn(s, len, ret);
+}
+ECDSA_SIG* OpenSSLLib::SSL_ECDSA_SIG_new() noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ECDSA_SIG_new();
+}
+void OpenSSLLib::SSL_ECDSA_SIG_free(ECDSA_SIG* sig) noexcept
+{
+    OpenSSLLibMockManager::getMockInterface().SSL_ECDSA_SIG_free(sig);
+}
+int OpenSSLLib::SSL_ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ECDSA_SIG_set0(sig, r, s);
+}
+int OpenSSLLib::SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char ** pp) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_i2d_ECDSA_SIG(sig, pp);
+}
 }  //::lib
 }  //::openssl
 }  //::mococrw

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -44,6 +44,11 @@ public:
     virtual void SSL_EC_KEY_free(EC_KEY* key) = 0;
     virtual EC_KEY* SSL_EC_KEY_new() = 0;
     virtual int SSL_EC_KEY_oct2key(EC_KEY* eckey, const unsigned char* buf, size_t len) = 0;
+    virtual int SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char ** pp) = 0;
+    virtual int SSL_ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s) = 0;
+    virtual void SSL_ECDSA_SIG_free(ECDSA_SIG* sig) = 0;
+    virtual ECDSA_SIG* SSL_ECDSA_SIG_new() = 0;
+    virtual BIGNUM* SSL_BN_bin2bn(const unsigned char* s, int len, BIGNUM*  ret) = 0;
     virtual void SSL_HMAC_CTX_free(HMAC_CTX* ctx) = 0;
     virtual HMAC_CTX* SSL_HMAC_CTX_new() = 0;
     virtual int SSL_HMAC_Final(HMAC_CTX* ctx, unsigned char* md, unsigned int* len) = 0;
@@ -333,6 +338,12 @@ public:
     MOCK_METHOD1(SSL_EC_KEY_free, void(EC_KEY*));
     MOCK_METHOD0(SSL_EC_KEY_new, EC_KEY*());
     MOCK_METHOD3(SSL_EC_KEY_oct2key, int(EC_KEY*, const unsigned char*, size_t));
+    MOCK_METHOD2(SSL_i2d_ECDSA_SIG, int(const ECDSA_SIG*, unsigned char **));
+    MOCK_METHOD3(SSL_ECDSA_SIG_set0, int(ECDSA_SIG*, BIGNUM*, BIGNUM*));
+    MOCK_METHOD1(SSL_ECDSA_SIG_set0, int(ECDSA_SIG*));
+    MOCK_METHOD1(SSL_ECDSA_SIG_free, void(ECDSA_SIG*));
+    MOCK_METHOD0(SSL_ECDSA_SIG_new, ECDSA_SIG*());
+    MOCK_METHOD3(SSL_BN_bin2bn, BIGNUM*(const unsigned char*, int, BIGNUM* ));
     MOCK_METHOD1(SSL_HMAC_CTX_free, void(HMAC_CTX*));
     MOCK_METHOD0(SSL_HMAC_CTX_new, HMAC_CTX*());
     MOCK_METHOD3(SSL_HMAC_Final, int(HMAC_CTX*, unsigned char*, unsigned int*));


### PR DESCRIPTION
ECDSA signatures are a tuple of two (larged) unsigned integers
(r,s). Most libraries and protocols encode ECDSA signature in
DER serialized ASN.1 of SEQUENCE (int r, int s). This is also
what the current verifyDigest() and verifyMessage() functions
in the ECDSASignaturePublicKeyCtx expect.

In addition to this format, there is also a serialization format
specified in IEEE 1363. This serializes (r,s) in the form
padToKeyLength(r) || padToKeyLength(s). As this is binary
incompatible, it can't be processed with the current verification
functions.

This patch adds the verifyDigestIEEE1363() and verifyMessageIEEE1363()
functions that take an ECDSA signature in IEEE 1363 serialized form,
then convert it into the format that OpenSSL expects and then uses the
already provided functionality to validate the signature.