### PR TITLE
cmake: Expose mococrw/bio.h as public header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ## Added
 
 * Examples for KDF, MAC, ECIES and EdDSA, and updated existing examples and documentation
+* Expose `mococrw/bio.h` as public header to simplify interoperability with OpenSSL functions
 
 
 # Release 3.0.0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ set(LIBRARY_PUBLIC_HEADERS
     mococrw/asn1time.h
     mococrw/asymmetric_crypto_ctx.h
     mococrw/basic_constraints.h
+    mococrw/bio.h
     mococrw/ca.h
     mococrw/crl.h
     mococrw/csr.h
@@ -57,9 +58,8 @@ set(LIBRARY_PUBLIC_HEADERS
     mococrw/openssl_wrap.h
     mococrw/padding_mode.h
     mococrw/sign_params.h
-    mococrw/symmetric_crypto.h
     mococrw/subject_key_identifier.h
-    mococrw/util.h
+    mococrw/symmetric_crypto.h
     mococrw/util.h
     mococrw/x509.h
 )


### PR DESCRIPTION
This header is useful when mixing MoCOCrW code and OpenSSL calls, but is not currently available to users of MoCOCrW. Expose it as a public header to simplify calling OpenSSL functions.

Sort and deduplicate the list of headers while there.