### PR TITLE
symmetric: Handle empty IVs with AES-GCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 * Replace `explicit_bzero(3)` with `OPENSSL_cleanse(3)` to fix compilation on non-glibc systems. (see #75)
 * Replaced manual calculation of hash digest length by library function in ECIES
+* Improved error message when attempting to create an AES-GCM cipher with empty IV. (see #83)
 
 ## Fixed
 

--- a/src/symmetric_crypto.cpp
+++ b/src/symmetric_crypto.cpp
@@ -79,10 +79,10 @@ public:
 
         _EVP_CipherInit_ex(_ctx.get(),
                            evpCipherConstructor(),
-                                    nullptr,
-                                    nullptr,
-                                    nullptr,
-                                    this->_operation == Operation::Encryption);
+                           nullptr,
+                           nullptr,
+                           nullptr,
+                           this->_operation == Operation::Encryption);
 
         // Check id key size matches cipher block size
         size_t expectedKeySize = _EVP_CIPHER_CTX_key_length(_ctx.get());
@@ -96,7 +96,7 @@ public:
         switch (mode) {
             case SymmetricCipherMode::GCM: {
                 _EVP_CIPHER_CTX_ctrl(_ctx.get(), EVP_CTRL_GCM_SET_IVLEN, _iv.size(),
-                                              nullptr);
+                                     nullptr);
             } break;
             case SymmetricCipherMode::CTR:
                 //[[fallthrough]];

--- a/src/symmetric_crypto.cpp
+++ b/src/symmetric_crypto.cpp
@@ -95,6 +95,9 @@ public:
         // Check IV length and adjust if cipher supports it
         switch (mode) {
             case SymmetricCipherMode::GCM: {
+                if (_iv.size() == 0) {
+                    throw MoCOCrWException("IV is empty, but AES-GCM does not support empty IVs.");
+                }
                 _EVP_CIPHER_CTX_ctrl(_ctx.get(), EVP_CTRL_GCM_SET_IVLEN, _iv.size(),
                                      nullptr);
             } break;


### PR DESCRIPTION
OpenSSL does not support using an empty IV with AES-GCM, but the error message is most unhelpful. Improve this by checking for this situation and throwing a MoCOCrWException with a clearer message.

Closes: #83.