### PR TITLE
symmetric: Avoid non-standard explicit_bzero(3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 # Unreleased
 
-N/A
+## Changed
+
+* Replace `explicit_bzero(3)` with `OPENSSL_cleanse(3)` to fix compilation on non-glibc systems. (see #75)
 
 # Release 3.0.0
 * Initial Release (starting at 3.0.0 to keep soversion in sync)

--- a/src/mococrw/util.h
+++ b/src/mococrw/util.h
@@ -42,7 +42,11 @@ std::vector<uint8_t> cryptoRandomBytes(size_t length);
 template<typename T>
 void vectorCleanse(std::vector<T> &vec)
 {
-    OPENSSL_cleanse(vec.data(), vec.size() * sizeof(T));
+    // Explicitly overwrite the memory, but check for size() > 0, since
+    // std::vector<T>::data() is allowed to return a nullptr if the size is 0.
+    if (vec.size() > 0) {
+        OPENSSL_cleanse(vec.data(), vec.size() * sizeof(T));
+    }
 }
 
 /**

--- a/src/symmetric_crypto.cpp
+++ b/src/symmetric_crypto.cpp
@@ -19,17 +19,15 @@
 
 #include "mococrw/symmetric_memory.h"
 
-// for explicit_bzero(3)
-#include <string.h>
-
 #include <string>
 #include <type_traits>
 
 #include <openssl/evp.h>
 
 #include "mococrw/error.h"
-#include "mococrw/symmetric_crypto.h"
 #include "mococrw/openssl_wrap.h"
+#include "mococrw/symmetric_crypto.h"
+#include "mococrw/util.h"
 
 namespace mococrw
 {
@@ -373,12 +371,7 @@ AESCipherBuilder::AESCipherBuilder(SymmetricCipherMode mode, SymmetricCipherKeyS
 
 AESCipherBuilder::~AESCipherBuilder()
 {
-    // Explicitly overwrite the key memory, but check for size() > 0, since
-    // std::vector<T>::data() is allowed to return a nullptr if the size is 0.
-    if (_secretKey.size() > 0) {
-        ::explicit_bzero(reinterpret_cast<void *>(_secretKey.data()),
-                         _secretKey.size() * sizeof(decltype(_secretKey)::value_type));
-    }
+    utility::vectorCleanse(_secretKey);
 }
 
 AESCipherBuilder &AESCipherBuilder::setIV(const std::vector<uint8_t> &iv)


### PR DESCRIPTION
`explicit_bzero(3)` is a glibc extension and may not be available, for example on systems using musl. We have a good alternative in `util::vectorCleanse()`, which uses `OPENSSL_cleanse(3)`, so use that instead.

See: #75