### PR TITLE
PKCS#11 testing infrastrucuture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: "Build MoCOCrW"
         run: |
           mkdir build
-          docker run --rm -u "$UID" -v "$PWD:/src:rw" -w /src/build ${{ env.DOCKER_TAG }} bash -c \
+          docker run --rm -e SOFTHSM2_CONF='/usr/share/softhsm/softhsm2.conf' -u "$UID":softhsm -v "$PWD:/src:rw" -w /src/build ${{ env.DOCKER_TAG }} bash -c \
             'cmake \
               -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
@@ -59,4 +59,4 @@ jobs:
 
       - name: "Run tests"
         run: |
-          docker run --rm -u "$UID" -v "$PWD:/src:rw" -w /src/build ${{ env.DOCKER_TAG }} bash -c 'ctest -j $(nproc)'
+          docker run --rm -e SOFTHSM2_CONF='/usr/share/softhsm/softhsm2.conf' -u "$UID":softhsm -v "$PWD:/src:rw" -w /src/build ${{ env.DOCKER_TAG }} bash -c 'ctest -j $(nproc)'

--- a/docker-build-env/Dockerfile
+++ b/docker-build-env/Dockerfile
@@ -10,9 +10,20 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         git \
         googletest \
         libboost-all-dev \
+        # libp11 engine
+        libengine-pkcs11-openssl \
+        # headers for p11 engine
+        # TODO: this may not be necessary if we don't use libp11 directly (only though openssl)
+        libp11-dev \
+        # softhsm2 module
+        libsofthsm2 \
         libssl-dev \
         make \
         ninja-build \
+        # for pkcs11-tool which we use to create keys in token
+        opensc \
+        # p11-kit-modules allows loading of libp11 engine without having to edit openssl.cnf
+        p11-kit-modules \
         pkg-config \
         wget \
         && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add packages to the docker container that are necessary to test
HSM functionality (provided by SoftHSM2) from MoCOCrW
(MoCOCrW -> OpenSSL -> libp11 engine -> SoftHSM2)

Create keys inside SoftHSM2 with docker-build-env/entrypoint.sh
script. This will probably need expansion as test base grows.