### PR TITLE
Fix CA tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,27 @@ All notable changes to this project will be documented in this file.
 
 ## Fixed
 
+* CA Tests' SetUp was changed so that all the objects involved do not depend on time when
+  construction of object is made. This led to problems where object of CA class had notBefore
+  attribute set to greater value than CA's certificate's notBefore which should never happen.
+  This subtle bug in test SetUp has greater chance of appearing when running in slower
+  environments, e.g., qemu.
+
 ## Added
+
+* Exceptions with better error messages were added in sanity check section of
+  CertificateAuthority::_signCSR function. This provides better understanding of
+  scenarios which we dont allow:
+    - Issued certificate has greater notAfter attribute than CA's certificate (issued
+      certificate's validity period should not exceed issuing certificate's validity
+      period)
+    - Case with the CA's notBefore being larger than the issued certificate's notBefore. This
+      results in issued certificate that are valid *before* issuing certificate which
+      should never happen.
+  This is not a behavior change in the library in the sense that a certificate that was issued
+  before won't be issued anymore. Certificates with these properties were already rejected
+  by CertificateAuthority::signCSR but with a rather misleading and generic error message.
+  This change just improves the error reporting.
 
 # Release 4.1.1
 

--- a/examples/ca-csr-example.cpp
+++ b/examples/ca-csr-example.cpp
@@ -32,6 +32,7 @@ using namespace mococrw;
 
 // Digest type to used by all examples
 static const DigestTypes digestType = DigestTypes::SHA512;
+static auto notBeforeTime = Asn1Time::now();
 
 /******************* Root CA *******************/
 /***********************************************/
@@ -50,7 +51,8 @@ CertificateAuthority getRootCa(const X509Certificate &rootCaCert,
     const auto rootCaKeyUsage = KeyUsageExtension::Builder{}.keyCertSign().cRLSign().build();
 
     auto rootCaSignParams = CertificateSigningParameters::Builder{}
-            .certificateValidity(Asn1Time::Seconds(120))
+            .certificateValidity(Asn1Time::Seconds(300))
+            .notBeforeAsn1(notBeforeTime + std::chrono::seconds{5})
             .digestType(digestType)
             .addExtension(rootCertSignConstraints)
             .addExtension(rootCaKeyUsage)
@@ -73,7 +75,7 @@ CertificateAuthority getIntermediateCa(const X509Certificate &intermediateCaCert
 
     auto intermediateCaSignParams = CertificateSigningParameters::Builder{}
             .certificateValidity(Asn1Time::Seconds(120))
-            .notBeforeAsn1(Asn1Time::now() - std::chrono::seconds{1})
+            .notBeforeAsn1(notBeforeTime + std::chrono::seconds{10})
             .digestType(digestType)
             .addExtension(intermediateCaSigningConstraints)
             .addExtension(intermediateCaKeyUsage)
@@ -97,7 +99,8 @@ X509Certificate createRootCertificate(const AsymmetricKeypair &rootEccKey)
     const auto rootCaKeyUsage = KeyUsageExtension::Builder{}.keyCertSign().cRLSign().build();
 
     auto rootCaSelfSignParams = CertificateSigningParameters::Builder{}
-            .certificateValidity(Asn1Time::Seconds(120))
+            .certificateValidity(Asn1Time::Seconds(600))
+            .notBeforeAsn1(notBeforeTime)
             .digestType(digestType)
             .addExtension(rootCertConstraint)
             .addExtension(rootCaKeyUsage)

--- a/tests/unit/test_ca.cpp
+++ b/tests/unit/test_ca.cpp
@@ -148,13 +148,14 @@ void CATest::SetUp()
                                                .keyCertSign().cRLSign().build());
 
     BasicConstraintsExtension caConstraint{true, 1};
+    auto notBeforeTime = Asn1Time::now() - std::chrono::seconds{1};
 
     _signParamsBuilder = CertificateSigningParameters::Builder{}
         .digestType(openssl::DigestTypes::SHA256)
         .addExtension(*_exampleConstraints)
         .addExtension(*_exampleUsage)
         .certificateValidity(Asn1Time::Seconds(120))
-        .notBeforeAsn1(Asn1Time::now() - std::chrono::seconds{1});
+        .notBeforeAsn1(notBeforeTime);
 
     _signParams = _signParamsBuilder.build();
 
@@ -163,6 +164,7 @@ void CATest::SetUp()
             .digestType(openssl::DigestTypes::SHA256)
             .addExtension(caConstraint)
             .addExtension(*_exampleUsage)
+            .notBeforeAsn1(notBeforeTime)
             .build();
 
     _caSignParamsOneYearOldOneYearToGo = CertificateSigningParameters::Builder{}
@@ -435,7 +437,7 @@ TEST_F(CATest, testVerifyCAAgainstPureOpenSslOutputECC)
 
 TEST_F(CATest, testGetNextSerialNumber)
 {
-    auto eccCa = std::make_unique<CertificateAuthority>(_caSignParams, 0, *_rootRsaCert, *_rootRSAKey);
+    auto eccCa = std::make_unique<CertificateAuthority>(_caSignParams, 0, *_rootEccCert, *_rootEccKey);
     auto keypair = AsymmetricKeypair::generateECC();
     auto nextSerial = eccCa->getNextSerialNumber();
 


### PR DESCRIPTION
CA tests were failing randomly because CA's notBefore was set on
first use which then can cause problems in sanity check section of
CertificateAuthority::_signCSR function. If CA's notBefore was set
to +1 second compared to CA certificate's notBefore, it would
complain with "certificate is not valid yet" on the first
cert.verify(ctx). If CA's notBefore was set to -1 second compared
to issued cert, it would complaind with "certificate expired" on
the second cert.verify(ctx).

Solution was to set CA's notBefore and CA certificate's notBefore
to the same value in test SetUp.