### PR TITLE
Add Engine API Wrapper to MoCOCrW

### DIFF
--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -1,7 +1,7 @@
 /*
  * #%L
  * %%
- * Copyright (C) 2018 BMW Car IT GmbH
+ * Copyright (C) 2022 BMW Car IT GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ extern "C" {
 #include <openssl/crypto.h>
 #include <openssl/dsa.h>
 #include <openssl/ec.h>
+#include <openssl/engine.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/objects.h>
@@ -58,6 +59,22 @@ namespace lib
 class OpenSSLLib
 {
 public:
+    static int SSL_ENGINE_free(ENGINE* e) noexcept;
+    static int SSL_ENGINE_finish(ENGINE* e) noexcept;
+    static ENGINE* SSL_ENGINE_by_id(const char* id) noexcept;
+    static int SSL_ENGINE_init(ENGINE* e) noexcept;
+    static int SSL_ENGINE_ctrl_cmd_string(ENGINE* e,
+                                          const char* cmd_name,
+                                          const char* cmd_arg,
+                                          int cmd_optional) noexcept;
+    static EVP_PKEY* SSL_ENGINE_load_public_key(ENGINE* e,
+                                                const char* key_id,
+                                                UI_METHOD* ui_method,
+                                                void* callback_data) noexcept;
+    static EVP_PKEY* SSL_ENGINE_load_private_key(ENGINE* e,
+                                                 const char* key_id,
+                                                 UI_METHOD* ui_method,
+                                                 void* callback_data) noexcept;
     static ECDSA_SIG* SSL_d2i_ECDSA_SIG(ECDSA_SIG** sig,
                                         const unsigned char** pp,
                                         long len) noexcept;

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -1,7 +1,7 @@
 /*
  * #%L
  * %%
- * Copyright (C) 2018 BMW Car IT GmbH
+ * Copyright (C) 2022 BMW Car IT GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -996,7 +996,31 @@ int OpenSSLLib::SSL_CMAC_Final(CMAC_CTX* ctx, unsigned char* out, size_t* poutle
     return CMAC_Final(ctx, out, poutlen);
 }
 int OpenSSLLib::SSL_CMAC_resume(CMAC_CTX* ctx) noexcept { return CMAC_resume(ctx); }
-
+EVP_PKEY* OpenSSLLib::SSL_ENGINE_load_private_key(ENGINE* e,
+                                                  const char* key_id,
+                                                  UI_METHOD* ui_method,
+                                                  void* callback_data) noexcept
+{
+    return ENGINE_load_private_key(e, key_id, ui_method, callback_data);
+}
+EVP_PKEY* OpenSSLLib::SSL_ENGINE_load_public_key(ENGINE* e,
+                                                 const char* key_id,
+                                                 UI_METHOD* ui_method,
+                                                 void* callback_data) noexcept
+{
+    return ENGINE_load_public_key(e, key_id, ui_method, callback_data);
+}
+int OpenSSLLib::SSL_ENGINE_ctrl_cmd_string(ENGINE* e,
+                                           const char* cmd_name,
+                                           const char* cmd_arg,
+                                           int cmd_optional) noexcept
+{
+    return ENGINE_ctrl_cmd_string(e, cmd_name, cmd_arg, cmd_optional);
+}
+int OpenSSLLib::SSL_ENGINE_init(ENGINE* e) noexcept { return ENGINE_init(e); }
+ENGINE* OpenSSLLib::SSL_ENGINE_by_id(const char* id) noexcept { return ENGINE_by_id(id); }
+int OpenSSLLib::SSL_ENGINE_finish(ENGINE* e) noexcept { return ENGINE_finish(e); }
+int OpenSSLLib::SSL_ENGINE_free(ENGINE* e) noexcept { return ENGINE_free(e); }
 }  // namespace lib
 }  // namespace openssl
 }  // namespace mococrw

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -1,7 +1,7 @@
 /*
  * #%L
  * %%
- * Copyright (C) 2018 BMW Car IT GmbH
+ * Copyright (C) 2022 BMW Car IT GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1555,6 +1555,46 @@ std::vector<uint8_t> _EVP_derive_key(const EVP_PKEY *peerkey, const EVP_PKEY *ke
             lib::OpenSSLLib::SSL_EVP_PKEY_derive, ctx.get(), result.data(), &secret_len);
 
     return result;
+}
+
+SSL_ENGINE_Ptr _ENGINE_by_id(const std::string &engineId)
+{
+    return SSL_ENGINE_Ptr{
+            OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_ENGINE_by_id, engineId.c_str())};
+}
+
+void _ENGINE_init(ENGINE *e) { OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_ENGINE_init, e); }
+
+void _ENGINE_ctrl_cmd_string(ENGINE *e, const std::string &cmdName, const std::string &cmdArg)
+{
+    OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_ENGINE_ctrl_cmd_string,
+                                  e,
+                                  cmdName.c_str(),
+                                  cmdArg.c_str(),
+                                  0 /*non-optional cmd */);
+}
+
+SSL_EVP_PKEY_Ptr _ENGINE_load_private_key(ENGINE *e, const std::string &keyId)
+{
+    /* For now, we do not support the passing of user-interface methods and callback_data.
+     * Instead, nullptr is provided for these parameters.
+     */
+    return SSL_EVP_PKEY_Ptr{OpensslCallPtr::callChecked(
+            lib::OpenSSLLib::SSL_ENGINE_load_private_key, e, keyId.c_str(), nullptr, nullptr)};
+}
+
+SSL_EVP_PKEY_Ptr _ENGINE_load_public_key(ENGINE *e, const std::string &keyId)
+{
+    /* For now, we do not support the passing of user-interface methods and callback_data.
+     * Instead, nullptr is provided for these parameters.
+     */
+    return SSL_EVP_PKEY_Ptr{OpensslCallPtr::callChecked(
+            lib::OpenSSLLib::SSL_ENGINE_load_public_key, e, keyId.c_str(), nullptr, nullptr)};
+}
+
+void _ENGINE_finish(ENGINE *e)
+{
+    OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_ENGINE_finish, e);
 }
 
 }  // namespace openssl

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -1,7 +1,7 @@
 /*
  * #%L
  * %%
- * Copyright (C) 2018 BMW Car IT GmbH
+ * Copyright (C) 2022 BMW Car IT GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1152,6 +1152,46 @@ int OpenSSLLib::SSL_EVP_CIPHER_key_length(const EVP_CIPHER* cipher) noexcept
 const char* OpenSSLLib::SSL_EVP_CIPHER_name(const EVP_CIPHER* cipher) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_name(cipher);
+}
+EVP_PKEY* OpenSSLLib::SSL_ENGINE_load_private_key(ENGINE* e,
+                                                  const char* key_id,
+                                                  UI_METHOD* ui_method,
+                                                  void* callback_data) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_load_private_key(
+            e, key_id, ui_method, callback_data);
+}
+EVP_PKEY* OpenSSLLib::SSL_ENGINE_load_public_key(ENGINE* e,
+                                                 const char* key_id,
+                                                 UI_METHOD* ui_method,
+                                                 void* callback_data) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_load_public_key(
+            e, key_id, ui_method, callback_data);
+}
+int OpenSSLLib::SSL_ENGINE_ctrl_cmd_string(ENGINE* e,
+                                           const char* cmd_name,
+                                           const char* cmd_arg,
+                                           int cmd_optional) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_ctrl_cmd_string(
+            e, cmd_name, cmd_arg, cmd_optional);
+}
+int OpenSSLLib::SSL_ENGINE_init(ENGINE* e) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_init(e);
+}
+ENGINE* OpenSSLLib::SSL_ENGINE_by_id(const char* id) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_by_id(id);
+}
+int OpenSSLLib::SSL_ENGINE_finish(ENGINE* e) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_finish(e);
+}
+int OpenSSLLib::SSL_ENGINE_free(ENGINE* e) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_free(e);
 }
 }  // namespace lib
 }  // namespace openssl

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -1,7 +1,7 @@
 /*
  * #%L
  * %%
- * Copyright (C) 2018 BMW Car IT GmbH
+ * Copyright (C) 2022 BMW Car IT GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,22 @@ namespace openssl
 class OpenSSLLibMockInterface
 {
 public:
+    virtual int SSL_ENGINE_free(ENGINE* e) = 0;
+    virtual int SSL_ENGINE_finish(ENGINE* e) = 0;
+    virtual ENGINE* SSL_ENGINE_by_id(const char* id) = 0;
+    virtual int SSL_ENGINE_init(ENGINE* e) = 0;
+    virtual int SSL_ENGINE_ctrl_cmd_string(ENGINE* e,
+                                           const char* cmd_name,
+                                           const char* cmd_arg,
+                                           int cmd_optional) = 0;
+    virtual EVP_PKEY* SSL_ENGINE_load_public_key(ENGINE* e,
+                                                 const char* key_id,
+                                                 UI_METHOD* ui_method,
+                                                 void* callback_data) = 0;
+    virtual EVP_PKEY* SSL_ENGINE_load_private_key(ENGINE* e,
+                                                  const char* key_id,
+                                                  UI_METHOD* ui_method,
+                                                  void* callback_data) = 0;
     virtual const char* SSL_EVP_CIPHER_name(const EVP_CIPHER* cipher) = 0;
     virtual int SSL_EVP_CIPHER_key_length(const EVP_CIPHER* cipher) = 0;
     virtual int SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) = 0;
@@ -397,6 +413,13 @@ public:
 class OpenSSLLibMock : public OpenSSLLibMockInterface
 {
 public:
+    MOCK_METHOD1(SSL_ENGINE_free, int(ENGINE*));
+    MOCK_METHOD1(SSL_ENGINE_finish, int(ENGINE*));
+    MOCK_METHOD1(SSL_ENGINE_by_id, ENGINE*(const char*));
+    MOCK_METHOD1(SSL_ENGINE_init, int(ENGINE*));
+    MOCK_METHOD4(SSL_ENGINE_ctrl_cmd_string, int(ENGINE*, const char*, const char*, int));
+    MOCK_METHOD4(SSL_ENGINE_load_public_key, EVP_PKEY*(ENGINE*, const char*, UI_METHOD*, void*));
+    MOCK_METHOD4(SSL_ENGINE_load_private_key, EVP_PKEY*(ENGINE*, const char*, UI_METHOD*, void*));
     MOCK_METHOD1(SSL_EVP_CIPHER_name, const char*(const EVP_CIPHER*));
     MOCK_METHOD1(SSL_EVP_CIPHER_key_length, int(const EVP_CIPHER*));
     MOCK_METHOD3(SSL_BN_bn2binpad, int(const BIGNUM*, unsigned char*, int));

--- a/tests/unit/test_opensslwrapper.cpp
+++ b/tests/unit/test_opensslwrapper.cpp
@@ -63,6 +63,20 @@ EVP_PKEY_CTX* somePkeyCtxPtr()
     static char dummyBuf[42] = {};
     return reinterpret_cast<EVP_PKEY_CTX*>(&dummyBuf);
 }
+
+EVP_PKEY* somePkeyPtr()
+{
+    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
+    static char dummyBuf[42] = {};
+    return reinterpret_cast<EVP_PKEY*>(&dummyBuf);
+}
+
+ENGINE* someEnginePtr()
+{
+    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
+    static char dummyBuf[42] = {};
+    return reinterpret_cast<ENGINE*>(&dummyBuf);
+}
 }  // namespace testutils
 
 void OpenSSLWrapperTest::SetUp()
@@ -218,4 +232,111 @@ TEST_F(OpenSSLWrapperTest, testThatX509ParsingThrowsOnNullptr)
     EXPECT_CALL(_mock(), SSL_PEM_read_bio_X509(bio, nullptr, nullptr, nullptr))
             .WillOnce(Return(nullptr));
     EXPECT_THROW(_PEM_read_bio_X509(bio), OpenSSLException);
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineById)
+{
+    std::string id = "engine_id";
+    EXPECT_CALL(_mock(), SSL_ENGINE_by_id(id.c_str()))
+            .WillOnce(Return(::testutils::someEnginePtr()));
+    EXPECT_NO_THROW(_ENGINE_by_id(id));
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineByIdThrowsException)
+{
+    std::string id = "engine_id";
+    EXPECT_CALL(_mock(), SSL_ENGINE_by_id(id.c_str())).WillOnce(Return(nullptr));
+    EXPECT_THROW(_ENGINE_by_id(id), OpenSSLException);
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineInit)
+{
+    auto engine = ::testutils::someEnginePtr();
+    EXPECT_CALL(_mock(), SSL_ENGINE_init(engine)).WillOnce(Return(1));
+    EXPECT_NO_THROW(_ENGINE_init(engine));
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineInitThrowsException)
+{
+    auto engine = ::testutils::someEnginePtr();
+    EXPECT_CALL(_mock(), SSL_ENGINE_init(engine)).WillOnce(Return(0));
+    EXPECT_THROW(_ENGINE_init(engine), OpenSSLException);
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineCtrlCmd)
+{
+    auto engine = ::testutils::someEnginePtr();
+    std::string cmd = "command";
+    std::string cmdArg = "command_arg";
+
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_ctrl_cmd_string(engine, cmd.c_str(), cmdArg.c_str(), 0 /*non-optional*/))
+            .WillOnce(Return(1));
+    EXPECT_NO_THROW(_ENGINE_ctrl_cmd_string(engine, cmd, cmdArg));
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineCtrlCmdiThrowsException)
+{
+    auto engine = ::testutils::someEnginePtr();
+    std::string cmd = "command";
+    std::string cmdArg = "command_arg";
+
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_ctrl_cmd_string(engine, cmd.c_str(), cmdArg.c_str(), 0 /*non-optional*/))
+            .WillOnce(Return(0));
+    EXPECT_THROW(_ENGINE_ctrl_cmd_string(engine, cmd, cmdArg), OpenSSLException);
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineLoadPublicKey)
+{
+    auto engine = ::testutils::someEnginePtr();
+    std::string keyId = "keyid";
+
+    EXPECT_CALL(_mock(), SSL_ENGINE_load_public_key(engine, keyId.c_str(), nullptr, nullptr))
+            .WillOnce(Return(::testutils::somePkeyPtr()));
+    EXPECT_NO_THROW(_ENGINE_load_public_key(engine, keyId));
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineLoadPublicKeyThrowsException)
+{
+    auto engine = ::testutils::someEnginePtr();
+    std::string keyId = "keyid";
+
+    EXPECT_CALL(_mock(), SSL_ENGINE_load_public_key(engine, keyId.c_str(), nullptr, nullptr))
+            .WillOnce(Return(nullptr));
+    EXPECT_THROW(_ENGINE_load_public_key(engine, keyId), OpenSSLException);
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineLoadPrivateKey)
+{
+    auto engine = ::testutils::someEnginePtr();
+    std::string keyId = "keyid";
+
+    EXPECT_CALL(_mock(), SSL_ENGINE_load_private_key(engine, keyId.c_str(), nullptr, nullptr))
+            .WillOnce(Return(::testutils::somePkeyPtr()));
+    EXPECT_NO_THROW(_ENGINE_load_private_key(engine, keyId));
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineLoadPrivateKeyThrowsException)
+{
+    auto engine = ::testutils::someEnginePtr();
+    std::string keyId = "keyid";
+
+    EXPECT_CALL(_mock(), SSL_ENGINE_load_private_key(engine, keyId.c_str(), nullptr, nullptr))
+            .WillOnce(Return(nullptr));
+    EXPECT_THROW(_ENGINE_load_private_key(engine, keyId), OpenSSLException);
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineFinish)
+{
+    auto engine = ::testutils::someEnginePtr();
+    EXPECT_CALL(_mock(), SSL_ENGINE_finish(engine)).WillOnce(Return(1));
+    EXPECT_NO_THROW(_ENGINE_finish(engine));
+}
+
+TEST_F(OpenSSLWrapperTest, testEngineFinishThrowsException)
+{
+    auto engine = ::testutils::someEnginePtr();
+    EXPECT_CALL(_mock(), SSL_ENGINE_finish(engine)).WillOnce(Return(0));
+    EXPECT_THROW(_ENGINE_finish(engine), OpenSSLException);
 }


### PR DESCRIPTION
Registers important OpenSSL's Engine API Functions to MoCOCrW's lowest level, namely openssl_lib.h. This will enable such functions to be then be wrapped and used by MoCOCrW in future PRs.