### PR TITLE
Make find_library for ASan work on Ubuntu 20.04

### DIFF
--- a/cmake/AddressSanitizerTarget.cmake
+++ b/cmake/AddressSanitizerTarget.cmake
@@ -95,7 +95,7 @@ mark_as_advanced(
 unset(_ASAN_FLAGS)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-    find_library(ASAN_LIBRARY asan)
+    find_library(ASAN_LIBRARY NAMES asan libasan.so.6 libasan.so.5)
 
     set(ASAN_FIND_REQUIRED TRUE)
     include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
This plain find_library(ASAN_LIBRARY asan) somehow fails to find libasan
on Ubuntu 20.04 (and likely other Debian-based systems). Mentioning
libasan.so.5 as a library file name candidate fixes this. libasan.so.6
is there for future-compatibility.