### PR TITLE
Asymetric crypto pimpl clean up and clang-tidy corrections

### DIFF
--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -51,6 +51,7 @@ void OpenSSLLibMockManager::resetMock()
 void OpenSSLLibMockManager::destroy()
 {
     std::lock_guard<std::mutex> _lock(_mutex);
+    // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
     _mock.reset();
 }
 


### PR DESCRIPTION
The PIMPL pattern was not correctly applied to the asymmetry crypto
contexts. E.g. the pimpl classes were just used to hold the variables
but the actual implementation was outside of the pimpl class.

clang-tidy complains about a virtual function call during destruction in
the OpenSSLLibMock.
This patch adds an instruction for clang-tidy to ignore it.