### PR TITLE
Allow to sign past/future certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ## Fixed
 
+## Added
+
+# Release 4.1.1
+
+## Changed
+
+## Fixed
+
 * CertificateAuthority now copies the subject of the CA directly into the
   issuer field of the issued certificate. This resolves problems around
   different orders of items in the underlying distinguished name. This fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
   different orders of items in the underlying distinguished name. This fixes
   issue #95. The DistinguishedName object is still not order-aware when loading
   a DN from OpenSSL. This is to be fixed in a later step.
+* X509Certificate::signCSR doesn't validate the certificate at the current
+  system time anymore but at certificate's notBefore and notAfter dates.
+  This fixes issue #96 by allowing to sign past and future certificates but
+  also ensures that the certificate's validity period does not exceed the
+  validity bounds of the issuing certificate.
 
 ## Added
 


### PR DESCRIPTION
within validity bounds of the root certificate

Resolves #96