### PR TITLE
Fix test library target in CMakeLists.txt

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -136,8 +136,8 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
 	"${SRC_DIR}/kdf.cpp"
 	${REAL_SOURCES})
 
-    target_link_libraries(openssltest ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-
+    target_link_libraries(openssltest
+        ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
     target_link_libraries(asn1timetests
         ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
     target_link_libraries(keytests

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -136,8 +136,10 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
 	"${SRC_DIR}/kdf.cpp"
 	${REAL_SOURCES})
 
-    target_link_libraries(openssltest
-        ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
+    target_link_libraries(openssltest ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    # Cannot link to imported OpenSSL and leverage implicit include-dir-propagation, as openssltest uses mocks.
+    target_include_directories(openssltest PUBLIC ${OPENSSL_INCLUDE_DIR})
+
     target_link_libraries(asn1timetests
         ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
     target_link_libraries(keytests


### PR DESCRIPTION
Adds CMakeLists.txt fix so that test no longer has missing OpenSSL target. 