### PR TITLE
Add missing parameter in AESCipherBuilder docs

### DIFF
--- a/src/mococrw/symmetric_crypto.h
+++ b/src/mococrw/symmetric_crypto.h
@@ -88,7 +88,7 @@ size_t getSymmetricCipherKeySize(SymmetricCipherKeySize keySize);
  *   auto iv = encryptor->getIV();
  *
  *   // Decryption
- *   auto decryptor = AESCipherBuilder{SymmetricCipherMode::CTR, secretKey}.setIV(iv).buildDecryptor();
+ *   auto decryptor = AESCipherBuilder{SymmetricCipherMode::CTR, SymmetricCipherKeySize::S_256, secretKey}.setIV(iv).buildDecryptor();
  *   decryptor->update(ciphertext);
  *   auto decryptedText = decryptor->finish();
  * @endcode
@@ -169,7 +169,7 @@ public:
  *   auto tag = encryptor->getAuthTag();
  *
  *   // Decryption
- *   auto decryptor = AESCipherBuilder{SymmetricCipherMode::GCM, secretKey}.setIV(iv).buildAuthenticatedDecryptor();
+ *   auto decryptor = AESCipherBuilder{SymmetricCipherMode::GCM, SymmetricCipherKeySize::S_256, secretKey}.setIV(iv).buildAuthenticatedDecryptor();
  *   decryptor->update(ciphertext);
  *   decryptor->setAuthTag(tag);
  *   std::vector<uint8_t> decryptedText;
@@ -279,7 +279,7 @@ private:
  * Factory for creating AES ciphers.
  *
  * @code
- * auto decryptor = AESCipherBuilder{SymmetricCipherMode::CTR, secretKey}.setIV(iv).buildDecryptor();
+ * auto decryptor = AESCipherBuilder{SymmetricCipherMode::CTR, SymmetricCipherKeySize::S_256, secretKey}.setIV(iv).buildDecryptor();
  * @endcode
  */
 class AESCipherBuilder


### PR DESCRIPTION
AESCipherBuilder takes three arguments, but only two were specified in some of the documentation comments. Add the key size parameter.

I figured since this doesn't affect API and only fixes a small oversight, it's not really worth writing a changelog entry.