### PR TITLE
tests: Avoid random failure in AES-GCM test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 * Exception message in AESCipher (thrown if key has unexpected length)
 * Install target of documentation
+* Fix toggling stream cipher test when encrypting short messages
 
 ## Added
 

--- a/tests/unit/test_symmetric_crypto.cpp
+++ b/tests/unit/test_symmetric_crypto.cpp
@@ -166,8 +166,18 @@ TEST_P(SymmetricCipherTest, DoubleCreationUsesDifferentIVs)
     auto ciphertext1 = encryptor1->finish();
 
     if (ciphertext0.size() > 0 || ciphertext1.size() > 0) {
-        ASSERT_NE(ciphertext0, ciphertext1)
-            << "Two encryption operations with different IVs should return different ciphertexts.";
+        if ((operationMode != SymmetricCipherMode::GCM && operationMode != SymmetricCipherMode::CTR) || ciphertext0.size() > 1) {
+            /* Don't compare AES-GCM and AES-CTR encryptions with different IVs
+             * if the ciphertext is only 1 byte. Because GCM and CTR are stream
+             * ciphers, it does occasionally happen that two different IVs with
+             * two different keys yield the same byte in the ciphertext. With
+             * block ciphers, this is not a problem, because they always
+             * produce outputs in multiples of the block size, where
+             * a collision is statistically unlikely enough so that we can
+             * ignore it. */
+            ASSERT_NE(ciphertext0, ciphertext1)
+                << "Two encryption operations with different IVs should return different ciphertexts.";
+        }
     }
 }
 


### PR DESCRIPTION
Encrypting a one-byte plaintext with different IVs and keys using AES-GCM has a chance of (1/255)^2 to produce the same output byte, which occasionally causes this test to fail. This is not a problem for our block cipher tests, since they always produce outputs that have a length that's a multiple of the block size.

Since our test does encryption with 0-byte, 1-byte and 10-byte strings, filtering size() > 1 is enough to avoid this random failure.