### PR TITLE
Add support for AES-CMAC according to RFC 4493

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ## Added
 
+* Support for AES-CMAC with key lengths of 128 and 256 bit.
+
 # Release 4.0.0
 
 Multiple (self-contained) example programs have been added to illustrate the features of this

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The library provides end-user interfaces for:
  * ECIES Encryption (according to IEEE 1363a-2004)
  * PBKDF2 and X963KDF Key derivation
  * HMAC
+ * AES-CMAC (according to RFC 4493 for 128 and 256 bit keys)
  * AES Encryption (including GCM to support authenticated encryption with additional data)
  * SHA 1/2/3 Hashing
 

--- a/doc/examples/example_mac.md
+++ b/doc/examples/example_mac.md
@@ -59,3 +59,50 @@ catch (const MoCOCrWException &e)  {
     ...
 }
 ```
+
+# CMAC
+
+## CMAC Creation
+
+The following example shows how to create a CMAC. The key size needs to match the selected cipher, i.e. you need a key of
+128 bits for AES-128.
+
+```cpp
+std::vector<uint8_t> key = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+};
+std::vector<uint8_t> msg = {'m', 'e', 's', 's', 'a', 'g', 'e'};
+
+mococrw::CMAC cmac = mococrw::CMAC(openssl::CmacCipherTypes::AES_CBC_128, key);
+cmac.update(msg);
+std::vector<uint8_t> mac = cmac.finish();
+```
+
+## CMAC Verification
+
+The following example shows how a CMAC can be verified. Please note that `mococrw::CMAC::verify()` performs a constant time
+comparison on the given mac. Do NOT re-calculate the mac and compare it to the given mac yourself.
+
+```cpp
+std::vector<uint8_t> key = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+};
+std::vector<uint8_t> msg = {'m', 'e', 's', 's', 'a', 'g', 'e'};
+std::vector<uint8_t> mac = {
+    0x93, 0xff, 0x8a, 0x52, 0x5b, 0xa9, 0xb8, 0x7f,
+    0xe4, 0x65, 0xd4, 0x18, 0x08, 0x8f, 0x00, 0x0c
+};
+
+mococrw::CMAC cmac = mococrw::CMAC(openssl::CmacCipherTypes::AES_CBC_128, key);
+cmac.update(msg);
+
+try {
+    cmac.verify(mac); // throws if verification fails
+}
+catch (const MoCOCrWException &e)  {
+    std::cerr << "Verification failed" << std:endl;
+    ...
+}
+```

--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -90,7 +90,7 @@ public:
     }
 
 private:
-    openssl::SSL_HMAC_CTX_SharedPtr _ctx = nullptr;
+    openssl::SSL_HMAC_CTX_Ptr _ctx = nullptr;
     bool _isFinished = false;
     std::vector<uint8_t> _result;
 };
@@ -105,10 +105,7 @@ HMAC::~HMAC() = default;
 
 HMAC::HMAC(HMAC&& other) = default;
 
-HMAC& HMAC::operator=(HMAC&& other) {
-    this->_impl = std::move(other._impl);
-    return *this;
-}
+HMAC& HMAC::operator=(HMAC&& other) = default;
 
 void HMAC::update(const std::vector<uint8_t> &message)
 {

--- a/src/mococrw/mac.h
+++ b/src/mococrw/mac.h
@@ -25,8 +25,8 @@ namespace mococrw
 {
 
 /**
- * @brief The MessageAuthenticationCode class is the abstract base class for the different implementation of
- * message authentication codes.
+ * @brief The MessageAuthenticationCode class is the abstract base class for the different
+ * implementation of message authentication codes
  */
 class MessageAuthenticationCode {
 public:
@@ -37,21 +37,23 @@ public:
     virtual ~MessageAuthenticationCode();
 
     /**
-     * Adds the message to the hash. This function may be invoked multiple times.
+     * @brief Adds the message to the MAC
+     *
+     * This function may be invoked multiple times.
      * For finishing the calculation of the MAC invoke finish().
      *
-     * @param message chunk of data used for MAC.
-     * @throws MoCOCrWException if this function is invoked after finish was called.
+     * @param message chunk of data used for MAC
+     * @throws MoCOCrWException if this function is invoked after finish was called
      */
     virtual void update(const std::vector<uint8_t>& message) = 0;
 
     /**
-     * @brief Finalize the MAC.
+     * @brief Finalize the MAC
      *
      * This function calculates the message authentication code.
      *
-     * @throws MoCOCrWException if this function is invoked twice.
-     * @return The calculated message authentication code.
+     * @throws MoCOCrWException if this function is invoked twice
+     * @return The calculated message authentication code
      */
     virtual std::vector<uint8_t> finish() = 0;
 
@@ -63,7 +65,8 @@ public:
      * The length of the calculated value and the given value has to be the same!
      *
      * The comparison happens in constant time.
-     * @throws MoCOCrWException if the verification fails because the values or their lengths differ.
+     *
+     * @throws MoCOCrWException if the verification fails because the values or their lengths differ
      * @param macValue The value which shall be compared to the calculated value
      */
     virtual void verify(const std::vector<uint8_t> &macValue) = 0;
@@ -73,8 +76,8 @@ class HMAC : public MessageAuthenticationCode {
 public:
     /**
      * @brief Constructor
-     * @param hashFunction The hash function which shall be used
-     * @param key The key used for HMAC
+     * @param hashFunction the hash function which shall be used
+     * @param key the key used for HMAC
      */
     HMAC(mococrw::openssl::DigestTypes hashFunction, const std::vector<uint8_t> &key);
 
@@ -84,23 +87,25 @@ public:
     ~HMAC();
 
     /**
-     * Adds the chunk of data to the hash. H(i-key || message1 [ || message2])
+     * @brief Adds the chunk of data to the hash
+     *
+     * Calculation: H(i-key || message1 [ || message2])
      * For getting the HMAC invoke finish()
      *
-     * @param message chunk of data to used for HMAC.
-     * @throws MoCOCrWException if this function is invoked after finish was called.
+     * @param message chunk of data to used for HMAC
+     * @throws MoCOCrWException if this function is invoked after finish was called
      */
     void update(const std::vector<uint8_t>& message) override;
 
 
     /**
-     * @brief Finalize the HMAC.
+     * @brief Finalize the HMAC
      *
      * This function calculates the message authentication code.
      * H(o-key || H(i-key || message [ || message]))
      *
-     * @throws MoCOCrWException if this function is invoked twice.
-     * @return The hashed message authentication code
+     * @throws MoCOCrWException if this function is invoked twice
+     * @return the hashed message authentication code
      */
     std::vector<uint8_t> finish() override;
 
@@ -111,19 +116,19 @@ public:
 
     /**
      * @brief The move constructor
-     * @param other The other HMAC to be moved
+     * @param other the other HMAC to be moved
      */
     HMAC(HMAC &&other);
 
     /**
      * @brief The assignment operator
-     * @param other The other HMAC to be assigned
-     * @return The result of the assignment
+     * @param other the other HMAC to be assigned
+     * @return the result of the assignment
      */
     HMAC &operator=(HMAC &&other);
 
     /**
-     * @brief Delete the copy constructor.
+     * @brief Delete the copy constructor
      */
     HMAC(const HMAC &other) = delete;
 
@@ -134,13 +139,12 @@ public:
 
 private:
     /**
-     * Internal class for applying the PIMPL design pattern
-     * (to hide the details of storing the padding objects from the client)
+     * @brief Internal class for applying the PIMPL design pattern
      */
     class Impl;
 
     /**
-     * Pointer for PIMPL design pattern
+     * @brief Pointer for PIMPL design pattern
      */
     std::unique_ptr<Impl> _impl;
 };

--- a/src/mococrw/mac.h
+++ b/src/mococrw/mac.h
@@ -145,4 +145,81 @@ private:
     std::unique_ptr<Impl> _impl;
 };
 
+class CMAC : public MessageAuthenticationCode {
+public:
+    /**
+     * @brief Constructor
+     * @param cipherType the type of encryption function which shall be used
+     * @param key the key used for CMAC
+     * @throws MoCOCrWException if key size does not match cipherType
+     */
+    CMAC(mococrw::openssl::CmacCipherTypes cipherType, const std::vector<uint8_t> &key);
+
+    /**
+     * @brief destructor
+     */
+    ~CMAC();
+
+    /**
+     * @brief Add (another) chunk of data which should be included in calculation of CMAC
+     *
+     * This function may be invoked multiple times.
+     * Invoke finish() to get the final CMAC.
+     *
+     * @param message chunk of data to used for CMAC
+     * @throws MoCOCrWException if this function is invoked after finish was called
+     */
+    void update(const std::vector<uint8_t>& message) override;
+
+
+    /**
+     * @brief Finalize the CMAC
+     *
+     * This function returns the message authentication code.
+     *
+     * @throws MoCOCrWException if this function is invoked twice
+     * @return the calculated message authentication code
+     */
+    std::vector<uint8_t> finish() override;
+
+    /**
+     * @see MessageAuthenticationCode::verify
+     */
+    void verify(const std::vector<uint8_t> &cmacValue) override;
+
+    /**
+     * @brief The move constructor
+     * @param other The other CMAC to be moved
+     */
+    CMAC(CMAC &&other);
+
+    /**
+     * @brief The assignment move operator
+     * @param other the other CMAC to be assigned
+     * @return the result of the assignment
+     */
+    CMAC &operator=(CMAC &&other);
+
+    /**
+     * @brief Delete the copy constructor
+     */
+    CMAC(const CMAC &other) = delete;
+
+    /**
+     * @brief Delete the copy assignment
+     */
+    CMAC & operator=(const CMAC&) = delete;
+
+private:
+    /**
+     * @brief Internal class for applying the PIMPL design pattern
+     */
+    class Impl;
+
+    /**
+     * @brief Pointer for PIMPL design pattern
+     */
+    std::unique_ptr<Impl> _impl;
+};
+
 }

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -35,6 +35,7 @@ extern "C" {
 #include <openssl/x509v3.h>
 #include <openssl/ec.h>
 #include <openssl/rand.h>
+#include <openssl/cmac.h>
 }
 
 namespace mococrw
@@ -68,6 +69,8 @@ public:
     static int SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) noexcept;
     static int SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) noexcept;
     static X509_REQ* SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) noexcept;
+    static const char* SSL_EVP_CIPHER_name(const EVP_CIPHER* cipher) noexcept;
+    static int SSL_EVP_CIPHER_key_length(const EVP_CIPHER* cipher) noexcept;
     static int SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX * c, int pad) noexcept;
     static int SSL_EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX * c) noexcept;
     static int SSL_RAND_bytes(unsigned char * buf, int num) noexcept;
@@ -125,7 +128,10 @@ public:
     static void SSL_X509_EXTENSION_free(X509_EXTENSION* a) noexcept;
     static int SSL_X509_add_ext(X509* x, X509_EXTENSION* ex, int loc) noexcept;
     static X509_EXTENSION* SSL_X509V3_EXT_conf_nid(lhash_st_CONF_VALUE* conf, X509V3_CTX* ctx, int ext_nid, char* value) noexcept;
+
+    static const EVP_CIPHER* SSL_EVP_aes_128_cbc() noexcept;
     static const EVP_CIPHER* SSL_EVP_aes_256_cbc() noexcept;
+
     static int SSL_BIO_write(BIO* b, const void* buf, int len) noexcept;
     static int SSL_BIO_read(BIO* b, void* buf, int len) noexcept;
     static BIO* SSL_BIO_new_file(const char* filename, const char* mode) noexcept;
@@ -353,6 +359,17 @@ public:
     static int SSL_HMAC_Final(HMAC_CTX* ctx, unsigned char* md, unsigned int* len) noexcept;
     static int SSL_HMAC_Update(HMAC_CTX* ctx, const unsigned char* data, int len) noexcept;
     static int SSL_HMAC_Init_ex(HMAC_CTX* ctx, const void* key, int key_len, const EVP_MD* md, ENGINE* impl) noexcept;
+
+    /* CMAC */
+    static CMAC_CTX* SSL_CMAC_CTX_new() noexcept;
+    static void SSL_CMAC_CTX_cleanup(CMAC_CTX* ctx) noexcept;
+    static void SSL_CMAC_CTX_free(CMAC_CTX* ctx) noexcept;
+    static EVP_CIPHER_CTX* SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX* ctx) noexcept;
+    static int SSL_CMAC_CTX_copy(CMAC_CTX* out, const CMAC_CTX* in) noexcept;
+    static int SSL_CMAC_Init(CMAC_CTX* ctx, const void* key, size_t keylen, const EVP_CIPHER* cipher, ENGINE* impl) noexcept;
+    static int SSL_CMAC_Update(CMAC_CTX* ctx, const void* data, size_t dlen) noexcept;
+    static int SSL_CMAC_Final(CMAC_CTX* ctx, unsigned char* out, size_t* poutlen) noexcept;
+    static int SSL_CMAC_resume(CMAC_CTX* ctx) noexcept;
 
     /* EC Point import and export */
     static size_t SSL_EC_KEY_key2buf(const EC_KEY* eckey, point_conversion_form_t form, unsigned char** pbuf, BN_CTX* ctx) noexcept;

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -272,6 +272,11 @@ const EVP_MD* OpenSSLLib::SSL_EVP_sha3_384() noexcept { return EVP_sha3_384(); }
 
 const EVP_MD* OpenSSLLib::SSL_EVP_sha3_512() noexcept { return EVP_sha3_512(); }
 
+const EVP_CIPHER* OpenSSLLib::SSL_EVP_aes_128_cbc() noexcept { return EVP_aes_128_cbc(); }
+
+const EVP_CIPHER* OpenSSLLib::SSL_EVP_aes_256_cbc() noexcept { return EVP_aes_256_cbc(); }
+
+
 int OpenSSLLib::SSL_PEM_write_bio_PKCS8PrivateKey(BIO* bp,
                                                   EVP_PKEY* x,
                                                   const EVP_CIPHER* enc,
@@ -511,11 +516,6 @@ int OpenSSLLib::SSL_BIO_read(BIO* b, void* buf, int len) noexcept
 int OpenSSLLib::SSL_BIO_write(BIO* b, const void* buf, int len) noexcept
 {
     return BIO_write(b, buf, len);
-}
-
-const EVP_CIPHER* OpenSSLLib::SSL_EVP_aes_256_cbc() noexcept
-{
-    return EVP_aes_256_cbc();
 }
 
 X509_EXTENSION* OpenSSLLib::SSL_X509V3_EXT_conf_nid(lhash_st_CONF_VALUE* conf,
@@ -865,6 +865,15 @@ int OpenSSLLib::SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) noexcept
     return i2d_X509_REQ_bio(bp, req);
 }
 
+int OpenSSLLib::SSL_EVP_CIPHER_key_length(const EVP_CIPHER* cipher) noexcept
+{
+    return EVP_CIPHER_key_length(cipher);
+}
+const char* OpenSSLLib::SSL_EVP_CIPHER_name(const EVP_CIPHER* cipher) noexcept
+{
+    return EVP_CIPHER_name(cipher);
+}
+
 int OpenSSLLib::SSL_EVP_CipherUpdate(EVP_CIPHER_CTX* ctx,
                                      unsigned char* out,
                                      int* outl,
@@ -1029,6 +1038,45 @@ int OpenSSLLib::SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) 
 {
     return BN_bn2binpad(a, to, tolen);
 }
+
+/* CMAC */
+CMAC_CTX* OpenSSLLib::SSL_CMAC_CTX_new() noexcept
+{
+    return CMAC_CTX_new();
+}
+void OpenSSLLib::SSL_CMAC_CTX_cleanup(CMAC_CTX* ctx) noexcept
+{
+    CMAC_CTX_cleanup(ctx);
+}
+void OpenSSLLib::SSL_CMAC_CTX_free(CMAC_CTX* ctx) noexcept
+{
+    CMAC_CTX_free(ctx);
+}
+EVP_CIPHER_CTX* OpenSSLLib::SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX* ctx) noexcept
+{
+    return CMAC_CTX_get0_cipher_ctx(ctx);
+}
+int OpenSSLLib::SSL_CMAC_CTX_copy(CMAC_CTX* out, const CMAC_CTX* in) noexcept
+{
+    return CMAC_CTX_copy(out, in);
+}
+int OpenSSLLib::SSL_CMAC_Init(CMAC_CTX* ctx, const void* key, size_t keylen, const EVP_CIPHER* cipher, ENGINE* impl) noexcept
+{
+    return CMAC_Init(ctx, key, keylen, cipher, impl);
+}
+int OpenSSLLib::SSL_CMAC_Update(CMAC_CTX* ctx, const void* data, size_t dlen) noexcept
+{
+    return CMAC_Update(ctx, data, dlen);
+}
+int OpenSSLLib::SSL_CMAC_Final(CMAC_CTX* ctx, unsigned char* out, size_t* poutlen) noexcept
+{
+    return CMAC_Final(ctx, out, poutlen);
+}
+int OpenSSLLib::SSL_CMAC_resume(CMAC_CTX* ctx) noexcept
+{
+    return CMAC_resume(ctx);
+}
+
 }  //::lib
 }  //::openssl
 }  //::mococrw

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -28,6 +28,7 @@
 #include <cstddef> /* this has to come before cppc (bug in boost) */
 #include <exception>
 #include <limits>
+#include <cassert>
 
 #include <cppc/checkcall.hpp>
 
@@ -644,6 +645,12 @@ HMAC_CTX *createOpenSSLObject<HMAC_CTX>()
 }
 
 template<>
+CMAC_CTX *createOpenSSLObject<CMAC_CTX>()
+{
+    return OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_CMAC_CTX_new);
+}
+
+template<>
 ECDSA_SIG *createOpenSSLObject<ECDSA_SIG>()
 {
     return OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_ECDSA_SIG_new);
@@ -920,6 +927,16 @@ std::string _X509_NAME_ENTRY_get_data(X509_NAME_ENTRY *entry)
     BioObject bio{BioObject::Types::MEM};
     _ASN1_STRING_print_ex(bio.internal(), data);
     return bio.flushToString();
+}
+
+const std::string _EVP_CIPHER_name(const EVP_CIPHER *cipher)
+{
+    return std::string{lib::OpenSSLLib::SSL_EVP_CIPHER_name(cipher)};
+}
+
+int _EVP_CIPHER_key_length(const EVP_CIPHER *cipher)
+{
+    return lib::OpenSSLLib::SSL_EVP_CIPHER_key_length(cipher);
 }
 
 SSL_EVP_CIPHER_CTX_Ptr _EVP_CIPHER_CTX_new() {
@@ -1384,6 +1401,49 @@ void _HMAC_Update(HMAC_CTX *ctx, const std::vector<uint8_t> &data)
 SSL_HMAC_CTX_Ptr _HMAC_CTX_new()
 {
     return createManagedOpenSSLObject<SSL_HMAC_CTX_Ptr>();
+}
+
+SSL_CMAC_CTX_Ptr _CMAC_CTX_new(void)
+{
+    return createManagedOpenSSLObject<SSL_CMAC_CTX_Ptr>();
+}
+
+void _CMAC_Init(CMAC_CTX *ctx, const std::vector<uint8_t> &key, const EVP_CIPHER *cipher, ENGINE *impl)
+{
+    OpensslCallIsOne::callChecked(
+            lib::OpenSSLLib::SSL_CMAC_Init, ctx,
+            key.data(), key.size(),
+            cipher,
+            impl);
+}
+
+void _CMAC_Update(CMAC_CTX *ctx, const std::vector<uint8_t> &data)
+{
+    OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_CMAC_Update, ctx, data.data(), data.size());
+}
+
+std::vector<uint8_t> _CMAC_Final(CMAC_CTX *ctx)
+{
+    std::vector<uint8_t> cmac(EVP_MAX_BLOCK_LENGTH);
+    size_t length = 0;
+    OpensslCallIsOne::callChecked(
+            lib::OpenSSLLib::SSL_CMAC_Final, ctx,
+            cmac.data(), &length);
+    assert(length <= cmac.size());
+    cmac.resize(length);
+    return cmac;
+}
+
+const EVP_CIPHER* _getCipherPtrFromCmacCipherType(CmacCipherTypes cipherType)
+{
+    switch (cipherType) {
+        case CmacCipherTypes::AES_CBC_128:
+            return lib::OpenSSLLib::SSL_EVP_aes_128_cbc();
+        case CmacCipherTypes::AES_CBC_256:
+            return lib::OpenSSLLib::SSL_EVP_aes_256_cbc();
+        default:
+            throw std::runtime_error("Unknown cipher type");
+    }
 }
 
 SSL_EC_KEY_Ptr _EC_KEY_oct2key(int nid, const std::vector<uint8_t> &buf)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -112,10 +112,15 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
 	"${SRC_DIR}/kdf.cpp"
 	${REAL_SOURCES})
 
-    add_executable(mactests test_mac.cpp
-	"${SRC_DIR}/mac.cpp"
-	"${SRC_DIR}/hash.cpp"
-	${REAL_SOURCES})
+    add_executable(hmactests test_hmac.cpp
+    	"${SRC_DIR}/mac.cpp"
+    	"${SRC_DIR}/hash.cpp"
+    	${REAL_SOURCES})
+
+    add_executable(cmactests test_cmac.cpp
+    	"${SRC_DIR}/mac.cpp"
+    	"${SRC_DIR}/hash.cpp"
+    	${REAL_SOURCES})
 
     add_executable(eciestests test_ecies.cpp
 	"${SRC_DIR}/ecies.cpp"
@@ -167,7 +172,9 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
         ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}  Boost::boost)
     target_link_libraries(kdftests
 	${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
-    target_link_libraries(mactests
+    target_link_libraries(hmactests
+	${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
+    target_link_libraries(cmactests
 	${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
     target_link_libraries(eciestests
 	${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
@@ -254,8 +261,12 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
 	COMMAND kdftests
     )
     add_test(
-	NAME MacSchemesTest
-	COMMAND mactests
+        NAME HMacSchemesTest
+	COMMAND hmactests
+    )
+    add_test(
+        NAME CMacSchemesTest
+	COMMAND cmactests
     )
     add_test(
 	NAME EciesSchemesTest

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -589,6 +589,10 @@ int OpenSSLLib::SSL_BIO_write(BIO* b, const void* buf, int len) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BIO_write(b, buf, len);
 }
+const EVP_CIPHER* OpenSSLLib::SSL_EVP_aes_128_cbc() noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_aes_128_cbc();
+}
 const EVP_CIPHER* OpenSSLLib::SSL_EVP_aes_256_cbc() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_aes_256_cbc();
@@ -1029,6 +1033,53 @@ const BIGNUM* OpenSSLLib::SSL_ECDSA_SIG_get0_s(const ECDSA_SIG* sig) noexcept
 int OpenSSLLib::SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BN_bn2binpad(a, to, tolen);
+}
+
+/* CMAC */
+CMAC_CTX* OpenSSLLib::SSL_CMAC_CTX_new() noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_CTX_new();
+}
+void OpenSSLLib::SSL_CMAC_CTX_cleanup(CMAC_CTX* ctx) noexcept
+{
+    OpenSSLLibMockManager::getMockInterface().SSL_CMAC_CTX_cleanup(ctx);
+}
+void OpenSSLLib::SSL_CMAC_CTX_free(CMAC_CTX* ctx) noexcept
+{
+    OpenSSLLibMockManager::getMockInterface().SSL_CMAC_CTX_free(ctx);
+}
+EVP_CIPHER_CTX* OpenSSLLib::SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX* ctx) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_CTX_get0_cipher_ctx(ctx);
+}
+int OpenSSLLib::SSL_CMAC_CTX_copy(CMAC_CTX* out, const CMAC_CTX* in) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_CTX_copy(out, in);
+}
+int OpenSSLLib::SSL_CMAC_Init(CMAC_CTX* ctx, const void* key, size_t keylen, const EVP_CIPHER* cipher, ENGINE* impl) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_Init(ctx, key, keylen, cipher, impl);
+}
+int OpenSSLLib::SSL_CMAC_Update(CMAC_CTX* ctx, const void* data, size_t dlen) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_Update(ctx, data, dlen);
+}
+int OpenSSLLib::SSL_CMAC_Final(CMAC_CTX* ctx, unsigned char* out, size_t* poutlen) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_Final(ctx, out, poutlen);
+}
+int OpenSSLLib::SSL_CMAC_resume(CMAC_CTX* ctx) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_resume(ctx);
+}
+
+int OpenSSLLib::SSL_EVP_CIPHER_key_length(const EVP_CIPHER* cipher) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_key_length(cipher);
+}
+const char* OpenSSLLib::SSL_EVP_CIPHER_name(const EVP_CIPHER* cipher) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_name(cipher);
 }
 }  //::lib
 }  //::openssl

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -35,6 +35,8 @@ namespace openssl
 class OpenSSLLibMockInterface
 {
 public:
+    virtual const char* SSL_EVP_CIPHER_name(const EVP_CIPHER* cipher) = 0;
+    virtual int SSL_EVP_CIPHER_key_length(const EVP_CIPHER* cipher) = 0;
     virtual int SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) = 0;
     virtual const BIGNUM* SSL_ECDSA_SIG_get0_s(const ECDSA_SIG* sig) = 0;
     virtual const BIGNUM* SSL_ECDSA_SIG_get0_r(const ECDSA_SIG* sig) = 0;
@@ -116,6 +118,7 @@ public:
                                                     X509V3_CTX* ctx,
                                                     int ext_nid,
                                                     char* value) = 0;
+    virtual const EVP_CIPHER* SSL_EVP_aes_128_cbc() = 0;
     virtual const EVP_CIPHER* SSL_EVP_aes_256_cbc() = 0;
     virtual int SSL_BIO_write(BIO* b, const void* buf, int len) = 0;
     virtual int SSL_BIO_read(BIO* b, void* buf, int len) = 0;
@@ -325,6 +328,17 @@ public:
     virtual int SSL_PKCS5_PBKDF2_HMAC(const char *pass, int passlen, const unsigned char *salt, int saltlen, int iter,
                                      const EVP_MD *digest, int keylen, unsigned char *out) = 0;
 
+    /* CMAC */
+    virtual CMAC_CTX* SSL_CMAC_CTX_new() = 0;
+    virtual void SSL_CMAC_CTX_cleanup(CMAC_CTX* ctx) = 0;
+    virtual void SSL_CMAC_CTX_free(CMAC_CTX* ctx) = 0;
+    virtual EVP_CIPHER_CTX* SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX* ctx) = 0;
+    virtual int SSL_CMAC_CTX_copy(CMAC_CTX* out, const CMAC_CTX* in) = 0;
+    virtual int SSL_CMAC_Init(CMAC_CTX* ctx, const void* key, size_t keylen, const EVP_CIPHER* cipher, ENGINE* impl) = 0;
+    virtual int SSL_CMAC_Update(CMAC_CTX* ctx, const void* data, size_t dlen) = 0;
+    virtual int SSL_CMAC_Final(CMAC_CTX* ctx, unsigned char* out, size_t* poutlen) = 0;
+    virtual int SSL_CMAC_resume(CMAC_CTX* ctx) = 0;
+
 };
 
 /**
@@ -334,6 +348,8 @@ public:
 class OpenSSLLibMock : public OpenSSLLibMockInterface
 {
 public:
+    MOCK_METHOD1(SSL_EVP_CIPHER_name, const char*(const EVP_CIPHER*));
+    MOCK_METHOD1(SSL_EVP_CIPHER_key_length, int(const EVP_CIPHER*));
     MOCK_METHOD3(SSL_BN_bn2binpad, int(const BIGNUM*, unsigned char*, int));
     MOCK_METHOD1(SSL_ECDSA_SIG_get0_s, const BIGNUM*(const ECDSA_SIG*));
     MOCK_METHOD1(SSL_ECDSA_SIG_get0_r, const BIGNUM*(const ECDSA_SIG*));
@@ -419,6 +435,7 @@ public:
                                                           X509V3_CTX*,
                                                           int,
                                                           char*));
+    MOCK_METHOD0(SSL_EVP_aes_128_cbc, const EVP_CIPHER*());
     MOCK_METHOD0(SSL_EVP_aes_256_cbc, const EVP_CIPHER*());
     MOCK_METHOD3(SSL_BIO_write, int(BIO*, const void*, int));
     MOCK_METHOD3(SSL_BIO_read, int(BIO*, void*, int));
@@ -588,6 +605,18 @@ public:
                                             int iter,const EVP_MD *digest, int keylen, unsigned char *out));
     MOCK_METHOD7(SSL_ECDH_KDF_X9_63, int(unsigned char *out, size_t outlen, const unsigned char *Z, size_t Zlen,
                                      const unsigned char *sinfo, size_t sinfolen, const EVP_MD *md));
+
+    /* CMAC */
+    MOCK_METHOD0(SSL_CMAC_CTX_new, CMAC_CTX*());
+    MOCK_METHOD1(SSL_CMAC_CTX_cleanup, void(CMAC_CTX*));
+    MOCK_METHOD1(SSL_CMAC_CTX_free, void(CMAC_CTX*));
+    MOCK_METHOD1(SSL_CMAC_CTX_get0_cipher_ctx, EVP_CIPHER_CTX*(CMAC_CTX*));
+    MOCK_METHOD2(SSL_CMAC_CTX_copy, int(CMAC_CTX*, const CMAC_CTX*));
+    MOCK_METHOD5(SSL_CMAC_Init, int(CMAC_CTX*, const void*, size_t, const EVP_CIPHER*, ENGINE*));
+    MOCK_METHOD3(SSL_CMAC_Update, int(CMAC_CTX*, const void*, size_t));
+    MOCK_METHOD3(SSL_CMAC_Final, int(CMAC_CTX*, unsigned char*, size_t*));
+    MOCK_METHOD1(SSL_CMAC_resume, int(CMAC_CTX*));
+
 };
 
 /**

--- a/tests/unit/test_cmac.cpp
+++ b/tests/unit/test_cmac.cpp
@@ -1,0 +1,247 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2020 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "util.cpp"
+
+#include "mococrw/mac.h"
+
+using namespace mococrw;
+
+using testing::Eq;
+
+
+TEST(CheckConstructor, FailsForInvalidKey)
+{
+    std::vector<uint8_t> invalidKey{1, 2, 3};
+    auto someCipher = openssl::CmacCipherTypes::AES_CBC_256;
+
+    EXPECT_THROW(
+            CMAC(someCipher, invalidKey),
+            MoCOCrWException);
+}
+
+TEST(CheckConstructor, WorksWithValidCipherAndMatchingKey)
+{
+    std::vector<uint8_t> someKey(16);
+    auto someCipher = openssl::CmacCipherTypes::AES_CBC_128;
+
+    CMAC(someCipher, someKey);
+}
+
+
+struct Testdata
+{
+    openssl::CmacCipherTypes cipherType;
+    std::string key;
+    std::string message;
+    std::string expectedCmac;
+};
+
+static std::vector<Testdata> prepareTestdataForCmacTests()
+{
+    std::vector<Testdata> testdata {
+        {
+            // Test data for AES-128 is taken from https://tools.ietf.org/html/rfc4493.
+            {
+                openssl::CmacCipherTypes::AES_CBC_128,
+                "2b7e151628aed2a6abf7158809cf4f3c",
+                "",
+                "bb1d6929e95937287fa37d129b756746",
+            },
+            {
+                openssl::CmacCipherTypes::AES_CBC_128,
+                "2b7e151628aed2a6abf7158809cf4f3c",
+                "6bc1bee22e409f96e93d7e117393172a",
+                "070a16b46b4d4144f79bdd9dd04a287c",
+            },
+            {
+                openssl::CmacCipherTypes::AES_CBC_128,
+                "2b7e151628aed2a6abf7158809cf4f3c",
+                "6bc1bee22e409f96e93d7e117393172a"
+                    "ae2d8a571e03ac9c9eb76fac45af8e51"
+                    "30c81c46a35ce411",
+                "dfa66747de9ae63030ca32611497c827",
+            },
+            {
+                openssl::CmacCipherTypes::AES_CBC_128,
+                "2b7e151628aed2a6abf7158809cf4f3c",
+                "6bc1bee22e409f96e93d7e117393172a"
+                    "ae2d8a571e03ac9c9eb76fac45af8e51"
+                    "30c81c46a35ce411e5fbc1191a0a52ef"
+                    "f69f2445df4f9b17ad2b417be66c3710",
+                "51f0bebf7e3b9d92fc49741779363cfe",
+            },
+
+            // Test data for AES-256.
+            {
+                openssl::CmacCipherTypes::AES_CBC_256,
+                "2b7e151628aed2a6abf7158809cf4f3c"
+                    "deadbeef38317deafbeef3831700cafe",
+                "",
+                "9922123e226ee972e5fd501e45cae51d",
+            },
+            {
+                openssl::CmacCipherTypes::AES_CBC_256,
+                "2b7e151628aed2a6abf7158809cf4f3c"
+                    "deadbeef38317deafbeef3831700cafe",
+                "6bc1bee22e409f96e93d7e117393172a",
+                "9414636aa65c795a59e8813e2fbb588a",
+            },
+            {
+                openssl::CmacCipherTypes::AES_CBC_256,
+                "2b7e151628aed2a6abf7158809cf4f3c"
+                    "deadbeef38317deafbeef3831700cafe",
+                "6bc1bee22e409f96e93d7e117393172a"
+                    "ae2d8a571e03ac9c9eb76fac45af8e51"
+                    "30c81c46a35ce411",
+                "bf20027ad24e648f88d7cf0d2eb03f93",
+            },
+            {
+                openssl::CmacCipherTypes::AES_CBC_256,
+                "2b7e151628aed2a6abf7158809cf4f3c"
+                    "deadbeef38317deafbeef3831700cafe",
+                "6bc1bee22e409f96e93d7e117393172a"
+                    "ae2d8a571e03ac9c9eb76fac45af8e51"
+                    "30c81c46a35ce411e5fbc1191a0a52ef"
+                    "f69f2445df4f9b17ad2b417be66c3710",
+                "3598968688288d17a2f5544cef0651ea",
+            },
+        }
+    };
+
+    return testdata;
+}
+
+class CalculateCmacValues : public testing::TestWithParam<Testdata> {};
+
+INSTANTIATE_TEST_CASE_P(
+        cmac,
+        CalculateCmacValues,
+        testing::ValuesIn(prepareTestdataForCmacTests()));
+
+TEST_P(CalculateCmacValues, returnsCorrectCmac)
+{
+    auto testdata = GetParam();
+
+    auto cmacCalculator = CMAC(testdata.cipherType, utility::fromHex(testdata.key));
+    cmacCalculator.update(utility::fromHex(testdata.message));
+    auto actualCmac = cmacCalculator.finish();
+
+    ASSERT_THAT(utility::toHex(actualCmac), Eq(testdata.expectedCmac));
+}
+
+TEST_P(CalculateCmacValues, verifyIsSuccessfulForCorrectCmac)
+{
+    auto testdata = GetParam();
+
+    auto cmacCalculator = CMAC(testdata.cipherType, utility::fromHex(testdata.key));
+    cmacCalculator.update(utility::fromHex(testdata.message));
+    cmacCalculator.finish();
+
+    auto expectedCmac = utility::fromHex(testdata.expectedCmac);
+    cmacCalculator.verify(expectedCmac);
+}
+
+TEST_P(CalculateCmacValues, verifyFailsForIncorrectCmac)
+{
+    auto testdata = GetParam();
+
+    auto cmacCalculator = CMAC(testdata.cipherType, utility::fromHex(testdata.key));
+    cmacCalculator.update(utility::fromHex(testdata.message));
+    cmacCalculator.finish();
+
+    auto incorrectCmac = utility::fromHex(testdata.expectedCmac);
+    incorrectCmac[0] ^= 0x01;
+    EXPECT_THROW(cmacCalculator.verify(incorrectCmac), MoCOCrWException);
+}
+
+
+TEST(CheckControlFlow, UpdateCanBeInvokedMultipleTimes)
+{
+    auto testdata = prepareTestdataForCmacTests().at(0);
+    auto cmacCalculator = CMAC(testdata.cipherType, utility::fromHex(testdata.key));
+
+    cmacCalculator.update(utility::fromHex(testdata.message));
+    cmacCalculator.update(utility::fromHex(testdata.message));
+}
+
+TEST(CheckControlFlow, VerifyCanBeInvokedMultipleTimes)
+{
+    auto testdata = prepareTestdataForCmacTests().at(0);
+    auto cmacCalculator = CMAC(testdata.cipherType, utility::fromHex(testdata.key));
+    cmacCalculator.update(utility::fromHex(testdata.message));
+    cmacCalculator.verify(utility::fromHex(testdata.expectedCmac));
+
+    cmacCalculator.verify(utility::fromHex(testdata.expectedCmac));
+}
+
+
+TEST(CheckControlFlow, VerifyInvokesFinishImplicitly)
+{
+    auto testdata = prepareTestdataForCmacTests().at(0);
+    auto cmacCalculator = CMAC(testdata.cipherType, utility::fromHex(testdata.key));
+    cmacCalculator.update(utility::fromHex(testdata.message));
+    cmacCalculator.verify(utility::fromHex(testdata.expectedCmac));
+
+    ASSERT_THROW(cmacCalculator.finish(), MoCOCrWException);
+}
+
+TEST(CheckControlFlow, UpdateFailesAfterFinish)
+{
+    auto testdata = prepareTestdataForCmacTests().at(0);
+    auto cmacCalculator = CMAC(testdata.cipherType, utility::fromHex(testdata.key));
+    cmacCalculator.update(utility::fromHex(testdata.message));
+    cmacCalculator.finish();
+
+    ASSERT_THROW(cmacCalculator.update(utility::fromHex(testdata.message)), MoCOCrWException);
+}
+
+
+class VerifyCmac : public testing::Test
+{
+protected:
+    CMAC getCmacCalculator()
+    {
+        auto cmacCalculator = CMAC(testdata.cipherType, utility::fromHex(testdata.key));
+        cmacCalculator.update(utility::fromHex(testdata.message));
+        cmacCalculator.finish();
+        return cmacCalculator;
+    }
+
+    Testdata testdata = prepareTestdataForCmacTests().at(0);
+};
+
+TEST_F(VerifyCmac, FailsForTooShortCmac) {
+    auto cmacCalculator = getCmacCalculator();
+    auto tooShortCmac = utility::fromHex(testdata.expectedCmac);
+    tooShortCmac.resize(tooShortCmac.size() - 2);
+
+    EXPECT_THROW(cmacCalculator.verify(tooShortCmac), MoCOCrWException);
+}
+
+TEST_F(VerifyCmac, FailsForTooLongCmac)
+{
+    auto cmacCalculator = getCmacCalculator();
+    auto tooLongCmac = utility::fromHex(testdata.expectedCmac);
+    tooLongCmac.push_back(5);
+
+    EXPECT_THROW(cmacCalculator.verify(tooLongCmac), MoCOCrWException);
+}

--- a/tests/unit/test_hmac.cpp
+++ b/tests/unit/test_hmac.cpp
@@ -42,7 +42,7 @@ struct inputData
 
 void testHmacSha(openssl::DigestTypes hashFunction, inputData testData, std::string expectedResult)
 {
-    /* Calculate the MAC */
+    /* Calculate the HMAC */
     auto hmac = mococrw::HMAC(hashFunction, utility::fromHex(testData.key));
     hmac.update(utility::fromHex(testData.data));
     auto result = hmac.finish();


### PR DESCRIPTION
This extends the existing generic `MessageAuthenticationCode` interface
with a second implementation besides HMAC. Given that the existing
naming suggests it this way, both implementations reside in `mac.cpp`
for now, but could be separated in future work.

The public interfaces are only extended, i.e. this change retains
API/ABI compatibility.