### PR TITLE
Create two Docker images to test MoCOCrW with and without HSM support separately.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ env:
   DOCKER_TAG: buildenv
   DOCKER_FILE_PATH: ./docker-build-env/Dockerfile
 
+  DOCKER_WITH_HSM_TAG: buildenv_with_hsm
+  DOCKER_WITH_HSM_FILE_PATH: ./docker-build-env/Dockerfile-With-HSM
+
 jobs:
   check-format:
     runs-on: ubuntu-latest
@@ -36,6 +39,18 @@ jobs:
         compiler: ["g++", "clang++"]
         build_type: ["", "ASAN"]
         hsm_flag: ["HSM_ENABLED=ON", "HSM_ENABLED=OFF"]
+
+        include:
+          - hsm_flag: "HSM_ENABLED=ON"
+            docker_tag: "buildenv_with_hsm"
+            softhsm2_conf: "/usr/share/softhsm/softhsm2.conf"
+            softhsm2_grp: ":softhsm"
+         
+          - hsm_flag: "HSM_ENABLED=OFF"
+            docker_tag: "buildenv"
+            softhsm2_conf: ""
+            softhsm2_grp:
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -46,10 +61,18 @@ jobs:
           docker_tag: ${{ env.DOCKER_TAG }}
           docker_file_path: ${{ env.DOCKER_FILE_PATH }}
 
+      - name: "Build Docker Image With HSM"
+        uses: ./.github/actions/build-docker
+        with:
+          docker_tag: ${{ env.DOCKER_WITH_HSM_TAG }}
+          docker_file_path: ${{ env.DOCKER_WITH_HSM_FILE_PATH }}
+
       - name: "Build MoCOCrW"
         run: |
           mkdir build
-          docker run --rm -e SOFTHSM2_CONF='/usr/share/softhsm/softhsm2.conf' -u "$UID":softhsm -v "$PWD:/src:rw" -w /src/build ${{ env.DOCKER_TAG }} bash -c \
+          docker run --rm -e SOFTHSM2_CONF="${{ matrix.softhsm2_conf }}" \
+            -u "$UID"${{ matrix.softhsm2_grp }} \
+            -v "$PWD:/src:rw" -w /src/build ${{ matrix.docker_tag }}  bash -c \
             'cmake \
               -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
@@ -61,4 +84,7 @@ jobs:
 
       - name: "Run tests"
         run: |
-          docker run --rm -e SOFTHSM2_CONF='/usr/share/softhsm/softhsm2.conf' -u "$UID":softhsm -v "$PWD:/src:rw" -w /src/build ${{ env.DOCKER_TAG }} bash -c 'ctest -j $(nproc)'
+          docker run --rm -e SOFTHSM2_CONF="${{ matrix.softhsm2_conf }}" \
+            -u "$UID"${{ matrix.softhsm2_grp }} \
+            -v "$PWD:/src:rw" -w /src/build ${{ matrix.docker_tag }}  bash -c \
+            'ctest -j $(nproc)'

--- a/docker-build-env/Dockerfile
+++ b/docker-build-env/Dockerfile
@@ -10,20 +10,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         git \
         googletest \
         libboost-all-dev \
-        # libp11 engine
-        libengine-pkcs11-openssl \
-        # headers for p11 engine
-        # TODO: this may not be necessary if we don't use libp11 directly (only though openssl)
-        libp11-dev \
-        # softhsm2 module
-        libsofthsm2 \
         libssl-dev \
+        # For llvm-symbolizer (used by ASAN).
+        llvm \
         make \
         ninja-build \
-        # for pkcs11-tool which we use to create keys in token
-        opensc \
-        # p11-kit-modules allows loading of libp11 engine without having to edit openssl.cnf
-        p11-kit-modules \
         pkg-config \
         wget \
         && rm -rf /var/lib/apt/lists/*

--- a/docker-build-env/Dockerfile
+++ b/docker-build-env/Dockerfile
@@ -11,8 +11,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         googletest \
         libboost-all-dev \
         libssl-dev \
-        # For llvm-symbolizer (used by ASAN).
-        llvm \
         make \
         ninja-build \
         pkg-config \

--- a/docker-build-env/Dockerfile-With-HSM
+++ b/docker-build-env/Dockerfile-With-HSM
@@ -1,0 +1,15 @@
+FROM buildenv
+
+# Install MoCOCrW dependencies (except OpenSSL)
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+        # libp11 engine
+        libengine-pkcs11-openssl \
+        # headers for p11 engine
+        # TODO: this may not be necessary if we don't use libp11 directly (only though openssl)
+        libp11-dev \
+        # for pkcs11-tool which we use to create keys in token
+        opensc \
+        # p11-kit-modules allows loading of libp11 engine without having to edit openssl.cnf
+        p11-kit-modules \
+        # softhsm2: includes both softhsm2-util and libsofthsm2
+        softhsm2

--- a/docker-build-env/Dockerfile-With-HSM
+++ b/docker-build-env/Dockerfile-With-HSM
@@ -11,4 +11,5 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         # p11-kit-modules allows loading of libp11 engine without having to edit openssl.cnf
         p11-kit-modules \
         # softhsm2: includes both softhsm2-util and libsofthsm2
-        softhsm2
+        softhsm2 \
+        && rm -rf /var/lib/apt/lists/*

--- a/docker-build-env/Dockerfile-With-HSM
+++ b/docker-build-env/Dockerfile-With-HSM
@@ -5,7 +5,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         # libp11 engine
         libengine-pkcs11-openssl \
         # headers for p11 engine
-        # TODO: this may not be necessary if we don't use libp11 directly (only though openssl)
         libp11-dev \
         # for pkcs11-tool which we use to create keys in token
         opensc \


### PR DESCRIPTION
In order to test properly MoCOCrW's builds with and without HSM support, we introduce two docker images and update our CI. In particular, we want to avoid cases where a build, which is intended to be without HSM support, incorrectly relies on an HSM dependency to successfully compile. 

Note, Dockerfile-With-HSM is based on Dockerfile, specifying solely PKCS11 dependencies.