### PR TITLE
*PublicKeyCtx: Sig validation error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 * Remove wrapper `openssl::_EVP_PKEY_CTX_get_rsa_oaep_label`. This is
   technically an ABI break, but since the wrappers are not considered part of
   the public API, we do not bump the SOVERSION for this.
+* Improve error message in MoCOCrWException that is thrown in case of invalid
+  signature validation.
 
 ## Fixed
 

--- a/src/asymmetric_crypto_ctx.cpp
+++ b/src/asymmetric_crypto_ctx.cpp
@@ -372,7 +372,9 @@ namespace mococrw {
                                  messageDigest.size());
             }
             catch (const OpenSSLException &e) {
-                throw MoCOCrWException(e.what());
+                throw MoCOCrWException((boost::format{"Signature validation failed. "
+                                                      "OpenSSL info: %1%"}
+                                                    % e.what()).str());
             }
         }
 
@@ -597,7 +599,9 @@ namespace {
                                  messageDigest.size());
             }
             catch (const OpenSSLException &e) {
-                throw MoCOCrWException(e.what());
+                throw MoCOCrWException((boost::format{"Signature validation failed. "
+                                                      "OpenSSL info: %1%"}
+                                                    % e.what()).str());
             }
         }
     };
@@ -734,7 +738,9 @@ namespace {
                 _EVP_DigestVerify(mctx.get(), signature.data(), signature.size(), message.data(), message.size());
             }
             catch (const OpenSSLException &e) {
-                throw MoCOCrWException(e.what());
+                throw MoCOCrWException((boost::format{"Signature validation failed. "
+                                                      "OpenSSL info: %1%"}
+                                                    % e.what()).str());
             }
         }
     };


### PR DESCRIPTION
In case that a signature is invalid, we just forward to error
message of the OpenSSLException generation by _EVP_PKEY_verify
to the MoCOCrWException. As an invalid signature is not really
a failure of the OpenSSL call, the OpenSSLException error message
is just error:00000000:lib(0):func(0):reason(0): 0.
This is very confusing and gives no indication that it actually
was the signature validation that failed.

This patch amends the error message and adds the part that signature
validation failed to the what() message of the MoCOCrWException
that is thrown.

Change-Id: Ibbe3e001fa554af9462d18a952d893d121c0e252