### PR TITLE
Prepare release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,22 @@ All notable changes to this project will be documented in this file.
 
 ## Changed
 
+## Fixed
+
+## Added
+
+# Release 4.1.0
+
+Support for AES-CMAC has been added (see `mac-example.cpp` for sample usage),
+as well as some minor changes listed below.
+
+## Changed
+
 * Remove wrapper `openssl::_EVP_PKEY_CTX_get_rsa_oaep_label`. This is
   technically an ABI break, but since the wrappers are not considered part of
   the public API, we do not bump the SOVERSION for this.
 * Improve error message in MoCOCrWException that is thrown in case of invalid
   signature validation.
-
-## Fixed
 
 ## Added
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,16 +14,16 @@ to versioning scheme described below.
 ### PR Checklist
 
 What should be done with every PR (if no new release is created):
-* [CHANGELOG](./CHANGELOG) is updated with the summary of the change (Unreleased section)
-* If your change is going to break ABI (at the next release) please also put that into the [CHANGELOG](./CHANGELOG)
+* [CHANGELOG](./CHANGELOG.md) is updated with the summary of the change (Unreleased section)
+* If your change is going to break ABI (at the next release) please also put that into the [CHANGELOG](./CHANGELOG.md)
 * CI testing against project specific CI systems
 
 ### Releasing Checklist
 
 Check if the following steps have been performed **before** creating a new release. This includes
 all kinds of releases (Major, Minor and Patch releases)
-* [REAMDE](./README) is updated if necessary
-* [CHANGELOG](./CHANGELOG) is updated (add the new release)
+* [README](./README.md) is updated if necessary
+* [CHANGELOG](./CHANGELOG.md) is updated (add the new release)
 * Library soversion is increased in [src/CMakeLists.txt](src/CMakeLists.txt#L5) (major release only)
 
 If all the steps above have been done you are good to go and create a new release:


### PR DESCRIPTION
This is a minor release, so the SOVERSION remains unchanged.

While at it, this fixes some invalid links in the release guidelines.