### PR TITLE
Remove wrapper and mock for rsa_oaep_label getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## Changed
 
+* Remove wrapper `openssl::_EVP_PKEY_CTX_get_rsa_oaep_label`. This is
+  technically an ABI break, but since the wrappers are not considered part of
+  the public API, we do not bump the SOVERSION for this.
+
 ## Fixed
 
 ## Added

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -334,7 +334,6 @@ public:
                                     const unsigned char *in, size_t inlen) noexcept;
     static int SSL_EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept;
     static int SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l, int llen) noexcept;
-    static int SSL_EVP_PKEY_CTX_get_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l) noexcept;
     static int SSL_RSA_size(const RSA *r) noexcept;
     static int SSL_EVP_MD_size(const EVP_MD *md) noexcept;
     static int SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept;

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -1306,11 +1306,6 @@ void _EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 void _EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l, int llen);
 
 /**
- * Gets the OAEP label
- */
-int _EVP_PKEY_CTX_get_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l);
-
-/**
  * Returns the size of an RSA Key
  */
 int _RSA_size(const RSA *r);

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -774,11 +774,6 @@ int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned 
     return EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, l, llen);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_get_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l) noexcept
-{
-    return EVP_PKEY_CTX_get0_rsa_oaep_label(ctx, l);
-}
-
 int OpenSSLLib::SSL_RSA_size(const RSA *r) noexcept
 {
     return RSA_size(r);

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -1271,11 +1271,6 @@ void _EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l, int l
     OpensslCallIsNonNegative::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_label, ctx, l, llen);
 }
 
-int _EVP_PKEY_CTX_get_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l)
-{
-    return OpensslCallIsNonNegative::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_CTX_get_rsa_oaep_label, ctx, l);
-}
-
 int _RSA_size(const RSA *r)
 {
     return lib::OpenSSLLib::SSL_RSA_size(r);

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -833,10 +833,6 @@ int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned 
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_rsa_oaep_label(ctx,
                                                                                          l, llen);
 }
-int OpenSSLLib::SSL_EVP_PKEY_CTX_get_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l) noexcept
-{
-    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_get_rsa_oaep_label(ctx, l);
-}
 int OpenSSLLib::SSL_RSA_size(const RSA *r) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_RSA_size(r);

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -317,7 +317,6 @@ public:
     virtual int SSL_EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) = 0;
     virtual int SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l,
                                                     int llen) = 0;
-    virtual int SSL_EVP_PKEY_CTX_get_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l) = 0;
     virtual int SSL_RSA_size(const RSA *r) = 0;
     virtual int SSL_EVP_MD_size(const EVP_MD *md) = 0;
 
@@ -580,7 +579,6 @@ public:
     MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_oaep_md, int(EVP_PKEY_CTX *ctx, const EVP_MD *md));
     MOCK_METHOD3(SSL_EVP_PKEY_CTX_set_rsa_oaep_label, int(EVP_PKEY_CTX *ctx, unsigned char *l,
                                                           int llen));
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_get_rsa_oaep_label, int(EVP_PKEY_CTX *ctx, unsigned char *l));
     MOCK_METHOD1(SSL_RSA_size, int(const RSA *r));
     MOCK_METHOD1(SSL_EVP_MD_size, int(const EVP_MD *md));
     MOCK_METHOD1(SSL_EVP_PKEY_get0_EC_KEY, EC_KEY*(EVP_PKEY *pkey));


### PR DESCRIPTION
The way this function is called does not match the interface
offered by OpenSSL. It expects a pointer-pointer to unsigned char as
output argument, but we pass just a pointer. This probably went
unnoticed in the build due to SFINAE.

The wrappers for the function are not used anywhere in MoCOCrW, and are
also very unlikely to be needed by any of our users.