### PR TITLE
Allow setting additional data for AEAD

### DIFF
--- a/src/mococrw/symmetric_crypto.h
+++ b/src/mococrw/symmetric_crypto.h
@@ -202,6 +202,18 @@ public:
      * @return the auth tag for this encryption operation
      */
     virtual std::vector<uint8_t> getAuthTag() const = 0;
+
+    /**
+     * Add associated data.
+     *
+     * This function adds the associated data in AEAD modes for authenticating while encrypting or verifying while
+     * decrypting. addAssociatedData() can be called multiple times but it must be called before finalizing decryption
+     * using SymmetricCipherI::finish() and before putting encrypted data to the message
+     * using SymmetricCipherI::update()
+     *
+     * @param associatedData chunk of data to associate/verify.
+     */
+    virtual void addAssociatedData(const std::vector<uint8_t> &associatedData) = 0;
 };
 
 class AESCipherBuilder;
@@ -253,6 +265,7 @@ public:
     // Implementation of AuthenticatedEncryptionI
     std::vector<uint8_t> getAuthTag() const override;
     void setAuthTag(const std::vector<uint8_t> &tag) override;
+    void addAssociatedData(const std::vector<uint8_t> &associatedData) override;
 
 private:
     friend AESCipherBuilder;

--- a/tests/unit/test_symmetric_crypto.cpp
+++ b/tests/unit/test_symmetric_crypto.cpp
@@ -504,8 +504,8 @@ TEST_F(SymmetricAuthenticatedCipherTest, throwsWhenCiphertextWasModified) {
     auto ciphertext = encryptor->finish();
     auto tag = encryptor->getAuthTag();
 
-    // flip a byte in authenticated ciphertext
-    ciphertext[4] ^= ciphertext[4];
+    // flip a bit in authenticated ciphertext
+    ciphertext[4] ^= 1;
 
     auto decryptor = AESCipherBuilder{SymmetricCipherMode::GCM,
                                       SymmetricCipherKeySize::S_256,
@@ -525,8 +525,8 @@ TEST_F(SymmetricAuthenticatedCipherTest, throwsWhenWrongTagIsUsed) {
     auto ciphertext = encryptor->finish();
     auto tag = encryptor->getAuthTag();
 
-    // flip a byte in the tag
-    tag[4] ^= tag[4];
+    // flip a bit in the tag
+    tag[4] ^= 1;
 
     auto decryptor = AESCipherBuilder{SymmetricCipherMode::GCM,
                                       SymmetricCipherKeySize::S_256,


### PR DESCRIPTION
Extend AuthenticatedAESCipher so it is possible to associate
additional data with the message.