### PR TITLE
Do not rely on global openssl.cnf in CSR test

### DIFF
--- a/tests/unit/test_csr.cpp
+++ b/tests/unit/test_csr.cpp
@@ -265,7 +265,7 @@ TEST_P(CSRTest, testCsrSignatureDigest)
         of << csr.toPEM();
         of.close();
 
-        std::string openSSLCmdline = "openssl req -in "s + _pemFile + " -noout -text";
+        std::string openSSLCmdline = "openssl req -config /dev/null -in "s + _pemFile + " -noout -text";
         auto output = exec(openSSLCmdline.c_str());
 
         auto sigAlgoPos = output.find("Signature Algorithm:");


### PR DESCRIPTION
This invocation of the openssl tool tries to load the global
configuration file by default. Having the test be influenced by this
external artifact is not ideal. More importantly, it also fails if the
file does not exist. Removing this dependency will allow us to use the
much smaller "install_sw" target (no docs, no config) when adding
OpenSSL to the build container.