### PR TITLE
ECDSA: Add support for IEEE1363 signature format for signing

### DIFF
--- a/src/mococrw/asymmetric_crypto_ctx.h
+++ b/src/mococrw/asymmetric_crypto_ctx.h
@@ -409,6 +409,24 @@ private:
 };
 
 /**
+ * @brief Serialization formats for ECDSA signatures
+ */
+enum class ECSDASignatureFormat {
+    ASN1_SEQUENCE_OF_INTS, /**< Encoding of (r,s) as ASN.1 sequence of integers as specified in ANSI X9.62 */
+    IEEE1363, /**< Encoding of (r,s) as raw big endian unsigned integers zero-padded to the key length
+               *   as specified in IEEE 1363 */
+};
+
+/**
+ * @brief Serialization formats for ECDSA signatures (correctly spelled)
+ */
+enum class ECDSASignatureFormat {
+    ASN1_SEQUENCE_OF_INTS, /**< Encoding of (r,s) as ASN.1 sequence of integers as specified in ANSI X9.62 */
+    IEEE1363, /**< Encoding of (r,s) as raw big endian unsigned integers zero-padded to the key length
+               *   as specified in IEEE 1363 */
+};
+
+/**
  * @brief ECDSASignaturePrivateKeyCtx
  *
  * This class supports signing messages and digests using ECDSA
@@ -458,14 +476,6 @@ private:
     std::unique_ptr<Impl> _impl;
 };
 
-/** @brief Serialization formats for ECDSA signatures
- */
-enum class ECSDASignatureFormat {
-    ASN1_SEQUENCE_OF_INTS, /**< Encoding of (r,s) as ASN.1 sequence of integers as specified in ANSI X9.62 */
-    IEEE1363, /**< Encoding of (r,s) as raw big endian unsigned integers zero-padded to the key length
-               *   as specified in IEEE 1363 */
-};
-
 /**
  * @brief ECDSASignaturePublicKeyCtx
  *
@@ -498,6 +508,17 @@ public:
     /**
      * @brief Constructor
      *
+     * @param key The public key to be used
+     * @param hashFunction The hash function to be used
+     * @param sigFormat The format that in which signatures are provided
+     * @throw MoCOCrWException If key is not an ECC public key
+     */
+    ECDSASignaturePublicKeyCtx(const AsymmetricPublicKey& key, openssl::DigestTypes hashFunction,
+                               ECDSASignatureFormat sigFormat);
+
+    /**
+     * @brief Constructor
+     *
      * @param cert The certificate containing the public key to be used
      * @param hashFunction The hash function to be used
      * @throw MoCOCrWException If cert doesn't contain an ECC public key
@@ -515,6 +536,18 @@ public:
      */
     ECDSASignaturePublicKeyCtx(const X509Certificate& cert, openssl::DigestTypes hashFunction,
                                ECSDASignatureFormat sigFormat);
+
+    /**
+     * @brief Constructor
+     *
+     * @param cert The certificate containing the public key to be used
+     * @param hashFunction The hash function to be used
+     * @param sigFormat The format that in which signatures are provided
+     * @throw MoCOCrWException If cert doesn't contain an ECC public key
+     */
+    ECDSASignaturePublicKeyCtx(const X509Certificate& cert, openssl::DigestTypes hashFunction,
+                               ECDSASignatureFormat sigFormat);
+
     /**
      * @brief Copy Constructor
      */

--- a/src/mococrw/asymmetric_crypto_ctx.h
+++ b/src/mococrw/asymmetric_crypto_ctx.h
@@ -409,7 +409,7 @@ private:
 };
 
 /**
- * @brief Serialization formats for ECDSA signatures
+ * @brief Serialization formats for ECDSA signatures (with typo)
  */
 enum class ECSDASignatureFormat {
     ASN1_SEQUENCE_OF_INTS, /**< Encoding of (r,s) as ASN.1 sequence of integers as specified in ANSI X9.62 */
@@ -418,7 +418,7 @@ enum class ECSDASignatureFormat {
 };
 
 /**
- * @brief Serialization formats for ECDSA signatures (correctly spelled)
+ * @brief Serialization formats for ECDSA signatures
  */
 enum class ECDSASignatureFormat {
     ASN1_SEQUENCE_OF_INTS, /**< Encoding of (r,s) as ASN.1 sequence of integers as specified in ANSI X9.62 */
@@ -443,6 +443,17 @@ public:
      */
     ECDSASignaturePrivateKeyCtx(const AsymmetricPrivateKey& key,
                                 openssl::DigestTypes hashFunction = openssl::DigestTypes::SHA256);
+
+    /**
+     * @brief Constructor
+     *
+     * @param key The private key to be used
+     * @param hashFunction The hash function to be used
+     * @param sigFormat The format of the generated signature
+     * @throw MoCOCrWException If key is not an ECC private key
+     */
+    ECDSASignaturePrivateKeyCtx(const AsymmetricPrivateKey& key, openssl::DigestTypes hashFunction,
+                                ECDSASignatureFormat sigFormat);
 
     /**
      * @brief Copy Constructor
@@ -502,6 +513,7 @@ public:
      * @param sigFormat The format that in which signatures are provided
      * @throw MoCOCrWException If key is not an ECC public key
      */
+    [[deprecated("Replaced by ECDSASignaturePublicKeyCtx() which expects ECDSASignatureFormat instead of ECSDASignatureFormat")]]
     ECDSASignaturePublicKeyCtx(const AsymmetricPublicKey& key, openssl::DigestTypes hashFunction,
                                ECSDASignatureFormat sigFormat);
 
@@ -534,6 +546,7 @@ public:
      * @param sigFormat The format that in which signatures are provided
      * @throw MoCOCrWException If cert doesn't contain an ECC public key
      */
+    [[deprecated("Replaced by ECDSASignaturePublicKeyCtx() which expects ECDSASignatureFormat instead of ECSDASignatureFormat")]]
     ECDSASignaturePublicKeyCtx(const X509Certificate& cert, openssl::DigestTypes hashFunction,
                                ECSDASignatureFormat sigFormat);
 

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -57,11 +57,15 @@ namespace lib
 class OpenSSLLib
 {
 public:
+    static ECDSA_SIG* SSL_d2i_ECDSA_SIG(ECDSA_SIG** sig, const unsigned char** pp, long len) noexcept;
     static int SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char ** pp) noexcept;
     static int SSL_ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s) noexcept;
+    static const BIGNUM* SSL_ECDSA_SIG_get0_s(const ECDSA_SIG* sig) noexcept;
+    static const BIGNUM* SSL_ECDSA_SIG_get0_r(const ECDSA_SIG* sig) noexcept;
     static void SSL_ECDSA_SIG_free(ECDSA_SIG* sig) noexcept;
     static ECDSA_SIG* SSL_ECDSA_SIG_new() noexcept;
     static BIGNUM* SSL_BN_bin2bn(const unsigned char* s, int len, BIGNUM*  ret) noexcept;
+    static int SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) noexcept;
     static int SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) noexcept;
     static X509_REQ* SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) noexcept;
     static int SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX * c, int pad) noexcept;

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -1397,9 +1397,9 @@ std::vector<uint8_t> _EVP_derive_key(const EVP_PKEY *peerkey, const EVP_PKEY *ke
 void _ECDSA_SIG_set0(ECDSA_SIG* sig, SSL_BIGNUM_Ptr r, SSL_BIGNUM_Ptr s);
 
 /**
- * Get the serialized ECSDA signature in ASN.1 format from ECSDA_SIG object
+ * Get the serialized ECDSA signature in ASN.1 format from ECDSA_SIG object
  */
-std::vector<uint8_t> _i2d_ECSDA_SIG(const ECDSA_SIG*);
+std::vector<uint8_t> _i2d_ECDSA_SIG(const ECDSA_SIG*);
 
 /* Bignum related */
 

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -1397,9 +1397,24 @@ std::vector<uint8_t> _EVP_derive_key(const EVP_PKEY *peerkey, const EVP_PKEY *ke
 void _ECDSA_SIG_set0(ECDSA_SIG* sig, SSL_BIGNUM_Ptr r, SSL_BIGNUM_Ptr s);
 
 /**
+ * Get the r signature component as bignum
+ */
+const BIGNUM* _ECDSA_SIG_get0_r(const ECDSA_SIG* sig);
+
+/**
+ * Get the s signature component as bignum
+ */
+const BIGNUM* _ECDSA_SIG_get0_s(const ECDSA_SIG* sig);
+
+/**
  * Get the serialized ECDSA signature in ASN.1 format from ECDSA_SIG object
  */
 std::vector<uint8_t> _i2d_ECDSA_SIG(const ECDSA_SIG*);
+
+/**
+ * Create ECDSA_SIG object from serialized ECDSA signature.
+ */
+SSL_ECDSA_SIG_Ptr _d2i_ECDSA_SIG(const std::vector<uint8_t>& signature);
 
 /* Bignum related */
 
@@ -1411,6 +1426,17 @@ std::vector<uint8_t> _i2d_ECDSA_SIG(const ECDSA_SIG*);
  * @throw OpenSSLException is a problem occurs during the conversion
  */
 SSL_BIGNUM_Ptr _BN_bin2bn(const uint8_t* data, size_t dataLen);
+
+/**
+ * Write an OpenSSL bignum in big-endian plain bytes representation of an
+ * unsigned integer. Returned vector will be padded if necessary.
+ *
+ * @param bignum Number to serialize
+ * @param tolen Length of the vector that will be returned
+ * @return Vector containing serialized number
+ * @throw OpenSSLException if tolen bytes cannot hold bignum
+ */
+std::vector<uint8_t> _BN_bn2binpad(const BIGNUM *bignum, int tolen);
 
 }  //::openssl
 }  //::mococrw

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -1008,6 +1008,22 @@ int OpenSSLLib::SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char ** pp) noe
 {
     return i2d_ECDSA_SIG(sig, pp);
 }
+ECDSA_SIG* OpenSSLLib::SSL_d2i_ECDSA_SIG(ECDSA_SIG** sig, const unsigned char** pp, long len) noexcept
+{
+    return d2i_ECDSA_SIG(sig, pp, len);
+}
+const BIGNUM* OpenSSLLib::SSL_ECDSA_SIG_get0_r(const ECDSA_SIG* sig) noexcept
+{
+    return ECDSA_SIG_get0_r(sig);
+}
+const BIGNUM* OpenSSLLib::SSL_ECDSA_SIG_get0_s(const ECDSA_SIG* sig) noexcept
+{
+    return ECDSA_SIG_get0_s(sig);
+}
+int OpenSSLLib::SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) noexcept
+{
+    return BN_bn2binpad(a, to, tolen);
+}
 }  //::lib
 }  //::openssl
 }  //::mococrw

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -1299,7 +1299,7 @@ void _ECDSA_SIG_set0(ECDSA_SIG* sig, SSL_BIGNUM_Ptr r, SSL_BIGNUM_Ptr s) {
     OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_ECDSA_SIG_set0, sig, r.release(), s.release());
 }
 
-std::vector<uint8_t> _i2d_ECSDA_SIG(const ECDSA_SIG *sig) {
+std::vector<uint8_t> _i2d_ECDSA_SIG(const ECDSA_SIG *sig) {
     OpenSSLGuardedOutputBuffer<unsigned char> outputBuffer;
     /**
      * The OpenSSL documentation for i2d_ECDSA_SIG is incomplete. As a parameter like unsigned char **pp
@@ -1311,10 +1311,10 @@ std::vector<uint8_t> _i2d_ECSDA_SIG(const ECDSA_SIG *sig) {
      */
     int result = lib::OpenSSLLib::SSL_i2d_ECDSA_SIG(sig, &outputBuffer.get());
     if (result <= 0) {
-        throw OpenSSLException("ECSDA Signature serialization to DER failed.");
+        throw OpenSSLException("ECDSA Signature serialization to DER failed.");
     } else {
         if (outputBuffer == nullptr) {
-            throw OpenSSLException("ECSDA Signature serialization to DER failed: Returned no data");
+            throw OpenSSLException("ECDSA Signature serialization to DER failed: Returned no data");
         }
         return std::vector<uint8_t>(outputBuffer.get(), outputBuffer.get() + result);
     }

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -1057,6 +1057,12 @@ SSL_BIGNUM_Ptr _BN_bin2bn(const uint8_t* data, size_t dataLen) {
     return SSL_BIGNUM_Ptr{OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_BN_bin2bn, data, static_cast<int>(dataLen), nullptr)};
 }
 
+std::vector<uint8_t> _BN_bn2binpad(const BIGNUM *bignum, int tolen) {
+    std::vector<uint8_t> out(tolen);
+    OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_BN_bn2binpad, bignum, out.data(), tolen);
+    return out;
+}
+
 uint64_t _X509_get_serialNumber(X509 *x)
 {
     auto serialNumber = OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_X509_get_serialNumber, x);
@@ -1299,6 +1305,14 @@ void _ECDSA_SIG_set0(ECDSA_SIG* sig, SSL_BIGNUM_Ptr r, SSL_BIGNUM_Ptr s) {
     OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_ECDSA_SIG_set0, sig, r.release(), s.release());
 }
 
+const BIGNUM* _ECDSA_SIG_get0_r(const ECDSA_SIG* sig) {
+    return OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_ECDSA_SIG_get0_r, sig);
+}
+
+const BIGNUM* _ECDSA_SIG_get0_s(const ECDSA_SIG* sig) {
+    return OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_ECDSA_SIG_get0_s, sig);
+}
+
 std::vector<uint8_t> _i2d_ECDSA_SIG(const ECDSA_SIG *sig) {
     OpenSSLGuardedOutputBuffer<unsigned char> outputBuffer;
     /**
@@ -1318,6 +1332,11 @@ std::vector<uint8_t> _i2d_ECDSA_SIG(const ECDSA_SIG *sig) {
         }
         return std::vector<uint8_t>(outputBuffer.get(), outputBuffer.get() + result);
     }
+}
+
+SSL_ECDSA_SIG_Ptr _d2i_ECDSA_SIG(const std::vector<uint8_t>& signature) {
+    const uint8_t* ptr = signature.data();
+    return SSL_ECDSA_SIG_Ptr{OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_d2i_ECDSA_SIG, nullptr, &ptr, signature.size())};
 }
 
 void _PKCS5_PBKDF2_HMAC(const std::vector<uint8_t> pass, const std::vector<uint8_t> salt, int iter,

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -1008,6 +1008,22 @@ int OpenSSLLib::SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char ** pp) noe
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_i2d_ECDSA_SIG(sig, pp);
 }
+ECDSA_SIG* OpenSSLLib::SSL_d2i_ECDSA_SIG(ECDSA_SIG** sig, const unsigned char** pp, long len) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_d2i_ECDSA_SIG(sig, pp, len);
+}
+const BIGNUM* OpenSSLLib::SSL_ECDSA_SIG_get0_r(const ECDSA_SIG* sig) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ECDSA_SIG_get0_r(sig);
+}
+const BIGNUM* OpenSSLLib::SSL_ECDSA_SIG_get0_s(const ECDSA_SIG* sig) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ECDSA_SIG_get0_s(sig);
+}
+int OpenSSLLib::SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_BN_bn2binpad(a, to, tolen);
+}
 }  //::lib
 }  //::openssl
 }  //::mococrw

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -35,6 +35,10 @@ namespace openssl
 class OpenSSLLibMockInterface
 {
 public:
+    virtual int SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) = 0;
+    virtual const BIGNUM* SSL_ECDSA_SIG_get0_s(const ECDSA_SIG* sig) = 0;
+    virtual const BIGNUM* SSL_ECDSA_SIG_get0_r(const ECDSA_SIG* sig) = 0;
+    virtual ECDSA_SIG* SSL_d2i_ECDSA_SIG(ECDSA_SIG** sig, const unsigned char** pp, long len) = 0;
     virtual int SSL_EVP_PKEY_derive(EVP_PKEY_CTX* ctx, unsigned char* key, size_t* keylen) = 0;
     virtual int SSL_EVP_PKEY_derive_set_peer(EVP_PKEY_CTX* ctx, EVP_PKEY* peer) = 0;
     virtual int SSL_EVP_PKEY_derive_init(EVP_PKEY_CTX* ctx) = 0;
@@ -329,6 +333,10 @@ public:
 class OpenSSLLibMock : public OpenSSLLibMockInterface
 {
 public:
+    MOCK_METHOD3(SSL_BN_bn2binpad, int(const BIGNUM*, unsigned char*, int));
+    MOCK_METHOD1(SSL_ECDSA_SIG_get0_s, const BIGNUM*(const ECDSA_SIG*));
+    MOCK_METHOD1(SSL_ECDSA_SIG_get0_r, const BIGNUM*(const ECDSA_SIG*));
+    MOCK_METHOD3(SSL_d2i_ECDSA_SIG, ECDSA_SIG*(ECDSA_SIG**, const unsigned char**, long));
     MOCK_METHOD3(SSL_EVP_PKEY_derive, int(EVP_PKEY_CTX*, unsigned char*, size_t*));
     MOCK_METHOD2(SSL_EVP_PKEY_derive_set_peer, int(EVP_PKEY_CTX*, EVP_PKEY*));
     MOCK_METHOD1(SSL_EVP_PKEY_derive_init, int(EVP_PKEY_CTX*));

--- a/tests/unit/test_signature.cpp
+++ b/tests/unit/test_signature.cpp
@@ -772,7 +772,7 @@ TEST_F(SignatureTest, testUnsuccessfulEccVerificationWithWrongPublicKey)
 TEST_F(SignatureTest, testSuccessfulEccVerificationInIEEE1363Format)
 {
     auto verifyCtx1 = ECDSASignaturePublicKeyCtx(_validEccPublicKey, DigestTypes::SHA1,
-                                                 ECSDASignatureFormat::IEEE1363);
+                                                 ECDSASignatureFormat::IEEE1363);
     ASSERT_NO_THROW(verifyCtx1.verifyDigest(_validEccIEEE1363SignatureSHA1,  _testMessageDigestSHA1));
 }
 
@@ -782,7 +782,7 @@ TEST_F(SignatureTest, testSuccessfulEccVerificationInIEEE1363Format)
 TEST_F(SignatureTest, testSuccessfulEccMessageVerificationInIEEE1363Format)
 {
     auto verifyCtx1 = ECDSASignaturePublicKeyCtx(_validEccPublicKey, DigestTypes::SHA1,
-                                                 ECSDASignatureFormat::IEEE1363);
+                                                 ECDSASignatureFormat::IEEE1363);
     ASSERT_NO_THROW(verifyCtx1.verifyMessage(_validEccIEEE1363SignatureSHA1,  signVerifyTestMessage));
 }
 
@@ -792,7 +792,7 @@ TEST_F(SignatureTest, testSuccessfulEccMessageVerificationInIEEE1363Format)
 TEST_F(SignatureTest, testfailedEccVerificationInIEEE1363FormatWhenRandSAreSwapped)
 {
     auto verifyCtx1 = ECDSASignaturePublicKeyCtx(_validEccPublicKey, DigestTypes::SHA1,
-                                                 ECSDASignatureFormat::IEEE1363);
+                                                 ECDSASignatureFormat::IEEE1363);
     ASSERT_THROW(verifyCtx1.verifyDigest(_eccIEEE1363SignatureSHA1SwappedInts,  signVerifyTestMessage), MoCOCrWException);
 }
 
@@ -802,7 +802,7 @@ TEST_F(SignatureTest, testfailedEccVerificationInIEEE1363FormatWhenRandSAreSwapp
 TEST_F(SignatureTest, testfailedEccMessageVerificationInIEEE1363FormatWhenRandSAreSwapped)
 {
     auto verifyCtx1 = ECDSASignaturePublicKeyCtx(_validEccPublicKey, DigestTypes::SHA1,
-                                                 ECSDASignatureFormat::IEEE1363);
+                                                 ECDSASignatureFormat::IEEE1363);
     ASSERT_THROW(verifyCtx1.verifyMessage(_eccIEEE1363SignatureSHA1SwappedInts,  _testMessageDigestSHA1), MoCOCrWException);
 }
 
@@ -815,7 +815,7 @@ TEST_F(SignatureTest, testfailedEccVerificationInIEEE1363FormatWhenSignatureTooS
     eccIEEE1363Signature.resize(eccIEEE1363Signature.size()-2);
 
     auto verifyCtx1 = ECDSASignaturePublicKeyCtx(_validEccPublicKey, DigestTypes::SHA1,
-                                                 ECSDASignatureFormat::IEEE1363);
+                                                 ECDSASignatureFormat::IEEE1363);
     ASSERT_THROW(verifyCtx1.verifyDigest(eccIEEE1363Signature,  _testMessageDigestSHA1), MoCOCrWException);
 }
 
@@ -829,7 +829,7 @@ TEST_F(SignatureTest, testfailedEccVerificationInIEEE1363FormatWhenSignatureTooL
     eccIEEE1363Signature.push_back(42);
 
     auto verifyCtx1 = ECDSASignaturePublicKeyCtx(_validEccPublicKey, DigestTypes::SHA1,
-                                                 ECSDASignatureFormat::IEEE1363);
+                                                 ECDSASignatureFormat::IEEE1363);
     ASSERT_THROW(verifyCtx1.verifyDigest(eccIEEE1363Signature,  _testMessageDigestSHA1), MoCOCrWException);
 }
 

--- a/tests/unit/test_signature.cpp
+++ b/tests/unit/test_signature.cpp
@@ -834,6 +834,38 @@ TEST_F(SignatureTest, testfailedEccVerificationInIEEE1363FormatWhenSignatureTooL
 }
 
 /**
+ * @brief Test that generated signature in IEEE1363 format can be verified successfully.
+ */
+TEST_F(SignatureTest, testSuccessfulEccMessageSigningAndVerificationInIEEE1363Format)
+{
+    auto signCtx1 = ECDSASignaturePrivateKeyCtx(_validEccPrivateKey, DigestTypes::SHA256,
+                                                ECDSASignatureFormat::IEEE1363);
+
+    auto signature = signCtx1.signMessage(signVerifyTestMessage);
+
+    auto verifyCtx1 = ECDSASignaturePublicKeyCtx(_validEccPublicKey, DigestTypes::SHA256,
+                                                 ECDSASignatureFormat::IEEE1363);
+    ASSERT_NO_THROW(verifyCtx1.verifyMessage(signature,  signVerifyTestMessage));
+}
+
+/**
+ * @brief Test that modified generated signature in IEEE1363 format fails verification.
+ */
+TEST_F(SignatureTest, testUnsuccessfulEccMessageSigningAndVerificationInIEEE1363Format)
+{
+    auto signCtx1 = ECDSASignaturePrivateKeyCtx(_validEccPrivateKey, DigestTypes::SHA256,
+                                                ECDSASignatureFormat::IEEE1363);
+
+    auto signature = signCtx1.signMessage(signVerifyTestMessage);
+
+    signature[0] ^= 1;
+
+    auto verifyCtx1 = ECDSASignaturePublicKeyCtx(_validEccPublicKey, DigestTypes::SHA256,
+                                                 ECDSASignatureFormat::IEEE1363);
+    ASSERT_THROW(verifyCtx1.verifyMessage(signature,  signVerifyTestMessage), MoCOCrWException);
+}
+
+/**
  * @brief Failed validation of IEEE 1363 encoded ECDSA signature with standard validation call
  */
 TEST_F(SignatureTest, testfailedEccVerificationInIEEE1363FormatWhenASN1Expected)


### PR DESCRIPTION
Up until now, the IEEE1363 signature format has only been supported
for verifying ECDSA signatures. This commit adds support for creating
ECDSA signatures in the IEEE1363 format.