### PR TITLE
Fix CA problems with DistinguishedName order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ## Fixed
 
+* CertificateAuthority now copies the subject of the CA directly into the
+  issuer field of the issued certificate. This resolves problems around
+  different orders of items in the underlying distinguished name. This fixes
+  issue #95. The DistinguishedName object is still not order-aware when loading
+  a DN from OpenSSL. This is to be fixed in a later step.
+
 ## Added
 
 # Release 4.1.0

--- a/src/mococrw/csr.h
+++ b/src/mococrw/csr.h
@@ -102,6 +102,16 @@ public:
      * @throw MoCOCrWException if the verification fails.
      */
     void verify() const;
+    
+    /**
+     * Get the internal openssl x509_req instance.
+     *
+     * This method can be used when interaction with
+     * OpenSSL's native methods is necessary for some
+     * reason.
+     */
+    const X509_REQ *internal() const { return _req.get(); }
+    X509_REQ *internal() { return _req.get(); }
 
 private:
     CertificateSigningRequest(openssl::SSL_X509_REQ_Ptr req);

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -230,7 +230,7 @@ public:
     static int SSL_X509_REQ_set_subject_name(X509_REQ* req, X509_NAME* name) noexcept;
     static void SSL_X509_REQ_free(X509_REQ* ptr) noexcept;
     static X509_REQ* SSL_X509_REQ_new() noexcept;
-    static X509_NAME* SSL_X509_REQ_get_subject_name(X509_REQ* req) noexcept;
+    static X509_NAME* SSL_X509_REQ_get_subject_name(const X509_REQ* req) noexcept;
     static EVP_PKEY* SSL_X509_REQ_get_pubkey(X509_REQ *req) noexcept;
     static int SSL_X509_REQ_verify(X509_REQ *a, EVP_PKEY *r) noexcept;
     static const EVP_MD* SSL_EVP_sha1() noexcept;

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -444,7 +444,7 @@ void _X509_REQ_set_version(X509_REQ* req, unsigned long version);
  *
  * NOTE this result *MUST NOT BE FREED*.
  */
-X509_NAME* _X509_REQ_get_subject_name(X509_REQ* req);
+X509_NAME* _X509_REQ_get_subject_name(const X509_REQ* req);
 
 /**
  * Get the public key for the given X509_REQ object.

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -192,7 +192,7 @@ int OpenSSLLib::SSL_X509_REQ_set_version(X509_REQ* req, unsigned long version) n
     return X509_REQ_set_version(req, version);
 }
 
-X509_NAME* OpenSSLLib::SSL_X509_REQ_get_subject_name(X509_REQ *req) noexcept
+X509_NAME* OpenSSLLib::SSL_X509_REQ_get_subject_name(const X509_REQ *req) noexcept
 {
     return X509_REQ_get_subject_name(req);
 }

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -333,7 +333,7 @@ void _X509_REQ_set_version(X509_REQ* req, unsigned long version)
     OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_X509_REQ_set_version, req, version);
 }
 
-X509_NAME* _X509_REQ_get_subject_name(X509_REQ *req)
+X509_NAME* _X509_REQ_get_subject_name(const X509_REQ *req)
 {
     return OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_X509_REQ_get_subject_name, req);
 }

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -91,7 +91,7 @@ X509_REQ* OpenSSLLib::SSL_X509_REQ_new() noexcept
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_new();
 }
 
-X509_NAME* OpenSSLLib::SSL_X509_REQ_get_subject_name(X509_REQ* req) noexcept
+X509_NAME* OpenSSLLib::SSL_X509_REQ_get_subject_name(const X509_REQ* req) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_get_subject_name(req);
 }

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -185,7 +185,7 @@ public:
     virtual int SSL_X509_REQ_set_pubkey(X509_REQ* x, EVP_PKEY* pkey) = 0;
     virtual int SSL_X509_REQ_set_version(X509_REQ* req, unsigned long version) = 0;
     virtual int SSL_X509_REQ_sign_ctx(X509_REQ*, EVP_MD_CTX*) = 0;
-    virtual X509_NAME* SSL_X509_REQ_get_subject_name(X509_REQ* req) = 0;
+    virtual X509_NAME* SSL_X509_REQ_get_subject_name(const X509_REQ* req) = 0;
     virtual EVP_PKEY* SSL_X509_REQ_get_pubkey(X509_REQ *req) = 0;
     virtual int SSL_X509_REQ_verify(X509_REQ *a, EVP_PKEY *r) = 0;
 
@@ -446,7 +446,7 @@ public:
 
     MOCK_METHOD1(SSL_X509_REQ_free, void(X509_REQ*));
     MOCK_METHOD0(SSL_X509_REQ_new, X509_REQ*());
-    MOCK_METHOD1(SSL_X509_REQ_get_subject_name, X509_NAME*(X509_REQ* req));
+    MOCK_METHOD1(SSL_X509_REQ_get_subject_name, X509_NAME*(const X509_REQ* req));
     MOCK_METHOD1(SSL_X509_REQ_get_pubkey, EVP_PKEY*(X509_REQ* req));
     MOCK_METHOD2(SSL_X509_REQ_verify, int(X509_REQ *a, EVP_PKEY *r));
 


### PR DESCRIPTION
The CertificateAuthority functionality in MoCoCrW has the
problem that distinguished names are defined as ordered in
the standard but this is not reflected in the DistinguishedName
objects in the library.
This lead to the problem that the CertificateAuthority objects
can't issue certificates with a CA certificate that uses a different
attribute order in the subject than the libraries default order.

This patch fixes the issue by directly copying the CAs subject
and the subject in the CSRs directly into the issuer and subject
fields of the newly issued certificate.

This fixes #95.

On the way, improve one the const correctness of some of the OpenSSL
methods as OpenSSL has improved since we began developing this library.