### PR TITLE
Fix typos in Example Documentation

### DIFF
--- a/doc/examples/example_asymm_crypto.md
+++ b/doc/examples/example_asymm_crypto.md
@@ -334,7 +334,7 @@ std::shared_ptr<RSASignaturePadding> padding = std::make_shared<PSSPadding>(null
 
 # ECDSA
 
-ECDSA only allows the choice of hash function used to create the signed hash. The default value is `SHA256`.
+ECDSA limits one to choose only the hash function that is used to create the signed hash. The default value is `SHA256`.
 
 ## Verification (Default Hash Function)
 

--- a/doc/examples/example_asymm_crypto.md
+++ b/doc/examples/example_asymm_crypto.md
@@ -4,7 +4,7 @@
 
 ## Encryption Interface
 
-All contexts that support en- / decryption are implementing an `encrypt()` or `decrypt()` method resprectively. The classes `mococrw::EncryptionCtx` and `mococrw::DecryptionCtx` provide a pure virtual interface to these methods:
+All contexts that support encryption/decryption implement an `encrypt()` or `decrypt()` method respectively. The classes `mococrw::EncryptionCtx` and `mococrw::DecryptionCtx` provide a pure virtual interface to these methods:
 <!-- TODO for when refactoring Examples: Generate such code snippets from code-->
 ```cpp
 class EncryptionCtx {
@@ -17,11 +17,11 @@ class DecryptionCtx {
     virtual std::vector<uint8_t> decrypt(const std::vector<uint8_t>& message) = 0;
 }
 ```
-That is, these classes can be used to access an en-/decryption context in a generic manner.
+These classes can be used to access an encryption/decryption contexts in a generic manner.
 
 ## Signature Interface
 
-All contexts that support signing implement a method to sign pre-hashed message digests (`signDigest()`) or unhashed messages (`signMessage()`) or both. Please note that if a message digest shall be signed (or verified) it is expected that the client provides the digest of the message to be signed (i.e. performs the hashing on his own). On the contrary, signing a message means that the message digest will be calculated and signed then. The classes `mococrw::DigestSignatureCtx`, `mococrw::MessageSignatureCtx`, `mococrw::DigestVerificationCtx` and `mococrw::MessageVerificationCtx` provide a pure virtual interface to these methods:
+All contexts that support signing implement a method to sign pre-hashed message digests (`signDigest()`) or unhashed messages (`signMessage()`) or both. Note that if a message digest is required to be signed (or verified), it is expected that the client provides the digest of the message to be signed (i.e. performs the hashing on his own). On the contrary, signing a message means that the message digest will be calculated and then signed. The classes `mococrw::DigestSignatureCtx`, `mococrw::MessageSignatureCtx`, `mococrw::DigestVerificationCtx` and `mococrw::MessageVerificationCtx` provide a pure virtual interface to these methods:
 
 ```cpp
 class DigestSignatureCtx {
@@ -48,24 +48,27 @@ class MessageVerificationCtx {
 ```
 
 #### Example
-If a context supports both, signing messages and message digest, the following code snippets are equal. For simplicity it is assumed that SHA256 is used to create the signed hash.
+
+If a context supports both signing messages and message digest, then the following code snippets are equal. For simplicity, it is assumed that SHA256 is used to create the signed hash.
+
 ```cpp
     std::shared_ptr<mococrw::DigestSignatureCtx> ctx = ...; // Hash Function set to SHA256
     std::vector<uint8_t> message = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
     std::vector<uint8_t> digest = mococrw::Hash::sha256(message);
     std::vector<uint8_t> signature = ctx->signDigest(digest);
 ```
+
 ```cpp
     std::shared_ptr<mococrw::MessageSignatureCtx> = ...; // Hash Function set to SHA256
     std::vector<uint8_t> message = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
     std::vector<uint8_t> signature = ctx->signMessage(message)
 ```
 
-The verification contexts behave similarly.
+The verification contexts have similar behaviour.
 
 # RSA - Encryption
 
-By default the RSA encryption crypto contexts (for en- and decryption) are using the following options:
+By default, the RSA encryption crypto contexts (for encryption and decryption) are using the following options:
  * OAEP Padding:
     * Hash Function SHA256
     * Mask Generation Function: MGF1(SHA256)
@@ -125,7 +128,9 @@ The current RSA encryption interface supports the following types of paddings fo
 * OAEP
 
 ### No Padding
-The following code shows how to create contexts that de-/encrypt without padding the content. Please note that this entails that the message size equals the size of the RSA key. Thus, this mode should only be used with care:
+
+The following code shows how to create contexts that encrypt/decrypt without padding the content. Note, it is required that the message size is equal to the size of the RSA key. Thus, this mode should be used with care:
+
 ```cpp
     std::shared_ptr<mococrw::RSAEncryptionPadding> padding = std::make_shared<mococrw::NoPadding>();
 
@@ -135,7 +140,9 @@ The following code shows how to create contexts that de-/encrypt without padding
 ```
 
 ### PKCS#1 v1.5
-The following code shows how to create a context that de-/encrypts using the PKCS#1 v1.5 padding:
+
+The following code shows how to create contexts that performs encryption and decryption using the PKCS#1 v1.5 padding:
+
 ```cpp
     std::shared_ptr<mococrw::RSAEncryptionPadding> padding = std::make_shared<mococrw::PKCSPadding>();
 
@@ -145,17 +152,19 @@ The following code shows how to create a context that de-/encrypts using the PKC
 ```
 
 ### OEAP Padding
+
 The OAEP Padding allows to choose the following:
  * Hash Function
  * Mask Generation Function
  * Label
 
-On the contrary to the previous paddings, the OAEP Padding can be configured. The default options for OAEP are:
+Unlike previous paddings, the OAEP Padding can be configured. The default options for OAEP are:
  * Hash Function: SHA256
  * Mask Generation Function: MGF1 (using the hash function specified as Hash Function)
  * Empty label
 
 A OAEP Padding with default options can be created as follows:
+
 ```cpp
     std::shared_ptr<mococrw::RSAEncryptionPadding> padding = std::make_shared<mococrw::OAEPPadding>();
 
@@ -164,7 +173,8 @@ A OAEP Padding with default options can be created as follows:
     mococrw::RSAEncryptionPrivateKeyCtx decCtx = mococrw::RSAEncryptionPrivateKeyCtx(key, padding);
 ```
 
-If a hash function other than SHA256 has to be used, the OEAP padding can be built as shown below:
+If a hash function other than SHA256 is needed, the OEAP padding can be built as shown below:
+
 ```cpp
     std::shared_ptr<mococrw::RSAEncryptionPadding> padding = std::make_shared<mococrw::OAEPPadding>(mococrw::openssl::DigestTypes::SHA512);
 
@@ -173,9 +183,10 @@ If a hash function other than SHA256 has to be used, the OEAP padding can be bui
     mococrw::RSAEncryptionPrivateKeyCtx decCtx = mococrw::RSAEncryptionPrivateKeyCtx(key, padding);
 ```
 
-In this case the hash function is set to SHA512. Please note that this also entails that SHA512 will be used by the mask generation function.
+In this case, the hash function is set to SHA512. Note that this also entails that SHA512 will be used by the mask generation function.
 
 If the hash function that has to be used by the mask generation function is different the padding needs to be constructed as shown below:
+
 ```cpp
     std::shared_ptr<mococrw::MaskGenerationFunction> mgf = std::make_shared<MGF1>(mococrw::openssl::DigestTypes::SHA512);
 
@@ -186,11 +197,11 @@ If the hash function that has to be used by the mask generation function is diff
     mococrw::RSAEncryptionPrivateKeyCtx decCtx = mococrw::RSAEncryptionPrivateKeyCtx(key, padding);
 ```
 
-Please note that for the moment being only the mask generation function MGF1 is available. The example above uses SHA256 as OEAP hash function and SHA512 as hash function for MGF1.
+Currently, only the mask generation function MGF1 is available. The example above uses SHA256 as OEAP hash function and SHA512 as hash function for MGF1.
 
 # RSA - Signing
 
-Similar to the en-/decrpytion interface the signature interface supports several paddings. By default the following option will be used:
+Similar to the encryption/decrpytion interface, the signature interface also supports several paddings. By default, the following options are used:
 * Hash Function: SHA256
 * PSS Padding:
     * Mask Generation Function: MGF1(SHA256)
@@ -260,8 +271,9 @@ std::vector<uint8_t> messageDigest = mococrw::Hash::sha256(message);
 signature = ctx.signDigest(messageDigest);
 ```
 
-## Using Different Hash Function
-To use different hash function to create the hash to be signed (e.g. SHA512) the contexts have to be created as follows:
+## Using Different Hash Functions
+
+To use a different hash function and create the hash to be signed (e.g. SHA512), the contexts have to be created as follows:
 
 ```cpp
 mococrw::RSASignaturePublicKeyCtx verifyCtx = mococrw::RSASignaturePublicKeyCtx(key, mococrw::openssl::DigestTypes::SHA512);
@@ -289,7 +301,7 @@ mococrw::RSASignaturePrivateKeyCtx signCtx = mococrw::RSASignaturePrivateKeyCtx(
 
 ### PSS Padding
 
-The PSS Padding allows to choose the following:
+The PSS Padding allows one to choose the following:
 * Mask Generation Function
 * Salt Length
 
@@ -298,28 +310,31 @@ The default values for these options are:
 * Salt Length: Length of the digests produced by the hash function used to create the signature digests
 
 A PSS Padding with default options can be created as shown below:
+
 ```cpp
 std::shared_ptr<RSASignaturePadding> padding = std::make_shared<PSSPadding>();
 ```
 
-The following example shows how to change the hash function (e.g. to SHA512) used by the Mask Generation Function. Please note that currently only
+The following example shows how to change the hash function (e.g. to SHA512) used by the Mask Generation Function. Currently, only
 MGF1 is available:
+
 ```cpp
 std::shared_ptr<MaskGenerationFunction> mgf = std::make_shared<MGF1>(mococrw::openssl::DigestTypes::SHA512);
 
 std::shared_ptr<RSASignaturePadding> padding = std::make_shared<PSSPadding>(mgf);
 ```
 
-Please note that enforces the hash function of MGF1 to be SHA512, regardless of the hash function used to create the signed hash.
+Please note the enforcing of the hash function of MGF1 to be SHA512, regardless of the hash function used to create the signed hash.
 
-If the salt length shall be a non-default value, `nullptr` can be passed as padding which keeps the default behaviour of the Mask Generation Function. The following example sets the salt length to 20, while keeping the default behaviour for the Mask Generation Function:
+If the salt length is a non-default value, `nullptr` can be passed as padding, which keeps the default behaviour of the Mask Generation Function. The following example sets the salt length to 20, while keeping the default behaviour for the Mask Generation Function:
+
 ```cpp
 std::shared_ptr<RSASignaturePadding> padding = std::make_shared<PSSPadding>(nullptr, 20);
 ```
 
 # ECDSA
 
-ECDSA only allows to choose the hash function that is used to create the signed hash. The default value is `SHA256`.
+ECDSA only allows the choice of hash function used to create the signed hash. The default value is `SHA256`.
 
 ## Verification (Default Hash Function)
 
@@ -385,8 +400,9 @@ std::vector<uint8_t> messageDigest = mococrw::Hash::sha256(message);
 signature = ctx.signDigest(messageDigest);
 ```
 
-## Using Different Hash Function
-To use different hash function to create the hash to be signed (e.g. SHA512) the contexts have to be created as follows:
+## Using Different Hash Functions
+
+To use a different hash function and create the hash to be signed (e.g. SHA512), the contexts have to be created as follows:
 
 ```cpp
 mococrw::ECDSASignaturePublicKeyCtx verifyCtx = mococrw::ECDSASignaturePublicKeyCtx(key, mococrw::openssl::DigestTypes::SHA512);
@@ -395,6 +411,7 @@ mococrw::ECDSASignaturePrivateKeyCtx signCtx = mococrw::ECDSASignaturePrivateKey
 ```
 
 ## Signature Formats
+
 MoCOCrW supports two different formats for the signature:
 * `mococrw::ECDSASignatureFormat::ASN1_SEQUENCE_OF_INTS`:
   Encoding of (r,s) as ASN.1 sequence of integers as specified in ANSI X9.62
@@ -407,7 +424,7 @@ MoCOCrW offers the following overloads to specify the signature formats:
 
 # EdDSA
 
-Please note that EdDSA only implements signMessage/verifyMessage methods. That is, the hash to be signed can not be specified manually.
+Note, EdDSA only implements signMessage/verifyMessage methods; the hash to be signed cannot be manually specified.
 
 ## Verification
 

--- a/doc/examples/example_ecies.md
+++ b/doc/examples/example_ecies.md
@@ -3,15 +3,15 @@
 # Basic ECIES
 
 ECIES utilizes well-known symmetric encryption, key derivation functions and message authentication codes
-to achieve encryption based on elliptic curves. However, ECIES is not limited to specific algorithms. That is,
+to achieve encryption based on elliptic curves. However, ECIES is not limited to specific algorithms. In particular,
 the algorithms used for symmetric encryption, key derivation and message authentication can be configured
 in our implementation. For the sake of easy usage, we have decided to use the following defaults:
  - Symmetric Encryption: AES-CBC with PKCS7 padding, IV=0x0, keysize 256 bit
  - Key Derivation Function: X9.63 without salt
  - Message Authentication Code: HMAC-SHA512 without salt
 
-The following examples show how to en- and decrypt using ECIES with these default settings. Afterwards, the
-different options to change the default values will be shown.
+The following examples show how to encrypt/decrypt using ECIES with these default settings. The
+different options to change the default values are presented in the next section.
 
 ## Encryption
 
@@ -80,20 +80,19 @@ catch (const mococrw::MoCOCrWException &e)  {
 ## Serialization of Artifacts
 
 The encryption of the plaintext creates several artifacts (ciphertext, mac and ephemeral key) that need to be transferred to the client in order to
-decrypt the ciphertext. MoCOCrW offers no serialization functionality because we don't want to make any assumptions of the format. That is,
+decrypt the ciphertext. MoCOCrW offers no serialization functionality because we don't want to make any assumptions on format. Essentially,
 the user of the library is responsible for the serialization.
 
 ### Ephemeral Key Encodig Format
 
-The methods `mococrw::AsymmetricPublicKey::toECPoint()` and `mococrw::AsymmetricPublicKey::toECPoint()` expect that the serialization format
-is specified by the programmer. The library currently offers three different formats:
-
+The methods `mococrw::AsymmetricPublicKey::toECPoint()` and `mococrw::AsymmetricPublicKey::toECPoint()` expect the serialization format
+to be specified by the programmer. The library currently offers three different formats:
 * `mococrw::openssl::EllipticCurvePointConversionForm::compressed`:
-   Format *z||x*, where *z* specifies which of the possible two solutions to *x* has been used
+   Format *z||x*, where *z* specifies which of the possible two solutions to *x* has been used.
 * `mococrw::openssl::EllipticCurvePointConversionForm::uncompressed`:
-   Format *0x04||x||y*, where *y* is the solution to *x* that has been used
+   Format *0x04||x||y*, where *y* is the solution to *x* that has been used.
 * `mococrw::openssl::EllipticCurvePointConversionForm::hybrid`
-   Format *z||x||y*, where *z* specifies which of the possible two solutions to *x* has been used and *y* contains this solution
+   Format *z||x||y*, where *z* specifies which of the possible two solutions to *x* has been used and *y* contains this solution.
 
 It is also possible to encode the ephemeral key as PEM, but this seems rather unsusal.
 
@@ -101,8 +100,9 @@ It is also possible to encode the ephemeral key as PEM, but this seems rather un
 # Change Default Parameters
 
 ## Symmetric Cipher
-The `mococrw::ECIESCtxBuilder` offers methods to modify the symmetric cipher that will be used for encryption.
-The following code shows how to use these methods to change the symmetric cipher to AES-CBC with a key size of 128 bit:
+
+`mococrw::ECIESCtxBuilder` offers methods to modify the symmetric cipher used for encryption.
+The following code shows how to use these methods to change the symmetric cipher to AES-CBC with a key size of 128-bit:
 
 ### Encryption
 
@@ -200,7 +200,7 @@ catch (const MoCOCrWException &e)  {
 
 ## Key Derivation Function (KDF)
 
-MoCOCrW offers different key derivation functions. The following example shows how to change the KDF used by ECIES. In addition, the example shows
+MoCOCrW offers various key derivation functions. The following example shows how to change the KDF used by ECIES. In addition, the example also shows
 how to set the optional salt for the key derivation.
 
 ### Encryption
@@ -284,7 +284,7 @@ catch (const MoCOCrWException &e)  {
 
 ## Message Authentication Code (MAC)
 
-The following example shows how to configure (and specify if there ever shall be more than one supported MAC) the MAC to be used by the ECIES scheme
+The following example shows how to configure (and specify if there will ever be more than one supported MAC) the MAC used by the ECIES scheme.
 
 ### Encryption
 

--- a/doc/examples/example_ecies.md
+++ b/doc/examples/example_ecies.md
@@ -86,7 +86,7 @@ the user of the library is responsible for the serialization.
 ### Ephemeral Key Encodig Format
 
 The methods `mococrw::AsymmetricPublicKey::toECPoint()` and `mococrw::AsymmetricPublicKey::toECPoint()` expect the serialization format
-to be specified by the programmer. The library currently offers three different formats:
+to be specified by the user. The library currently offers three different formats:
 * `mococrw::openssl::EllipticCurvePointConversionForm::compressed`:
    Format *z||x*, where *z* specifies which of the possible two solutions to *x* has been used.
 * `mococrw::openssl::EllipticCurvePointConversionForm::uncompressed`:

--- a/doc/examples/example_hash.md
+++ b/doc/examples/example_hash.md
@@ -25,9 +25,9 @@ The following algorithms are supported:
 - `mococrw::sha3_384()`
 - `mococrw::sha3_512()`
 
-# Other Hash interfaces
+# Other Hash Interfaces
 
-MoCOCrW also implements a hash interface that allows giving the content to be hashed
+MoCOCrW also implements a hash interface that enables the hashing of content to be done
 in multiple steps. The following example shows how to use this interface:
 
 ```cpp
@@ -43,7 +43,7 @@ h.update(message3);
 std::vector<uint8_t> hash = h.digest();
 ```
 
-This interface supports also supports all the algorithms listed above:
+This interface also supports all the algorithms listed above:
 - `mococrw::Hash::sha1()`
 - `mococrw::Hash::sha256()`
 - `mococrw::Hash::sha384()`
@@ -51,4 +51,3 @@ This interface supports also supports all the algorithms listed above:
 - `mococrw::Hash::sha3_256()`
 - `mococrw::Hash::sha3_384()`
 - `mococrw::Hash::sha3_512()`
-

--- a/doc/examples/example_kdf.md
+++ b/doc/examples/example_kdf.md
@@ -3,7 +3,7 @@
 # KDF Interface
 
 All the KDF classes implement the method `mococrw::KeyDerivationFunction::deriveKey()` to derive a key
-of a fixed length from a given password and salt. Algorithm specific parameters are specified via the constructor.
+of fixed length from a provided password and salt. Algorithm specific parameters are specified via the constructor.
 
 ```cpp
 class KeyDerivationFunction
@@ -17,6 +17,7 @@ public:
 ```
 
 # PBKDF2
+
 The following code shows how to derive a key using PBKFD2:
 
 ```cpp
@@ -29,6 +30,7 @@ std::vector<uint8_t> derivedKey = pbkdf2.deriveKey(pw, derivedKeyLen, salt);
 ```
 
 # X963KDF
+
 The following code shows how to derive a key using X963KDF:
 
 ```cpp

--- a/doc/examples/example_mac.md
+++ b/doc/examples/example_mac.md
@@ -3,7 +3,7 @@
 # Message Authentication Code Interface
 
 All the MAC classes (currently only one) implement the methods listed below.
-Algorithm specific parameters are specified via the constructor.
+Algorithm-specific parameters are specified via the constructor.
 
 ```cpp
 class MessageAuthenticationCode {
@@ -35,7 +35,7 @@ std::vector<uint8_t> mac = hmac.finish();
 
 ## HMAC Verification
 
-The following example shows how an HMAC can be verified. Please note that `mococrw::HMAC::verify()` performs a constant time
+The following example shows how an HMAC is verified. Note, `mococrw::HMAC::verify()` performs a constant time
 comparison on the given mac. Do NOT re-calculate the mac and compare it to the given mac on your own.
 
 ```cpp
@@ -65,7 +65,7 @@ catch (const MoCOCrWException &e)  {
 ## CMAC Creation
 
 The following example shows how to create a CMAC. The key size needs to match the selected cipher, i.e. you need a key of
-128 bits for AES-128.
+128-bits for AES-128.
 
 ```cpp
 std::vector<uint8_t> key = {
@@ -81,7 +81,7 @@ std::vector<uint8_t> mac = cmac.finish();
 
 ## CMAC Verification
 
-The following example shows how a CMAC can be verified. Please note that `mococrw::CMAC::verify()` performs a constant time
+The following example shows how a CMAC is verified. Note, `mococrw::CMAC::verify()` performs a constant time
 comparison on the given mac. Do NOT re-calculate the mac and compare it to the given mac yourself.
 
 ```cpp

--- a/doc/examples/example_main_page.md
+++ b/doc/examples/example_main_page.md
@@ -1,6 +1,6 @@
 # Usage Examples
 
-Table of contents:
+Table of Contents:
 
 - [Asymmetric Key Example](example_asymm_key.md)
 - [Asymmetric Crypto API](example_asymm_crypto.md)

--- a/doc/examples/example_symm.md
+++ b/doc/examples/example_symm.md
@@ -1,8 +1,8 @@
 # Symmetric Crypto API
 
-## Encrypting messages in one-shot mode
+## Encrypting Messages in One-Shot Mode
 
-The code below demonstrates encryption and then further decryption of a simple message. The example also shows how to generate random encryption key and IV.
+The code below demonstrates encryption, followed by decryption, of a simple message. This example also shows how to generate random encryption key and IV.
 
 ```cpp
 
@@ -53,13 +53,13 @@ assert(std::equal(plaintext.begin(), plaintext.end(), decryptedtext.begin()));
 
 ```
 
-## Using authenticated encryption
+## Using Authenticated Encryption
 
-Authenticated ciphers not only encrypt data but also compute authentication tag over it. It allows to detect if data was modified after it was encrypted.
+Authenticated ciphers not only encrypt data but also compute an authentication tag over it. It enables the detection of data that was modified after the data was encrypted.
 
-It is also possible to associate additional unencrypted data with the message. The authentication tag will ensure the integrity of both encrypted and unencrypted data in that case. This is, e.g., used to protect the integrity of header fields that contain metadata that need to be visible on transport.
+It is also possible to associate additional unencrypted data with the message. In this case, the authentication tag will ensure the integrity of both encrypted and unencrypted data. For instance, this is useful to protect the integrity of header fields that contain meta-data which need to be visible on transport.
 
-Example below is similar to the previous one but uses authenticated cipher mode GCM. After encryption we take computed authentication tag and carry it along with the message for further authentication.
+Example below is similar to the previous one but uses authenticated cipher mode GCM. After encryption, we take the computed authentication tag and carry it along with the message for further authentication.
 
 ```cpp
 using namespace mococrw;
@@ -124,11 +124,11 @@ assert(std::equal(plaintext.begin(), plaintext.end(), decryptedtext.begin()));
 
 ```
 
-## Streaming-mode
+## Streaming-Mode
 
-Symmetric encryption interface also supports streaming use-case. It allows encryption of big chunks of data without loading them into memory. The implementation is optimized to avoid unnecessary copies of the input and output buffers when used with fixed block sizes in streaming en-/decryption.
+The symmetric encryption interface also supports the streaming use-case. It allows encryption of big chunks of data without the need of loading them into memory. The implementation is optimized to avoid unnecessary copies of the input and output buffers when used with fixed block sizes in streaming encrypting/decryption.
 
-The following example demonstrates how to use stream mode with authenticated cipher.
+The following example demonstrates how to use stream-mode with an authenticated cipher.
 
 ```cpp
 using namespace mococrw;

--- a/doc/examples/example_symm.md
+++ b/doc/examples/example_symm.md
@@ -2,7 +2,7 @@
 
 ## Encrypting Messages in One-Shot Mode
 
-The code below demonstrates encryption, followed by decryption, of a simple message. This example also shows how to generate random encryption key and IV.
+The code below demonstrates encryption, followed by decryption, of a simple message. This example also shows how to generate a random encryption key and and IV.
 
 ```cpp
 
@@ -59,7 +59,7 @@ Authenticated ciphers not only encrypt data but also compute an authentication t
 
 It is also possible to associate additional unencrypted data with the message. In this case, the authentication tag will ensure the integrity of both encrypted and unencrypted data. For instance, this is useful to protect the integrity of header fields that contain meta-data which need to be visible on transport.
 
-Example below is similar to the previous one but uses authenticated cipher mode GCM. After encryption, we take the computed authentication tag and carry it along with the message for further authentication.
+The example below is similar to the previous one but uses authenticated cipher mode GCM. After encryption, we take the computed authentication tag and carry it along with the message for further authentication.
 
 ```cpp
 using namespace mococrw;

--- a/doc/examples/example_x509.md
+++ b/doc/examples/example_x509.md
@@ -100,8 +100,8 @@ std::string certToPem = cert.toPEM();
 
 It's possible to add more parameters to the certificate verification by providing the verify method
 with a VerificationCtx object where we can set, amongst others, a CRL (certificate revocation list) and
-a time-check verification.
-In the example below, we create a context that enables a time-check verification.
+a time verification check.
+In the example below, we create a context that enables a time verification check.
 
 ```cpp
 mococrw::X509Certificate cert = mococrw::X509Certificate::fromPEM(intPemString);

--- a/doc/examples/example_x509.md
+++ b/doc/examples/example_x509.md
@@ -68,8 +68,8 @@ uRZLQUBt1w+r1qEakvSIoinjrmS616qfkOBPHJEkvQ==
 };
 ```
 
-In the example bellow we are loading two certificates from their respective PEM strings
-and then are verifying if the intCert was signed by the rootCert
+In the example below, we are loading two certificates from their respective PEM strings
+and then are verifying whether the intCert was signed by the rootCert.
 
 ```cpp
 mococrw::X509Certificate rootCert = mococrw::X509Certificate::fromPEM("rootPemString");
@@ -98,11 +98,10 @@ mococrw::X509Certificate cert;
 std::string certToPem = cert.toPEM();
 ```
 
-It's possible to add more parameters to the Certificate verification by providing the verify method
-with a VerificationCtx Object where we can set a CRL (certificate revocation list),
-a time check verification and others.
-In the example below, we can see an example where we create a context that enables
-a time check verification.
+It's possible to add more parameters to the certificate verification by providing the verify method
+with a VerificationCtx object where we can set, amongst others, a CRL (certificate revocation list) and
+a time-check verification.
+In the example below, we create a context that enables a time-check verification.
 
 ```cpp
 mococrw::X509Certificate cert = mococrw::X509Certificate::fromPEM(intPemString);


### PR DESCRIPTION
Fixed several typos and wordings in Example Documentation of MoCOCrW, via a quick manual pass.