### PR TITLE
Add P11 API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,8 @@ if(HSM_ENABLED)
   set(LIBRARY_SOURCES
       ${LIBRARY_SOURCES}
       hsm.cpp
+      p11_lib.cpp
+      p11_wrap.cpp
   )
 endif()
 
@@ -77,6 +79,8 @@ if(HSM_ENABLED)
   set(LIBRARY_PUBLIC_HEADERS
       ${LIBRARY_PUBLIC_HEADERS}
       mococrw/hsm.h
+      mococrw/p11_lib.h
+      mococrw/p11_wrap.h
   )
 endif()
 

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -114,8 +114,11 @@ struct SSLFree
  * An Exception for OpenSSL errors.
  *
  * This exception is thrown by all methods when an OpenSSL error occurs.
+ *
+ * It is also the parent class of other exception types, including
+ * P11Exception.
  */
-class OpenSSLException final : public std::exception
+class OpenSSLException : public std::exception
 {
 public:
     template <class StringType>

--- a/src/mococrw/p11_lib.h
+++ b/src/mococrw/p11_lib.h
@@ -1,0 +1,85 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#pragma once
+
+extern "C" {
+#include <libp11.h>
+}
+
+namespace mococrw
+{
+namespace p11
+{
+namespace lib
+{
+/**
+ * Thin wrapper around the "naked" P11 library (namely libp11).
+ *
+ * Prefix all method names with 'P11_' to distinguish them from their
+ * LibP11 counterparts.
+ */
+class LibP11
+{
+public:
+    /* Initialisation */
+    static PKCS11_CTX *P11_PKCS11_CTX_new(void) noexcept;
+    static int P11_PKCS11_CTX_load(PKCS11_CTX *ctx, const char *ident) noexcept;
+
+    /* Slot and Token Management */
+    static int P11_PKCS11_enumerate_slots(PKCS11_CTX *ctx,
+                                          PKCS11_SLOT **slotsp,
+                                          unsigned int *nslotsp) noexcept;
+    static void P11_PKCS11_release_all_slots(PKCS11_CTX *ctx,
+                                             PKCS11_SLOT *slots,
+                                             unsigned int nslots) noexcept;
+    static PKCS11_SLOT *P11_PKCS11_find_token(PKCS11_CTX *ctx,
+                                              PKCS11_SLOT *slots,
+                                              unsigned int nslots) noexcept;
+
+    /* Session and Login */
+    static int P11_PKCS11_open_session(PKCS11_SLOT *slot, int rw) noexcept;
+    static int P11_PKCS11_login(PKCS11_SLOT *slot, int so, const char *pin) noexcept;
+    static int P11_PKCS11_logout(PKCS11_SLOT *slot) noexcept;
+    static int P11_PKCS11_is_logged_in(PKCS11_SLOT *slot, int so, int *res) noexcept;
+
+    /* Key Management */
+    static int P11_PKCS11_store_private_key(PKCS11_TOKEN *token,
+                                            EVP_PKEY *pk,
+                                            char *label,
+                                            unsigned char *id,
+                                            size_t id_len) noexcept;
+    static int P11_PKCS11_store_public_key(PKCS11_TOKEN *token,
+                                           EVP_PKEY *pk,
+                                           char *label,
+                                           unsigned char *id,
+                                           size_t id_len) noexcept;
+    static int P11_PKCS11_generate_key(PKCS11_TOKEN *token,
+                                       int algorithm,
+                                       unsigned int bits,
+                                       char *label,
+                                       unsigned char *id,
+                                       size_t id_len) noexcept;
+
+    /* Clean-up Functions */
+    static void P11_PKCS11_CTX_unload(PKCS11_CTX *ctx) noexcept;
+    static void P11_PKCS11_CTX_free(PKCS11_CTX *ctx) noexcept;
+};
+}  // namespace lib
+}  // namespace p11
+}  // namespace mococrw

--- a/src/mococrw/p11_wrap.h
+++ b/src/mococrw/p11_wrap.h
@@ -110,7 +110,7 @@ public:
     /**
      * Finds the slot of a token on the HSM.
      */
-    P11_PKCS11_SLOT_SharedPtr findSlot();
+    P11_PKCS11_SLOT_SharedPtr findFirstSlot();
 
 private:
     P11_PKCS11_CTX_SharedPtr _ctx;             // The context associated with the slot information.

--- a/src/mococrw/p11_wrap.h
+++ b/src/mococrw/p11_wrap.h
@@ -1,0 +1,227 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#pragma once
+
+#include "p11_lib.h"
+#include "util.h"
+
+namespace mococrw
+{
+namespace p11
+{
+/**
+ * Template to wrap OpenSSLs "_free" functions
+ * into a functor so that a std::unique_ptr
+ * can use them.
+ */
+template <class R, class P, R(Func)(P *)>
+struct P11Deleter
+{
+    template <class T>
+    void operator()(T *ptr) const noexcept
+    {
+        if (ptr) {
+            Func(ptr);
+        }
+    }
+};
+
+/**
+ * An Exception for LibP11 errors.
+ *
+ * This exception is thrown by all methods when an OpenSSL error occurs.
+ */
+class P11Exception final : public std::exception
+{
+public:
+    template <class StringType>
+    explicit P11Exception(StringType &&message) : _message{std::forward<StringType>(message)}
+    {
+    }
+
+    /**
+     * Generate an exception with the defalt LibP11 error-string
+     * as message.
+     *
+     */
+    P11Exception() : _message{generateP11ErrorString()} {}
+
+    const char *what() const noexcept override { return _message.c_str(); }
+
+private:
+    static std::string generateP11ErrorString();
+    std::string _message;
+};
+
+/*
+ * Wrap all the pointer-types returned by LibP11.
+ */
+
+using P11_PKCS11_CTX_Ptr =
+        std::unique_ptr<PKCS11_CTX, P11Deleter<void, PKCS11_CTX, lib::LibP11::P11_PKCS11_CTX_free>>;
+
+/*
+ * The memory referred to by these pointer types live out of scope of their pointers.
+ * Therefore, simply wrap the C pointer, without use of smart pointer (this is a bit ugly).
+ */
+using P11_PKCS11_SLOT_PTR = PKCS11_SLOT *;
+using P11_PKCS11_TOKEN_PTR = PKCS11_TOKEN *;
+
+/* Below is the "wrapped" LibP11 library. By convention, all functions start with an
+ * underscore to visually distinguish them from the methods of the class P11Lib and
+ * from the native LibP11 methods.
+ */
+
+/**
+ * Returns a new PKCS11 context for HSM interaction.
+ */
+P11_PKCS11_CTX_Ptr _PKCS11_CTX_new(void);
+
+/**
+ * Loads the PKCS11 module to use.
+ *
+ * @param ctx The current context obtained via _PKCS11_CTX_new().
+ * @param module The PKCS#11 module filename.
+ */
+void _PKCS11_CTX_load(PKCS11_CTX *ctx, const std::string &module);
+
+struct P11_SlotInfo
+{
+    PKCS11_SLOT *_slots;     // Array consisting of slot descriptors on the HSM.
+    unsigned int _numSlots;  // The size of the array, i.e., the number of slots.
+
+    P11_SlotInfo();
+    P11_SlotInfo(PKCS11_SLOT *slots, unsigned int numSlots);
+};
+
+/**
+ * Obtains information of all current slots on the HSM.
+ *
+ * @param ctx The current context obtained via _PKCS11_CTX_new().
+ */
+P11_SlotInfo _PKCS11_enumerate_slots(PKCS11_CTX *ctx);
+
+/**
+ * Destroys slot information obtained by _PKCS11_enumerate_slots().
+ *
+ * @param ctx The current context obtained via _PKCS11_CTX_new().
+ * @param slotInfo The slot-list information to destroy.
+ */
+void _PKCS11_release_all_slots(PKCS11_CTX *ctx, P11_SlotInfo &slotInfo);
+
+/**
+ * Finds a token on the HSM according to the passed slot information \p slotInfo.
+ *
+ * @param ctx The current context obtained via _PKCS11_CTX_new().
+ * @param slotInfo Slot information obtained via _PKCS11_enumerate_slots().
+ */
+P11_PKCS11_SLOT_PTR _PKCS11_find_token(PKCS11_CTX *ctx, P11_SlotInfo &slotInfo);
+
+/**
+ * Returns the token descriptor associated with \p slot.
+ *
+ * @param slot The slot of the returned token.
+ */
+P11_PKCS11_TOKEN_PTR _PKCS11_getTokenFromSlot(PKCS11_SLOT *slot);
+
+enum SessionMode { ReadOnly = 0, ReadWrite = 1 };
+
+/**
+ * Opens a sessions with the passed \p slot.
+ *
+ * @param slot The slot to open session with.
+ * @param rw Whether to open the session in read/write mode. Set to != 0
+ * if read/write mode is required.
+ */
+void _PKCS11_open_session(PKCS11_SLOT *slot, SessionMode mode);
+
+/**
+ * Performs a user login to the HSM.
+ *
+ * @param slot The slot to consider for login.
+ * @param pin The pin to perform the login.
+ *
+ * \note This function performs a user login and not an SO login.
+ */
+void _PKCS11_login(PKCS11_SLOT *slot, const std::string &pin);
+
+/**
+ * Performs a user logout from the HSM.
+ *
+ * @param slot The slot logout from.
+ *
+ * \note This function only performs a user logout, and not an SO logout.
+ */
+void _PKCS11_logout(PKCS11_SLOT *slot);
+
+/**
+ * Returns true if a user is currently logged in.
+ *
+ * @param slot The slot to check login status.
+ */
+bool _PKCS11_is_logged_in(PKCS11_SLOT *slot);
+
+/**
+ * Stores a private key inside the HSM.
+ *
+ * @param token The token used to store the private key.
+ * @param pk The key to store.
+ * @param label The label of the key to store.
+ * @param id The ID of the key to store.
+ */
+void _PKCS11_store_private_key(PKCS11_TOKEN *token,
+                               EVP_PKEY *pk,
+                               const std::string &label,
+                               const std::string &id);
+
+/**
+ * Stores a public key inside the HSM.
+ *
+ * @param token The token used to store the public key.
+ * @param pk The key to store.
+ * @param label The label of the key to store.
+ * @param id The ID of the key to store.
+ */
+void _PKCS11_store_public_key(PKCS11_TOKEN *token,
+                              EVP_PKEY *pk,
+                              const std::string &label,
+                              const std::string &id);
+
+/**
+ * Generates a key inside the HSM.
+ *
+ * @param token The token used to generate the key.
+ * @param bits The size of the modulus in bits.
+ * @param label The label of the generated key.
+ * @param id The ID of the generated key.
+ *
+ * \note Due to limited support offered by LibP11, this function only generates RSA keys.
+ */
+void _PKCS11_generate_key(PKCS11_TOKEN *token,
+                          unsigned int bits,
+                          const std::string &label,
+                          const std::string &id);
+
+/**
+ * Unloads the PKCS11 module.
+ */
+void _PKCS11_CTX_unload(PKCS11_CTX *ctx);
+
+}  // namespace p11
+}  // namespace mococrw

--- a/src/p11_lib.cpp
+++ b/src/p11_lib.cpp
@@ -1,0 +1,120 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/*
+ * This file is the only place where we should see any
+ * "vanilla" LibP11 methods whatsoever. Any other
+ * translation unit should use the methods exposed via
+ * P11Lib.
+ *
+ * Moreover, the methods exposed by P11Lib should only
+ * be used in p11_wrap.cpp and p11_wrap.h.
+ *
+ */
+
+#include "mococrw/p11_lib.h"
+
+namespace mococrw
+{
+namespace p11
+{
+namespace lib
+{
+/* The implementation of P11Lib class members.
+ *
+ *
+ * Any method here simply forwards to an equivalent LibP11 method
+ */
+
+PKCS11_CTX *LibP11::P11_PKCS11_CTX_new(void) noexcept { return PKCS11_CTX_new(); }
+
+int LibP11::P11_PKCS11_CTX_load(PKCS11_CTX *ctx, const char *ident) noexcept
+{
+    return PKCS11_CTX_load(ctx, ident);
+}
+
+int LibP11::P11_PKCS11_enumerate_slots(PKCS11_CTX *ctx,
+                                       PKCS11_SLOT **slotsp,
+                                       unsigned int *nslotsp) noexcept
+{
+    return PKCS11_enumerate_slots(ctx, slotsp, nslotsp);
+}
+
+void LibP11::P11_PKCS11_release_all_slots(PKCS11_CTX *ctx,
+                                          PKCS11_SLOT *slots,
+                                          unsigned int nslots) noexcept
+{
+    PKCS11_release_all_slots(ctx, slots, nslots);
+}
+
+PKCS11_SLOT *LibP11::P11_PKCS11_find_token(PKCS11_CTX *ctx,
+                                           PKCS11_SLOT *slots,
+                                           unsigned int nslots) noexcept
+{
+    return PKCS11_find_token(ctx, slots, nslots);
+}
+
+/* Session and Login */
+int LibP11::P11_PKCS11_open_session(PKCS11_SLOT *slot, int rw) noexcept
+{
+    return PKCS11_open_session(slot, rw);
+}
+
+int LibP11::P11_PKCS11_login(PKCS11_SLOT *slot, int so, const char *pin) noexcept
+{
+    return PKCS11_login(slot, so, pin);
+}
+
+int LibP11::P11_PKCS11_logout(PKCS11_SLOT *slot) noexcept { return PKCS11_logout(slot); }
+
+int LibP11::P11_PKCS11_is_logged_in(PKCS11_SLOT *slot, int so, int *res) noexcept
+{
+    return PKCS11_is_logged_in(slot, so, res);
+}
+
+/* Key Management */
+int LibP11::P11_PKCS11_store_private_key(
+        PKCS11_TOKEN *token, EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len) noexcept
+{
+    return PKCS11_store_private_key(token, pk, label, id, id_len);
+}
+
+int LibP11::P11_PKCS11_store_public_key(
+        PKCS11_TOKEN *token, EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len) noexcept
+{
+    return PKCS11_store_public_key(token, pk, label, id, id_len);
+}
+
+int LibP11::P11_PKCS11_generate_key(PKCS11_TOKEN *token,
+                                    int algorithm,
+                                    unsigned int bits,
+                                    char *label,
+                                    unsigned char *id,
+                                    size_t id_len) noexcept
+{
+    return PKCS11_generate_key(token, algorithm, bits, label, id, id_len);
+}
+
+void LibP11::P11_PKCS11_CTX_unload(PKCS11_CTX *ctx) noexcept { PKCS11_CTX_unload(ctx); }
+
+void LibP11::P11_PKCS11_CTX_free(PKCS11_CTX *ctx) noexcept { PKCS11_CTX_free(ctx); }
+
+}  // namespace lib
+}  // namespace p11
+}  // namespace mococrw

--- a/src/p11_wrap.cpp
+++ b/src/p11_wrap.cpp
@@ -93,13 +93,14 @@ void P11SlotInfo::SlotListDeleter::operator()(PKCS11_SLOT *slotList)
     lib::LibP11::P11_PKCS11_release_all_slots(_ctx.get(), slotList, _numSlots);
 }
 
-P11_PKCS11_SLOT_SharedPtr P11SlotInfo::findSlot()
+P11_PKCS11_SLOT_SharedPtr P11SlotInfo::findFirstSlot()
 {
     auto raw_slot = P11CallPtr::callChecked(
             lib::LibP11::P11_PKCS11_find_token, _ctx.get(), _slotList.get(), _numSlots);
 
     // The memory of the slot is owned by the slot list. Therefore, use shared pointer's alias
-    // constructor.
+    // constructor. This prevents the list from being destroyed until the the created shared pointer
+    // of the slot becomes out-of-scope.
     return P11_PKCS11_SLOT_SharedPtr(_slotList, raw_slot);
 }
 

--- a/src/p11_wrap.cpp
+++ b/src/p11_wrap.cpp
@@ -1,0 +1,283 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/*
+ * This file is the only place where we should see any
+ * methods from LibP11. Any other code should use
+ * the more high-level methods declared and define in
+ * p11_wrap.cpp and p11_wrap.h.
+ *
+ */
+
+#include <boost/algorithm/hex.hpp>
+#include <cassert>
+#include <cstddef> /* this has to come before cppc (bug in boost) */
+#include <exception>
+
+#include <cppc/checkcall.hpp>
+#include "mococrw/openssl_wrap.h"
+#include "mococrw/p11_wrap.h"
+
+namespace mococrw
+{
+namespace p11
+{
+std::string P11Exception::generateP11ErrorString()
+{
+    // Note, pkcs11_CTX_new() internally loads LibP11 error strings,
+    // i.e., it invokes ERR_load_PKCS11_strings(). We therefore
+    // don't trigger the loading ourselves.
+    auto error = openssl::lib::OpenSSLLib::SSL_ERR_get_error();
+    auto formatter = boost::format("%s: %d");
+    formatter % openssl::lib::OpenSSLLib::SSL_ERR_error_string(error, nullptr) % error;
+    return formatter.str();
+}
+
+/**
+ * This struct is used by CWrap to
+ * determine how to react to an error
+ * when performing a LibP11 call.
+ */
+struct P11ExceptionErrorPolicy
+{
+    template <class Rv>
+    static void handleError(const Rv &);
+};
+
+/**
+ * Throw a P11 exception upon error.
+ *
+ * This method gets the error string and throws an exception
+ * with the corresponding message.
+ */
+template <class Rv>
+void P11ExceptionErrorPolicy::handleError(const Rv & /* unused */)
+{
+    throw P11Exception();
+}
+
+using P11CallPtr =
+        ::cppc::CallCheckContext<::cppc::IsNotNullptrReturnCheckPolicy, P11ExceptionErrorPolicy>;
+using P11IsNonNegative =
+        ::cppc::CallCheckContext<::cppc::IsNotNegativeReturnCheckPolicy, P11ExceptionErrorPolicy>;
+
+P11_SlotInfo::P11_SlotInfo() : _slots(nullptr), _numSlots(0) {}
+
+P11_SlotInfo::P11_SlotInfo(PKCS11_SLOT *slots, unsigned int numSlots)
+        : _slots(slots), _numSlots(numSlots)
+{
+}
+
+static std::string parseID(const std::string &idHexString)
+{
+    /* We require IDs to be represented as hex strings from the user.
+     * Libp11 does the necessary pre-processing, such as unhexing, on IDs
+     * only when invoked via OpenSSL's Engine API. However, when interacting directly
+     * with LibP11 API, like we do here, this pre-processing is not performed. To make
+     * matters worse, LibP11 does not export its internal
+     * pre-processing function. We therefore begin to re-implement it here.
+     */
+    auto parsedID = boost::algorithm::unhex(idHexString);
+    return parsedID;
+}
+
+P11_PKCS11_CTX_Ptr _PKCS11_CTX_new(void)
+{
+    return P11_PKCS11_CTX_Ptr{P11CallPtr::callChecked(lib::LibP11::P11_PKCS11_CTX_new)};
+}
+
+void _PKCS11_CTX_load(PKCS11_CTX *ctx, const std::string &module)
+{
+    P11IsNonNegative::callChecked(lib::LibP11::P11_PKCS11_CTX_load, ctx, module.c_str());
+}
+
+void _PKCS11_CTX_unload(PKCS11_CTX *ctx)
+{
+    if (ctx == nullptr) {
+        throw P11Exception("NULL passed for context that is required to be unloaded");
+    }
+    lib::LibP11::P11_PKCS11_CTX_unload(ctx);
+}
+
+P11_SlotInfo _PKCS11_enumerate_slots(PKCS11_CTX *ctx)
+{
+    if (ctx == nullptr) {
+        throw P11Exception("NULL passed for context when enumerating slots");
+    }
+
+    PKCS11_SLOT *slotsp;
+    unsigned int nslotsp;
+    P11IsNonNegative::callChecked(lib::LibP11::P11_PKCS11_enumerate_slots, ctx, &slotsp, &nslotsp);
+
+    // Based on the information obtained by slot enumaration, we instantiate
+    // a corresponding P11_SlotInfo object as a return value.
+    P11_SlotInfo slotInfo(slotsp, nslotsp);
+    return slotInfo;
+}
+
+void _PKCS11_release_all_slots(PKCS11_CTX *ctx, P11_SlotInfo &slotInfo)
+{
+    if (ctx == nullptr) {
+        throw P11Exception("NULL passed for context when releaseing slots");
+    }
+
+    if (slotInfo._slots == nullptr) {
+        throw P11Exception("NULL list when releaseing slots");
+    }
+
+    lib::LibP11::P11_PKCS11_release_all_slots(ctx, slotInfo._slots, slotInfo._numSlots);
+
+    // Finally, clear the object to remove dangling information.
+    slotInfo._slots = nullptr;
+    slotInfo._numSlots = 0;
+}
+
+P11_PKCS11_SLOT_PTR _PKCS11_find_token(PKCS11_CTX *ctx, P11_SlotInfo &slotInfo)
+{
+    if (ctx == nullptr) {
+        throw P11Exception("NULL passed for ctx");
+    }
+
+    return P11CallPtr::callChecked(
+            lib::LibP11::P11_PKCS11_find_token, ctx, slotInfo._slots, slotInfo._numSlots);
+}
+
+P11_PKCS11_TOKEN_PTR _PKCS11_getTokenFromSlot(PKCS11_SLOT *slot)
+{
+    if (slot == nullptr) {
+        throw P11Exception("Cannot retrieve token from NULL slot pointer");
+    }
+
+    // Simply obtain the token via the slot's data structure.
+    P11_PKCS11_TOKEN_PTR token = slot->token;
+    if (token == nullptr) {
+        throw P11Exception("Cannot get token. Slot not associated with token");
+    }
+
+    return token;
+}
+
+void _PKCS11_open_session(PKCS11_SLOT *slot, SessionMode mode)
+{
+    if (slot == nullptr) {
+        throw P11Exception("Cannot open session from NULL slot pointer");
+    }
+
+    P11IsNonNegative::callChecked(
+            lib::LibP11::P11_PKCS11_open_session, slot, mode /* Denotes read/write mode. */);
+}
+
+void _PKCS11_login(PKCS11_SLOT *slot, const std::string &pin)
+{
+    if (slot == nullptr) {
+        throw P11Exception("Cannot login from NULL slot pointer");
+    }
+
+    if (_PKCS11_is_logged_in(slot)) {
+        throw P11Exception("Mismatch detected; user already logged in");
+    }
+
+    P11IsNonNegative::callChecked(
+            lib::LibP11::P11_PKCS11_login, slot, 0 /* Always login as normal user. */, pin.c_str());
+}
+
+void _PKCS11_logout(PKCS11_SLOT *slot)
+{
+    if (slot == nullptr) {
+        throw P11Exception("Cannot logout from NULL slot pointer");
+    }
+
+    if (!_PKCS11_is_logged_in(slot)) {
+        throw P11Exception("Mismatch detected; user not logged in to perform logout");
+    }
+
+    P11IsNonNegative::callChecked(lib::LibP11::P11_PKCS11_logout, slot);
+}
+
+bool _PKCS11_is_logged_in(PKCS11_SLOT *slot)
+{
+    if (slot == nullptr) {
+        throw P11Exception("Cannot check login from NULL slot pointer");
+    }
+
+    int result;
+    P11IsNonNegative::callChecked(
+            lib::LibP11::P11_PKCS11_is_logged_in, slot, 0 /* Check normal user. */, &result);
+
+    // Result is 1 if logged in.
+    return result == 1;
+}
+
+void _PKCS11_store_private_key(PKCS11_TOKEN *token,
+                               EVP_PKEY *pk,
+                               const std::string &label,
+                               const std::string &id)
+{
+    std::string parsedStrID = parseID(id);
+    unsigned char *parsedID =
+            reinterpret_cast<unsigned char *>(const_cast<char *>(parsedStrID.c_str()));
+
+    P11IsNonNegative::callChecked(lib::LibP11::P11_PKCS11_store_private_key,
+                                  token,
+                                  pk,
+                                  const_cast<char *>(label.c_str()),
+                                  parsedID,
+                                  parsedStrID.size());
+}
+
+void _PKCS11_store_public_key(PKCS11_TOKEN *token,
+                              EVP_PKEY *pk,
+                              const std::string &label,
+                              const std::string &id)
+{
+    auto parsedStrID = parseID(id);
+    unsigned char *parsedID =
+            reinterpret_cast<unsigned char *>(const_cast<char *>(parsedStrID.c_str()));
+
+    P11IsNonNegative::callChecked(lib::LibP11::P11_PKCS11_store_public_key,
+                                  token,
+                                  pk,
+                                  const_cast<char *>(label.c_str()),
+                                  parsedID,
+                                  parsedStrID.size());
+}
+
+void _PKCS11_generate_key(PKCS11_TOKEN *token,
+                          unsigned int bits,
+                          const std::string &label,
+                          const std::string &id)
+{
+    std::string parsedStrID = parseID(id);
+    unsigned char *parsedID =
+            reinterpret_cast<unsigned char *>(const_cast<char *>(parsedStrID.c_str()));
+
+    // Note, PKCS11_generate_key() function only generates RSA keys.
+    // It is deprecated but no alternative has been implemented yet.
+    // See: https://github.com/OpenSC/libp11/pull/378
+    P11IsNonNegative::callChecked(lib::LibP11::P11_PKCS11_generate_key,
+                                  token,
+                                  0 /* Currently, algorithm is ignored by LibP11. */,
+                                  bits,
+                                  const_cast<char *>(label.c_str()),
+                                  parsedID,
+                                  parsedStrID.size());
+}
+
+}  // namespace p11
+}  // namespace mococrw

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -275,6 +275,27 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
 	COMMAND eciestests
     )
 
+    if(HSM_ENABLED)
+        message(STATUS "HSM features are enabled. Building hsm-related tests")
+
+        set(HSM_LIB_SOURCES "${SRC_DIR}/p11_wrap.cpp" ${REAL_SOURCES})
+        set(HSM_MOCK_SOURCES "p11_lib_mock.cpp" ${HSM_LIB_SOURCES})
+        set(HSM_REAL_SOURCES "${SRC_DIR}/p11_lib.cpp" ${HSM_LIB_SOURCES})
+
+        add_executable(p11test test_p11wrapper.cpp ${HSM_MOCK_SOURCES})
+
+        target_link_libraries(p11test ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
+            OpenSSL::Crypto OpenSSL::SSL LibP11::P11 Boost::boost)
+        target_include_directories(p11test PUBLIC ${LIBP11_INCLUDE_DIR})
+
+        add_test(
+            NAME P11Test
+            COMMAND p11test
+        )
+    else()
+        message(WARNING "HSM features are disabled. Not building HSM-related tests")
+    endif()
+
     # Configure valgrind
     find_program(MEMORYCHECK_COMMAND NAMES valgrind)
     set(_ARGS "--leak-check=full --track-origins=yes")

--- a/tests/unit/p11_lib_mock.cpp
+++ b/tests/unit/p11_lib_mock.cpp
@@ -109,11 +109,6 @@ int LibP11::P11_PKCS11_logout(PKCS11_SLOT *slot) noexcept
     return LibP11MockManager::getMockInterface().P11_PKCS11_logout(slot);
 }
 
-int LibP11::P11_PKCS11_is_logged_in(PKCS11_SLOT *slot, int so, int *res) noexcept
-{
-    return LibP11MockManager::getMockInterface().P11_PKCS11_is_logged_in(slot, so, res);
-}
-
 /* Key Management */
 int LibP11::P11_PKCS11_store_private_key(
         PKCS11_TOKEN *token, EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len) noexcept

--- a/tests/unit/p11_lib_mock.cpp
+++ b/tests/unit/p11_lib_mock.cpp
@@ -58,14 +58,9 @@ void LibP11MockManager::destroy()
 namespace lib
 {
 /**
- * Provide implementations for the OpenSSLLib members that forward
+ * Provide implementations for the LibP11 members that forward
  * to the mock object.
- *
- * This translation unit is inserted into the bulid process for unit-tests
- * via CMake. The library gets these definitions from a corresponding class
- * in the src-dir.
  */
-// TODO unit test the initialization
 
 PKCS11_CTX *LibP11::P11_PKCS11_CTX_new(void) noexcept
 {

--- a/tests/unit/p11_lib_mock.cpp
+++ b/tests/unit/p11_lib_mock.cpp
@@ -1,0 +1,160 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <cstddef>
+
+#include <gmock/gmock.h>
+
+#include "mococrw/p11_wrap.h"
+#include "p11_lib_mock.h"
+
+namespace mococrw
+{
+namespace p11
+{
+std::unique_ptr<::testing::NiceMock<LibP11Mock>> LibP11MockManager::_mock{nullptr};
+std::mutex LibP11MockManager::_mutex{};
+
+/*
+ * If there is no mock yet, we create a new one.
+ */
+testing::NiceMock<LibP11Mock> &LibP11MockManager::getMockInterface()
+{
+    if (!_mock) {
+        resetMock();
+    }
+
+    return *_mock;
+}
+
+void LibP11MockManager::resetMock()
+{
+    std::lock_guard<std::mutex> _lock(_mutex);
+    _mock = std::make_unique<::testing::NiceMock<LibP11Mock>>();
+}
+
+void LibP11MockManager::destroy()
+{
+    std::lock_guard<std::mutex> _lock(_mutex);
+    // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
+    _mock.reset();
+}
+
+namespace lib
+{
+/**
+ * Provide implementations for the OpenSSLLib members that forward
+ * to the mock object.
+ *
+ * This translation unit is inserted into the bulid process for unit-tests
+ * via CMake. The library gets these definitions from a corresponding class
+ * in the src-dir.
+ */
+// TODO unit test the initialization
+
+PKCS11_CTX *LibP11::P11_PKCS11_CTX_new(void) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_CTX_new();
+}
+
+int LibP11::P11_PKCS11_CTX_load(PKCS11_CTX *ctx, const char *ident) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_CTX_load(ctx, ident);
+}
+
+int LibP11::P11_PKCS11_enumerate_slots(PKCS11_CTX *ctx,
+                                       PKCS11_SLOT **slotsp,
+                                       unsigned int *nslotsp) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_enumerate_slots(ctx, slotsp, nslotsp);
+}
+
+void LibP11::P11_PKCS11_release_all_slots(PKCS11_CTX *ctx,
+                                          PKCS11_SLOT *slots,
+                                          unsigned int nslots) noexcept
+{
+    LibP11MockManager::getMockInterface().P11_PKCS11_release_all_slots(ctx, slots, nslots);
+}
+
+PKCS11_SLOT *LibP11::P11_PKCS11_find_token(PKCS11_CTX *ctx,
+                                           PKCS11_SLOT *slots,
+                                           unsigned int nslots) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_find_token(ctx, slots, nslots);
+}
+
+/* Session and Login */
+int LibP11::P11_PKCS11_open_session(PKCS11_SLOT *slot, int rw) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_open_session(slot, rw);
+}
+
+int LibP11::P11_PKCS11_login(PKCS11_SLOT *slot, int so, const char *pin) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_login(slot, so, pin);
+}
+
+int LibP11::P11_PKCS11_logout(PKCS11_SLOT *slot) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_logout(slot);
+}
+
+int LibP11::P11_PKCS11_is_logged_in(PKCS11_SLOT *slot, int so, int *res) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_is_logged_in(slot, so, res);
+}
+
+/* Key Management */
+int LibP11::P11_PKCS11_store_private_key(
+        PKCS11_TOKEN *token, EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_store_private_key(
+            token, pk, label, id, id_len);
+}
+
+int LibP11::P11_PKCS11_store_public_key(
+        PKCS11_TOKEN *token, EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_store_public_key(
+            token, pk, label, id, id_len);
+}
+
+int LibP11::P11_PKCS11_generate_key(PKCS11_TOKEN *token,
+                                    int algorithm,
+                                    unsigned int bits,
+                                    char *label,
+                                    unsigned char *id,
+                                    size_t id_len) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_generate_key(
+            token, algorithm, bits, label, id, id_len);
+}
+
+void LibP11::P11_PKCS11_CTX_unload(PKCS11_CTX *ctx) noexcept
+{
+    LibP11MockManager::getMockInterface().P11_PKCS11_CTX_unload(ctx);
+}
+
+void LibP11::P11_PKCS11_CTX_free(PKCS11_CTX *ctx) noexcept
+{
+    return LibP11MockManager::getMockInterface().P11_PKCS11_CTX_free(ctx);
+}
+
+}  // namespace lib
+}  // namespace p11
+}  // namespace mococrw

--- a/tests/unit/p11_lib_mock.h
+++ b/tests/unit/p11_lib_mock.h
@@ -123,7 +123,7 @@ public:
  * inside static members of this class.
  *
  * This gets rid of the need for a singleton and all
- * the realted problems.
+ * the related problems.
  */
 class LibP11MockManager
 {

--- a/tests/unit/p11_lib_mock.h
+++ b/tests/unit/p11_lib_mock.h
@@ -1,0 +1,158 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#pragma once
+
+#include <memory>
+#include <mutex>
+
+#include "mococrw/p11_lib.h"
+
+namespace mococrw
+{
+namespace p11
+{
+/**
+ * Gmock interface.
+ *
+ * Gmock requires a virtual interface.
+ */
+class LibP11MockInterface
+{
+public:
+    virtual ~LibP11MockInterface() = default;
+
+    /* Initialisation */
+    virtual PKCS11_CTX *P11_PKCS11_CTX_new(void) = 0;
+    virtual int P11_PKCS11_CTX_load(PKCS11_CTX *ctx, const char *ident) = 0;
+
+    /* Slot and Token Management */
+    virtual int P11_PKCS11_enumerate_slots(PKCS11_CTX *ctx,
+                                           PKCS11_SLOT **slotsp,
+                                           unsigned int *nslotsp) = 0;
+    virtual void P11_PKCS11_release_all_slots(PKCS11_CTX *ctx,
+                                              PKCS11_SLOT *slots,
+                                              unsigned int nslots) = 0;
+    virtual PKCS11_SLOT *P11_PKCS11_find_token(PKCS11_CTX *ctx,
+                                               PKCS11_SLOT *slots,
+                                               unsigned int nslots) = 0;
+
+    /* Session and Login */
+    virtual int P11_PKCS11_open_session(PKCS11_SLOT *slot, int rw) = 0;
+    virtual int P11_PKCS11_login(PKCS11_SLOT *slot, int so, const char *pin) = 0;
+    virtual int P11_PKCS11_logout(PKCS11_SLOT *slot) = 0;
+    virtual int P11_PKCS11_is_logged_in(PKCS11_SLOT *slot, int so, int *res) = 0;
+
+    /* Key Management */
+    virtual int P11_PKCS11_store_private_key(
+            PKCS11_TOKEN *token, EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len) = 0;
+    virtual int P11_PKCS11_store_public_key(
+            PKCS11_TOKEN *token, EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len) = 0;
+    virtual int P11_PKCS11_generate_key(PKCS11_TOKEN *token,
+                                        int algorithm,
+                                        unsigned int bits,
+                                        char *label,
+                                        unsigned char *id,
+                                        size_t id_len) = 0;
+
+    /* Clean-up Functions */
+    virtual void P11_PKCS11_CTX_unload(PKCS11_CTX *ctx) = 0;
+    virtual void P11_PKCS11_CTX_free(PKCS11_CTX *ctx) = 0;
+};
+
+/**
+ * GMock class to mock the above interface.
+ *
+ */
+class LibP11Mock : public LibP11MockInterface
+{
+public:
+    MOCK_METHOD0(P11_PKCS11_CTX_new, PKCS11_CTX *(void));
+    MOCK_METHOD2(P11_PKCS11_CTX_load, int(PKCS11_CTX *ctx, const char *ident));
+
+    MOCK_METHOD3(P11_PKCS11_enumerate_slots,
+                 int(PKCS11_CTX *ctx, PKCS11_SLOT **slotsp, unsigned int *nslotsp));
+    MOCK_METHOD3(P11_PKCS11_release_all_slots,
+                 void(PKCS11_CTX *ctx, PKCS11_SLOT *slots, unsigned int nslots));
+    MOCK_METHOD3(P11_PKCS11_find_token,
+                 PKCS11_SLOT *(PKCS11_CTX *ctx, PKCS11_SLOT *slots, unsigned int nslots));
+
+    /* Session and Login */
+    MOCK_METHOD2(P11_PKCS11_open_session, int(PKCS11_SLOT *slot, int rw));
+    MOCK_METHOD3(P11_PKCS11_login, int(PKCS11_SLOT *slot, int so, const char *pin));
+    MOCK_METHOD1(P11_PKCS11_logout, int(PKCS11_SLOT *slot));
+    MOCK_METHOD3(P11_PKCS11_is_logged_in, int(PKCS11_SLOT *slot, int so, int *res));
+
+    /* Key Management */
+    MOCK_METHOD5(
+            P11_PKCS11_store_private_key,
+            int(PKCS11_TOKEN *token, EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len));
+    MOCK_METHOD5(
+            P11_PKCS11_store_public_key,
+            int(PKCS11_TOKEN *token, EVP_PKEY *pk, char *label, unsigned char *id, size_t id_len));
+    MOCK_METHOD6(P11_PKCS11_generate_key,
+                 int(PKCS11_TOKEN *token,
+                     int algorithm,
+                     unsigned int bits,
+                     char *label,
+                     unsigned char *id,
+                     size_t id_len));
+
+    /* Clean-up Functions */
+    MOCK_METHOD1(P11_PKCS11_CTX_unload, void(PKCS11_CTX *ctx));
+    MOCK_METHOD1(P11_PKCS11_CTX_free, void(PKCS11_CTX *ctx));
+};
+
+/**
+ * Wrap instances of the LibP11Mock
+ * inside static members of this class.
+ *
+ * This gets rid of the need for a singleton and all
+ * the realted problems.
+ */
+class LibP11MockManager
+{
+public:
+    /**
+     * Access the P11LibMock instance currently
+     * maintained. Create a new one, if none is present.
+     */
+    static ::testing::NiceMock<LibP11Mock> &getMockInterface();
+
+    /**
+     * Reset the current LibP11Mock instance
+     * maintained within this class.
+     */
+    static void resetMock();
+
+    /**
+     * Destroy current mock object to trigger gmock call analysis
+     */
+    static void destroy();
+
+private:
+    static std::unique_ptr<::testing::NiceMock<LibP11Mock>> _mock;
+
+    /* Unsure how much parallization happens with regard to the tests
+     * but let's be safe
+     */
+    static std::mutex _mutex;
+};
+
+}  // namespace p11
+}  // namespace mococrw

--- a/tests/unit/test_p11wrapper.cpp
+++ b/tests/unit/test_p11wrapper.cpp
@@ -207,7 +207,7 @@ void P11WrapperTest::testFindSlotHelper(PKCS11_CTX *context,
                         ::testutils::somePKCS11CtxPtr(), ::testutils::somePKCS11SlotPtr(), 1))
             .WillOnce(Return(retSlot));
 
-    slotInfo->findSlot();
+    slotInfo->findFirstSlot();
 }
 
 /* Test P11_PKCS11_find_token() with bad return value. */

--- a/tests/unit/test_p11wrapper.cpp
+++ b/tests/unit/test_p11wrapper.cpp
@@ -1,0 +1,403 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+
+#include "mococrw/p11_wrap.h"
+#include "p11_lib_mock.h"
+
+using namespace ::mococrw::p11;
+using namespace ::std::string_literals;
+
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::DoAll;
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+/**
+ * Test the P11 wrapper.
+ *
+ * These tests are to determine that the p11-wrapper,
+ * declared and defined in p11_wrap.h and p11_wrap.cpp
+ * behaves as intended and calls the underlying p11 library
+ * correctly.
+ *
+ */
+class P11WrapperTest : public ::testing::Test
+{
+public:
+    void SetUp() override;
+    void TearDown() override;
+
+protected:
+    LibP11Mock &_mock() const { return LibP11MockManager::getMockInterface(); }
+};
+
+namespace testutils
+{
+PKCS11_CTX *somePKCS11CtxPtr()
+{
+    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
+    static char dummyBuf[42] = {};
+    return reinterpret_cast<PKCS11_CTX *>(&dummyBuf);
+}
+
+PKCS11_SLOT *somePKCS11SlotPtr()
+{
+    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
+    static char dummyBuf[42] = {};
+    return reinterpret_cast<PKCS11_SLOT *>(&dummyBuf);
+}
+
+PKCS11_TOKEN *somePKCS11TokenPtr()
+{
+    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
+    static char dummyBuf[42] = {};
+    return reinterpret_cast<PKCS11_TOKEN *>(&dummyBuf);
+}
+
+EVP_PKEY *someEVP_PKEY()
+{
+    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
+    static char dummyBuf[42] = {};
+    return reinterpret_cast<EVP_PKEY *>(&dummyBuf);
+}
+
+}  // namespace testutils
+
+void P11WrapperTest::SetUp() { LibP11MockManager::resetMock(); }
+
+void P11WrapperTest::TearDown() { LibP11MockManager::destroy(); }
+
+/* Test that exception is triggered if P11_PKCS11_CTX_new()
+ * returns NULL.
+ */
+TEST_F(P11WrapperTest, badInitPKCS11Ctx)
+{
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_new()).WillOnce(Return(nullptr));
+
+    EXPECT_THROW(_PKCS11_CTX_new(), P11Exception);
+}
+
+/* Test successful _PKCS11_CTX_new(). */
+TEST_F(P11WrapperTest, goodInitPKCS11Ctx)
+{
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_new()).WillOnce(Return(::testutils::somePKCS11CtxPtr()));
+
+    /* Since we wrap in a unique_ptr, expect a call to the "free" function */
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_free(::testutils::somePKCS11CtxPtr()));
+
+    EXPECT_NO_THROW(_PKCS11_CTX_new());
+}
+
+/* Test failed _PKCS11_CTX_load(). */
+TEST_F(P11WrapperTest, badPKCS11Load)
+{
+    std::string test = "test";
+
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_load(nullptr, test.c_str())).WillOnce(Return(-1));
+
+    EXPECT_THROW(_PKCS11_CTX_load(nullptr, test), P11Exception);
+}
+
+/* Test successful _PKCS11_CTX_load(). */
+TEST_F(P11WrapperTest, goodPKCS11Load)
+{
+    std::string test = "test";
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_load(::testutils::somePKCS11CtxPtr(), test.c_str()))
+            .WillOnce(Return(0));
+
+    EXPECT_NO_THROW(_PKCS11_CTX_load(::testutils::somePKCS11CtxPtr(), test));
+}
+
+/* Test  _PKCS11_enumerate_slots() with NULL context. */
+TEST_F(P11WrapperTest, badSlotEnumeration)
+{
+    EXPECT_THROW(_PKCS11_enumerate_slots(nullptr), P11Exception);
+}
+
+/* Test _PKCS11_enumerate_slots with valid context. */
+TEST_F(P11WrapperTest, goodSlotEnumeration)
+{
+    EXPECT_CALL(_mock(), P11_PKCS11_enumerate_slots(::testutils::somePKCS11CtxPtr(), _, _))
+            .WillOnce(Return(0));
+
+    EXPECT_NO_THROW(_PKCS11_enumerate_slots(::testutils::somePKCS11CtxPtr()));
+}
+
+/* Test _PKCS11_release_all_slots() with NULL context. */
+TEST_F(P11WrapperTest, badSlotRelease)
+{
+    P11_SlotInfo slotInfo(::testutils::somePKCS11SlotPtr(), 2);
+    EXPECT_THROW(_PKCS11_release_all_slots(nullptr, slotInfo), P11Exception);
+}
+
+/* Test _PKCS11_release_all_slots() with bad slot information. */
+TEST_F(P11WrapperTest, badSlotRelease2)
+{
+    P11_SlotInfo slotInfo;
+    EXPECT_THROW(_PKCS11_release_all_slots(::testutils::somePKCS11CtxPtr(), slotInfo),
+                 P11Exception);
+}
+
+/* Test successful _PKCS11_release_all_slots().
+ */
+TEST_F(P11WrapperTest, goodSlotRelease)
+{
+    P11_SlotInfo slotInfo(::testutils::somePKCS11SlotPtr(), 2);
+
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_release_all_slots(
+                        ::testutils::somePKCS11CtxPtr(), slotInfo._slots, slotInfo._numSlots))
+            .WillOnce(Return());
+
+    EXPECT_NO_THROW(_PKCS11_release_all_slots(::testutils::somePKCS11CtxPtr(), slotInfo));
+}
+
+/* Test _PKCS11_find_token() with NULL PKCS11 context. */
+TEST_F(P11WrapperTest, badSlotFinding)
+{
+    P11_SlotInfo slotInfo(::testutils::somePKCS11SlotPtr(), 2);
+    EXPECT_THROW(_PKCS11_find_token(nullptr, slotInfo), P11Exception);
+}
+
+/* Test P11_PKCS11_find_token() with bad value. */
+TEST_F(P11WrapperTest, badSlotFinding2)
+{
+    P11_SlotInfo slotInfo(::testutils::somePKCS11SlotPtr(), 2);
+
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_find_token(
+                        ::testutils::somePKCS11CtxPtr(), slotInfo._slots, slotInfo._numSlots))
+            .WillOnce(Return(nullptr));
+
+    EXPECT_THROW(_PKCS11_find_token(::testutils::somePKCS11CtxPtr(), slotInfo), P11Exception);
+}
+
+/* Test successful P11_PKCS11_find_token(). */
+TEST_F(P11WrapperTest, goodSlotFinding)
+{
+    P11_SlotInfo slotInfo(::testutils::somePKCS11SlotPtr(), 2);
+
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_find_token(
+                        ::testutils::somePKCS11CtxPtr(), slotInfo._slots, slotInfo._numSlots))
+            .WillOnce(Return(::testutils::somePKCS11SlotPtr()));
+
+    EXPECT_NO_THROW(_PKCS11_find_token(::testutils::somePKCS11CtxPtr(), slotInfo));
+}
+
+/* Test _PKCS11_open_session() with NULL slot pointer. */
+TEST_F(P11WrapperTest, badOpenSession)
+{
+    EXPECT_THROW(_PKCS11_open_session(nullptr, SessionMode::ReadWrite), P11Exception);
+}
+
+/* Test _PKCS11_open_session() with error return value. */
+TEST_F(P11WrapperTest, badOpenSession2)
+{
+    EXPECT_CALL(_mock(), P11_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), 1))
+            .WillOnce(Return(-1));
+
+    EXPECT_THROW(_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), SessionMode::ReadWrite),
+                 P11Exception);
+}
+
+/* Test successful _PKCS11_open_session(). */
+TEST_F(P11WrapperTest, goodOpenSession)
+{
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), SessionMode::ReadWrite))
+            .WillOnce(Return(0));
+
+    EXPECT_NO_THROW(_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), SessionMode::ReadWrite));
+}
+
+/* Test successful _PKCS11_open_session() without write permissions. */
+TEST_F(P11WrapperTest, goodOpenSession2)
+{
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), SessionMode::ReadOnly))
+            .WillOnce(Return(0));
+
+    EXPECT_NO_THROW(_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), SessionMode::ReadOnly));
+}
+
+/* Test _PKCS11_login() with NULL slot pointer. */
+TEST_F(P11WrapperTest, badLogin)
+{
+    std::string pin = "1002";
+    EXPECT_THROW(_PKCS11_login(nullptr, pin), P11Exception);
+}
+
+/* Test _PKCS11_login() with error return value. */
+TEST_F(P11WrapperTest, badLogin2)
+{
+    std::string pin = "1002";
+
+    EXPECT_CALL(_mock(), P11_PKCS11_login(::testutils::somePKCS11SlotPtr(), 0, _))
+            .WillOnce(Return(-1));
+
+    EXPECT_THROW(_PKCS11_login(::testutils::somePKCS11SlotPtr(), pin), P11Exception);
+}
+
+/* Test successful _PKCS11_login(). */
+TEST_F(P11WrapperTest, goodLogin)
+{
+    std::string pin = "1002";
+
+    EXPECT_CALL(_mock(), P11_PKCS11_login(::testutils::somePKCS11SlotPtr(), 0, _))
+            .WillOnce(Return(0));
+
+    EXPECT_NO_THROW(_PKCS11_login(::testutils::somePKCS11SlotPtr(), pin));
+}
+
+/* Test _PKCS11_login() with NULL slot pointer. */
+TEST_F(P11WrapperTest, badLogout) { EXPECT_THROW(_PKCS11_logout(nullptr), P11Exception); }
+
+/* Test _PKCS11_logout() with error return value. */
+TEST_F(P11WrapperTest, badLogout2)
+{
+    EXPECT_CALL(_mock(), P11_PKCS11_logout(::testutils::somePKCS11SlotPtr())).WillOnce(Return(-1));
+
+    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr(), 0, _))
+            .WillOnce(DoAll(SetArgPointee<2>(1), Return(0)));
+
+    EXPECT_THROW(_PKCS11_logout(::testutils::somePKCS11SlotPtr()), P11Exception);
+}
+
+/* Test successful _PKCS11_logout(). */
+TEST_F(P11WrapperTest, goodLogout)
+{
+    EXPECT_CALL(_mock(), P11_PKCS11_logout(::testutils::somePKCS11SlotPtr())).WillOnce(Return(0));
+
+    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr(), 0, _))
+            .WillOnce(DoAll(SetArgPointee<2>(1), Return(0)));
+
+    EXPECT_NO_THROW(_PKCS11_logout(::testutils::somePKCS11SlotPtr()));
+}
+
+/* Test _PKCS11_is_logged_in() with error return value. */
+TEST_F(P11WrapperTest, badIsLogin)
+{
+    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr(), 0, _))
+            .WillOnce(DoAll(SetArgPointee<2>(1), Return(-1)));
+
+    EXPECT_THROW(_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr()), P11Exception);
+}
+
+/* Test successful _PKCS11_is_logged_in() with true for login. */
+TEST_F(P11WrapperTest, goodTrueIsLogin)
+{
+    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr(), 0, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(1), Return(0)));
+
+    EXPECT_NO_THROW(_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr()));
+    EXPECT_TRUE(_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr()));
+}
+
+/* Test successful _PKCS11_is_logged_in() with false for login. */
+TEST_F(P11WrapperTest, goodFalseIsLogin)
+{
+    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr(), 0, _))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(0), Return(0)));
+
+    EXPECT_NO_THROW(_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr()));
+    EXPECT_FALSE(_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr()));
+}
+
+/* Test _PKCS11_store_private_key() with error return value. */
+TEST_F(P11WrapperTest, badPrivStore)
+{
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_store_private_key(
+                        ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), _, _, _))
+            .WillOnce(Return(-1));
+
+    EXPECT_THROW(_PKCS11_store_private_key(::testutils::somePKCS11TokenPtr(),
+                                           ::testutils::someEVP_PKEY(),
+                                           "label",
+                                           "1001"),
+                 P11Exception);
+}
+
+/* Test successful _PKCS11_store_private_key(). */
+TEST_F(P11WrapperTest, goodPrivStore)
+{
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_store_private_key(
+                        ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), _, _, _))
+            .WillOnce(Return(0));
+
+    EXPECT_NO_THROW(_PKCS11_store_private_key(
+            ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), "label", "1001"));
+}
+
+/* Test _PKCS11_store_public_key() with error return value. */
+TEST_F(P11WrapperTest, badPubStore)
+{
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_store_public_key(
+                        ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), _, _, _))
+            .WillOnce(Return(-1));
+
+    EXPECT_THROW(_PKCS11_store_public_key(::testutils::somePKCS11TokenPtr(),
+                                          ::testutils::someEVP_PKEY(),
+                                          "label",
+                                          "1001"),
+                 P11Exception);
+}
+
+/* Test successful _PKCS11_store_public_key(). */
+TEST_F(P11WrapperTest, goodPubStore)
+{
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_store_public_key(
+                        ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), _, _, _))
+            .WillOnce(Return(0));
+
+    EXPECT_NO_THROW(_PKCS11_store_public_key(
+            ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), "label", "1001"));
+}
+
+/* Test _PKCS11_generate_key() with error return value. */
+TEST_F(P11WrapperTest, badKeyGen)
+{
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_generate_key(::testutils::somePKCS11TokenPtr(), _, 2048, _, _, _))
+            .WillOnce(Return(-1));
+
+    EXPECT_THROW(_PKCS11_generate_key(::testutils::somePKCS11TokenPtr(), 2048, "label", "1001"),
+                 P11Exception);
+}
+
+/* Test successful _PKCS11_generate_key(). */
+TEST_F(P11WrapperTest, goodKeyGen)
+{
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_generate_key(::testutils::somePKCS11TokenPtr(), _, 2048, _, _, _))
+            .WillOnce(Return(0));
+
+    EXPECT_NO_THROW(_PKCS11_generate_key(::testutils::somePKCS11TokenPtr(), 2048, "label", "1001"));
+}

--- a/tests/unit/test_p11wrapper.cpp
+++ b/tests/unit/test_p11wrapper.cpp
@@ -25,6 +25,8 @@
 #include "mococrw/p11_wrap.h"
 #include "p11_lib_mock.h"
 
+#include <boost/core/null_deleter.hpp>
+
 using namespace ::mococrw::p11;
 using namespace ::std::string_literals;
 
@@ -52,29 +54,49 @@ public:
 
 protected:
     LibP11Mock &_mock() const { return LibP11MockManager::getMockInterface(); }
+
+    // Helper functions to avoid code duplication:
+    void testGoodOpenSessionHelper(int rawMode, SessionMode mode);
+    P11_SlotInfo testCreateSlotInfoHelper(PKCS11_CTX *context,
+                                          PKCS11_SLOT *slotsp,
+                                          unsigned int nslotsp,
+                                          int retVal);
+    void testFindSlotHelper(PKCS11_CTX *context, PKCS11_SLOT *slot, PKCS11_SLOT *retSlot);
+    void testIsLoginHelper(PKCS11_SLOT *rawSlot, int isLoggedIn, int retVal);
+    P11_Session testCreateSessionHelper(PKCS11_SLOT *someSlot,
+                                        std::string &pin,
+                                        SessionMode mode,
+                                        int loginRetVal);
+    void testPrivStoreHelper(SessionMode mode, int retVal);
+    void testPubStoreHelper(SessionMode mode, int retVal);
+    void testKeyGenHelper(SessionMode mode, int retVal);
 };
 
 namespace testutils
 {
+// The following some* functions return dummy pointers, which are never dereferenced and
+// are just required to get several tests going:
+
 PKCS11_CTX *somePKCS11CtxPtr()
 {
-    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
+    /* Reserve some memory and cast a pointer to that ; the pointer will not be dereferenced */
     static char dummyBuf[42] = {};
     return reinterpret_cast<PKCS11_CTX *>(&dummyBuf);
 }
 
-PKCS11_SLOT *somePKCS11SlotPtr()
-{
-    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
-    static char dummyBuf[42] = {};
-    return reinterpret_cast<PKCS11_SLOT *>(&dummyBuf);
-}
-
 PKCS11_TOKEN *somePKCS11TokenPtr()
 {
-    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
+    /* Reserve some memory and cast a pointer to that ; the pointers will not be dereferenced */
     static char dummyBuf[42] = {};
     return reinterpret_cast<PKCS11_TOKEN *>(&dummyBuf);
+}
+
+PKCS11_SLOT *somePKCS11SlotPtr()
+{
+    /* Reserve some memory and cast a pointer to that */
+    static PKCS11_SLOT slot = {};
+    slot.token = somePKCS11TokenPtr();
+    return reinterpret_cast<PKCS11_SLOT *>(&slot);
 }
 
 EVP_PKEY *someEVP_PKEY()
@@ -93,311 +115,310 @@ void P11WrapperTest::TearDown() { LibP11MockManager::destroy(); }
 /* Test that exception is triggered if P11_PKCS11_CTX_new()
  * returns NULL.
  */
-TEST_F(P11WrapperTest, badInitPKCS11Ctx)
+TEST_F(P11WrapperTest, badCreatePKCS11Ctx)
 {
-    EXPECT_CALL(_mock(), P11_PKCS11_CTX_new()).WillOnce(Return(nullptr));
+    std::string mod = "test_mod";
 
-    EXPECT_THROW(_PKCS11_CTX_new(), P11Exception);
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_new()).WillOnce(Return(nullptr));
+    EXPECT_THROW(_PKCS11_CTX_create(mod), P11Exception);
 }
 
-/* Test successful _PKCS11_CTX_new(). */
-TEST_F(P11WrapperTest, goodInitPKCS11Ctx)
+/* Test that exception is triggered if P11_PKCS11_CTX_load()
+ * fails.
+ */
+TEST_F(P11WrapperTest, badCreatePKCS11Ctx2)
 {
-    EXPECT_CALL(_mock(), P11_PKCS11_CTX_new()).WillOnce(Return(::testutils::somePKCS11CtxPtr()));
+    std::string mod = "test_mod";
 
-    /* Since we wrap in a unique_ptr, expect a call to the "free" function */
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_new()).WillOnce(Return(::testutils::somePKCS11CtxPtr()));
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_load(::testutils::somePKCS11CtxPtr(), mod.c_str()))
+            .WillOnce(Return(-1));
+    // Should be called to free the allocated ctx.
     EXPECT_CALL(_mock(), P11_PKCS11_CTX_free(::testutils::somePKCS11CtxPtr()));
 
-    EXPECT_NO_THROW(_PKCS11_CTX_new());
+    EXPECT_THROW(_PKCS11_CTX_create(mod), P11Exception);
 }
 
-/* Test failed _PKCS11_CTX_load(). */
-TEST_F(P11WrapperTest, badPKCS11Load)
+/* Test successful _PKCS11_CTX_create(). */
+TEST_F(P11WrapperTest, goodCreatePKCS11Ctx)
 {
-    std::string test = "test";
+    std::string mod = "test_mod";
 
-    EXPECT_CALL(_mock(), P11_PKCS11_CTX_load(nullptr, test.c_str())).WillOnce(Return(-1));
-
-    EXPECT_THROW(_PKCS11_CTX_load(nullptr, test), P11Exception);
-}
-
-/* Test successful _PKCS11_CTX_load(). */
-TEST_F(P11WrapperTest, goodPKCS11Load)
-{
-    std::string test = "test";
-    EXPECT_CALL(_mock(), P11_PKCS11_CTX_load(::testutils::somePKCS11CtxPtr(), test.c_str()))
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_new()).WillOnce(Return(::testutils::somePKCS11CtxPtr()));
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_load(::testutils::somePKCS11CtxPtr(), mod.c_str()))
             .WillOnce(Return(0));
 
-    EXPECT_NO_THROW(_PKCS11_CTX_load(::testutils::somePKCS11CtxPtr(), test));
+    /* Since we wrap in a unique_ptr, expect a call to the "free" function */
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_unload(::testutils::somePKCS11CtxPtr()));
+    EXPECT_CALL(_mock(), P11_PKCS11_CTX_free(::testutils::somePKCS11CtxPtr()));
+
+    EXPECT_NO_THROW(_PKCS11_CTX_create(mod));
 }
 
-/* Test  _PKCS11_enumerate_slots() with NULL context. */
-TEST_F(P11WrapperTest, badSlotEnumeration)
+P11_SlotInfo P11WrapperTest::testCreateSlotInfoHelper(PKCS11_CTX *context,
+                                                      PKCS11_SLOT *slotsp,
+                                                      unsigned int nslotsp,
+                                                      int retVal)
 {
-    EXPECT_THROW(_PKCS11_enumerate_slots(nullptr), P11Exception);
+    auto ctx = P11_PKCS11_CTX_Ptr(context, boost::null_deleter());
+
+    EXPECT_CALL(_mock(), P11_PKCS11_enumerate_slots(context, _, _))
+            .WillOnce(DoAll(SetArgPointee<1>(slotsp), SetArgPointee<2>(nslotsp), Return(retVal)));
+
+    if (retVal == 0 && slotsp != nullptr) {
+        // If enumeration is successful, then we expect there to be a release upon slot list
+        // destruction.
+        EXPECT_CALL(_mock(), P11_PKCS11_release_all_slots(context, slotsp, nslotsp))
+                .WillOnce(Return());
+    }
+
+    return P11_SlotInfo(ctx);
 }
 
-/* Test _PKCS11_enumerate_slots with valid context. */
-TEST_F(P11WrapperTest, goodSlotEnumeration)
+/* Test bad creation of SlotInfo due to returned error value. */
+TEST_F(P11WrapperTest, badSlotInfoCreation)
 {
-    EXPECT_CALL(_mock(), P11_PKCS11_enumerate_slots(::testutils::somePKCS11CtxPtr(), _, _))
-            .WillOnce(Return(0));
-
-    EXPECT_NO_THROW(_PKCS11_enumerate_slots(::testutils::somePKCS11CtxPtr()));
-}
-
-/* Test _PKCS11_release_all_slots() with NULL context. */
-TEST_F(P11WrapperTest, badSlotRelease)
-{
-    P11_SlotInfo slotInfo(::testutils::somePKCS11SlotPtr(), 2);
-    EXPECT_THROW(_PKCS11_release_all_slots(nullptr, slotInfo), P11Exception);
-}
-
-/* Test _PKCS11_release_all_slots() with bad slot information. */
-TEST_F(P11WrapperTest, badSlotRelease2)
-{
-    P11_SlotInfo slotInfo;
-    EXPECT_THROW(_PKCS11_release_all_slots(::testutils::somePKCS11CtxPtr(), slotInfo),
+    EXPECT_THROW(P11WrapperTest::testCreateSlotInfoHelper(
+                         ::testutils::somePKCS11CtxPtr(), ::testutils::somePKCS11SlotPtr(), 1, -1),
                  P11Exception);
 }
 
-/* Test successful _PKCS11_release_all_slots().
- */
-TEST_F(P11WrapperTest, goodSlotRelease)
+/* Test bad creation of SlotInfo due to NULL slot list. */
+TEST_F(P11WrapperTest, badSlotInfoCreation2)
 {
-    P11_SlotInfo slotInfo(::testutils::somePKCS11SlotPtr(), 2);
-
-    EXPECT_CALL(_mock(),
-                P11_PKCS11_release_all_slots(
-                        ::testutils::somePKCS11CtxPtr(), slotInfo._slots, slotInfo._numSlots))
-            .WillOnce(Return());
-
-    EXPECT_NO_THROW(_PKCS11_release_all_slots(::testutils::somePKCS11CtxPtr(), slotInfo));
+    EXPECT_THROW(
+            {
+                try {
+                    testCreateSlotInfoHelper(::testutils::somePKCS11CtxPtr(), nullptr, 1, 0);
+                } catch (const P11Exception &e) {
+                    EXPECT_STREQ(P11Exception::nullSlotListExceptionString.c_str(), e.what());
+                    throw;
+                }
+            },
+            P11Exception);
 }
 
-/* Test _PKCS11_find_token() with NULL PKCS11 context. */
-TEST_F(P11WrapperTest, badSlotFinding)
+/* Test successful creation of SlotInfo */
+TEST_F(P11WrapperTest, goodSlotInfoCreation)
 {
-    P11_SlotInfo slotInfo(::testutils::somePKCS11SlotPtr(), 2);
-    EXPECT_THROW(_PKCS11_find_token(nullptr, slotInfo), P11Exception);
+    EXPECT_NO_THROW(P11WrapperTest::testCreateSlotInfoHelper(
+            ::testutils::somePKCS11CtxPtr(), ::testutils::somePKCS11SlotPtr(), 1, 0));
 }
 
-/* Test P11_PKCS11_find_token() with bad value. */
-TEST_F(P11WrapperTest, badSlotFinding2)
+void P11WrapperTest::testFindSlotHelper(PKCS11_CTX *context,
+                                        PKCS11_SLOT *slot,
+                                        PKCS11_SLOT *retSlot)
 {
-    P11_SlotInfo slotInfo(::testutils::somePKCS11SlotPtr(), 2);
+    auto slotInfo = P11WrapperTest::testCreateSlotInfoHelper(context, slot, 1, 0);
 
     EXPECT_CALL(_mock(),
                 P11_PKCS11_find_token(
-                        ::testutils::somePKCS11CtxPtr(), slotInfo._slots, slotInfo._numSlots))
-            .WillOnce(Return(nullptr));
+                        ::testutils::somePKCS11CtxPtr(), ::testutils::somePKCS11SlotPtr(), 1))
+            .WillOnce(Return(retSlot));
 
-    EXPECT_THROW(_PKCS11_find_token(::testutils::somePKCS11CtxPtr(), slotInfo), P11Exception);
+    slotInfo.findSlot();
+}
+
+/* Test P11_PKCS11_find_token() with bad return value. */
+TEST_F(P11WrapperTest, badSlotFinding)
+{
+    EXPECT_THROW(
+            testFindSlotHelper(
+                    ::testutils::somePKCS11CtxPtr(), ::testutils::somePKCS11SlotPtr(), nullptr),
+            P11Exception);
 }
 
 /* Test successful P11_PKCS11_find_token(). */
 TEST_F(P11WrapperTest, goodSlotFinding)
 {
-    P11_SlotInfo slotInfo(::testutils::somePKCS11SlotPtr(), 2);
-
-    EXPECT_CALL(_mock(),
-                P11_PKCS11_find_token(
-                        ::testutils::somePKCS11CtxPtr(), slotInfo._slots, slotInfo._numSlots))
-            .WillOnce(Return(::testutils::somePKCS11SlotPtr()));
-
-    EXPECT_NO_THROW(_PKCS11_find_token(::testutils::somePKCS11CtxPtr(), slotInfo));
+    EXPECT_NO_THROW(testFindSlotHelper(::testutils::somePKCS11CtxPtr(),
+                                       ::testutils::somePKCS11SlotPtr(),
+                                       ::testutils::somePKCS11SlotPtr()));
 }
 
-/* Test _PKCS11_open_session() with NULL slot pointer. */
+/* Test bad session creation due to P11_PKCS11_open_session() returning an error value. */
 TEST_F(P11WrapperTest, badOpenSession)
 {
-    EXPECT_THROW(_PKCS11_open_session(nullptr, SessionMode::ReadWrite), P11Exception);
-}
+    auto slot = P11_PKCS11_SLOT_PTR(::testutils::somePKCS11SlotPtr(), boost::null_deleter());
+    std::string pin = "1002";
+    SessionMode mode = ReadWrite;
 
-/* Test _PKCS11_open_session() with error return value. */
-TEST_F(P11WrapperTest, badOpenSession2)
-{
-    EXPECT_CALL(_mock(), P11_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), 1))
+    EXPECT_CALL(_mock(), P11_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), mode))
             .WillOnce(Return(-1));
 
-    EXPECT_THROW(_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), SessionMode::ReadWrite),
+    EXPECT_THROW(P11_Session(slot, pin, mode), P11Exception);
+}
+
+void P11WrapperTest::testIsLoginHelper(PKCS11_SLOT *rawSlot, int isLoggedIn, int retVal)
+{
+    auto slot = P11_PKCS11_SLOT_PTR(rawSlot, boost::null_deleter());
+    std::string pin = "1002";
+    SessionMode mode = ReadWrite;
+
+    EXPECT_CALL(_mock(), P11_PKCS11_open_session(rawSlot, mode)).WillOnce(Return(0));
+
+    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(rawSlot, 0, _))
+            .WillOnce(DoAll(SetArgPointee<2>(isLoggedIn), Return(retVal)));
+
+    P11_Session(slot, pin, mode);
+}
+
+/* Test bad session creation due to P11_PKCS11_is_logged_in() returning an error value. */
+TEST_F(P11WrapperTest, badIsLogin)
+{
+    EXPECT_THROW(testIsLoginHelper(::testutils::somePKCS11SlotPtr(), 0 /* not logged in */, -1),
                  P11Exception);
 }
 
-/* Test successful _PKCS11_open_session(). */
-TEST_F(P11WrapperTest, goodOpenSession)
+/* Test bad session creation due to login mismatch. */
+TEST_F(P11WrapperTest, badIsLogin2)
 {
-    EXPECT_CALL(_mock(),
-                P11_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), SessionMode::ReadWrite))
-            .WillOnce(Return(0));
-
-    EXPECT_NO_THROW(_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), SessionMode::ReadWrite));
+    EXPECT_THROW(
+            {
+                try {
+                    testIsLoginHelper(::testutils::somePKCS11SlotPtr(), 1 /* is logged in */, 0);
+                } catch (const P11Exception &e) {
+                    EXPECT_STREQ(P11Exception::mismatchLoginExceptionString.c_str(), e.what());
+                    throw;
+                }
+            },
+            P11Exception);
 }
 
-/* Test successful _PKCS11_open_session() without write permissions. */
-TEST_F(P11WrapperTest, goodOpenSession2)
+P11_Session P11WrapperTest::testCreateSessionHelper(PKCS11_SLOT *someSlot,
+                                                    std::string &pin,
+                                                    SessionMode mode,
+                                                    int loginRetVal)
 {
-    EXPECT_CALL(_mock(),
-                P11_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), SessionMode::ReadOnly))
-            .WillOnce(Return(0));
+    auto slot = P11_PKCS11_SLOT_PTR(someSlot, boost::null_deleter());
 
-    EXPECT_NO_THROW(_PKCS11_open_session(::testutils::somePKCS11SlotPtr(), SessionMode::ReadOnly));
+    EXPECT_CALL(_mock(), P11_PKCS11_open_session(someSlot, mode)).WillOnce(Return(0));
+
+    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(someSlot, 0 /* Not SO */, _))
+            .WillOnce(DoAll(SetArgPointee<2>(0), Return(0)))
+            .WillRepeatedly(DoAll(SetArgPointee<2>(1), Return(0)));
+
+    EXPECT_CALL(_mock(), P11_PKCS11_login(someSlot, 0 /* Not SO */, pin.c_str()))
+            .WillOnce(Return(loginRetVal));
+
+    if (loginRetVal == 0) {
+        // If login successful, we expect a logout upon session destruction.
+        EXPECT_CALL(_mock(), P11_PKCS11_logout(someSlot)).WillOnce(Return(0));
+    }
+
+    return P11_Session(slot, pin, mode);
 }
 
-/* Test _PKCS11_login() with NULL slot pointer. */
+/* Test bad session creation due to P11_PKCS11_login() returning an error value. */
 TEST_F(P11WrapperTest, badLogin)
 {
     std::string pin = "1002";
-    EXPECT_THROW(_PKCS11_login(nullptr, pin), P11Exception);
+    SessionMode mode = ReadWrite;
+
+    EXPECT_THROW(testCreateSessionHelper(::testutils::somePKCS11SlotPtr(), pin, mode, -1),
+                 P11Exception);
 }
 
-/* Test _PKCS11_login() with error return value. */
-TEST_F(P11WrapperTest, badLogin2)
+/* Test successful session creation with read/write mode. */
+TEST_F(P11WrapperTest, goodCreateSession)
 {
     std::string pin = "1002";
+    SessionMode mode = ReadWrite;
 
-    EXPECT_CALL(_mock(), P11_PKCS11_login(::testutils::somePKCS11SlotPtr(), 0, _))
-            .WillOnce(Return(-1));
-
-    EXPECT_THROW(_PKCS11_login(::testutils::somePKCS11SlotPtr(), pin), P11Exception);
+    EXPECT_NO_THROW(testCreateSessionHelper(::testutils::somePKCS11SlotPtr(), pin, mode, 0));
 }
 
-/* Test successful _PKCS11_login(). */
-TEST_F(P11WrapperTest, goodLogin)
+/* Test successful session creation without write permissions. */
+TEST_F(P11WrapperTest, goodCreatreSession2)
 {
     std::string pin = "1002";
+    SessionMode mode = ReadOnly;
 
-    EXPECT_CALL(_mock(), P11_PKCS11_login(::testutils::somePKCS11SlotPtr(), 0, _))
-            .WillOnce(Return(0));
-
-    EXPECT_NO_THROW(_PKCS11_login(::testutils::somePKCS11SlotPtr(), pin));
+    EXPECT_NO_THROW(testCreateSessionHelper(::testutils::somePKCS11SlotPtr(), pin, mode, 0));
 }
 
-/* Test _PKCS11_login() with NULL slot pointer. */
-TEST_F(P11WrapperTest, badLogout) { EXPECT_THROW(_PKCS11_logout(nullptr), P11Exception); }
-
-/* Test _PKCS11_logout() with error return value. */
-TEST_F(P11WrapperTest, badLogout2)
+void P11WrapperTest::testPrivStoreHelper(SessionMode mode, int retVal)
 {
-    EXPECT_CALL(_mock(), P11_PKCS11_logout(::testutils::somePKCS11SlotPtr())).WillOnce(Return(-1));
+    std::string pin = "1002";
+    P11_Session session = testCreateSessionHelper(::testutils::somePKCS11SlotPtr(), pin, mode, 0);
 
-    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr(), 0, _))
-            .WillOnce(DoAll(SetArgPointee<2>(1), Return(0)));
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_store_private_key(
+                        ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), _, _, _))
+            .WillOnce(Return(retVal));
 
-    EXPECT_THROW(_PKCS11_logout(::testutils::somePKCS11SlotPtr()), P11Exception);
-}
-
-/* Test successful _PKCS11_logout(). */
-TEST_F(P11WrapperTest, goodLogout)
-{
-    EXPECT_CALL(_mock(), P11_PKCS11_logout(::testutils::somePKCS11SlotPtr())).WillOnce(Return(0));
-
-    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr(), 0, _))
-            .WillOnce(DoAll(SetArgPointee<2>(1), Return(0)));
-
-    EXPECT_NO_THROW(_PKCS11_logout(::testutils::somePKCS11SlotPtr()));
-}
-
-/* Test _PKCS11_is_logged_in() with error return value. */
-TEST_F(P11WrapperTest, badIsLogin)
-{
-    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr(), 0, _))
-            .WillOnce(DoAll(SetArgPointee<2>(1), Return(-1)));
-
-    EXPECT_THROW(_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr()), P11Exception);
-}
-
-/* Test successful _PKCS11_is_logged_in() with true for login. */
-TEST_F(P11WrapperTest, goodTrueIsLogin)
-{
-    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr(), 0, _))
-            .WillRepeatedly(DoAll(SetArgPointee<2>(1), Return(0)));
-
-    EXPECT_NO_THROW(_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr()));
-    EXPECT_TRUE(_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr()));
-}
-
-/* Test successful _PKCS11_is_logged_in() with false for login. */
-TEST_F(P11WrapperTest, goodFalseIsLogin)
-{
-    EXPECT_CALL(_mock(), P11_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr(), 0, _))
-            .WillRepeatedly(DoAll(SetArgPointee<2>(0), Return(0)));
-
-    EXPECT_NO_THROW(_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr()));
-    EXPECT_FALSE(_PKCS11_is_logged_in(::testutils::somePKCS11SlotPtr()));
+    _PKCS11_store_private_key(session, ::testutils::someEVP_PKEY(), "label", "1001");
 }
 
 /* Test _PKCS11_store_private_key() with error return value. */
 TEST_F(P11WrapperTest, badPrivStore)
 {
-    EXPECT_CALL(_mock(),
-                P11_PKCS11_store_private_key(
-                        ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), _, _, _))
-            .WillOnce(Return(-1));
+    SessionMode mode = ReadWrite;
 
-    EXPECT_THROW(_PKCS11_store_private_key(::testutils::somePKCS11TokenPtr(),
-                                           ::testutils::someEVP_PKEY(),
-                                           "label",
-                                           "1001"),
-                 P11Exception);
+    EXPECT_THROW(testPrivStoreHelper(mode, -1), P11Exception);
 }
 
 /* Test successful _PKCS11_store_private_key(). */
 TEST_F(P11WrapperTest, goodPrivStore)
 {
-    EXPECT_CALL(_mock(),
-                P11_PKCS11_store_private_key(
-                        ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), _, _, _))
-            .WillOnce(Return(0));
+    SessionMode mode = ReadWrite;
 
-    EXPECT_NO_THROW(_PKCS11_store_private_key(
-            ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), "label", "1001"));
+    EXPECT_NO_THROW(testPrivStoreHelper(mode, 0));
 }
 
-/* Test _PKCS11_store_public_key() with error return value. */
+void P11WrapperTest::testPubStoreHelper(SessionMode mode, int retVal)
+{
+    std::string pin = "1002";
+    P11_Session session = testCreateSessionHelper(::testutils::somePKCS11SlotPtr(), pin, mode, 0);
+
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_store_public_key(
+                        ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), _, _, _))
+            .WillOnce(Return(retVal));
+
+    _PKCS11_store_public_key(session, ::testutils::someEVP_PKEY(), "label", "1001");
+}
+
+/* Test bad public storage. */
 TEST_F(P11WrapperTest, badPubStore)
 {
-    EXPECT_CALL(_mock(),
-                P11_PKCS11_store_public_key(
-                        ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), _, _, _))
-            .WillOnce(Return(-1));
+    SessionMode mode = ReadWrite;
 
-    EXPECT_THROW(_PKCS11_store_public_key(::testutils::somePKCS11TokenPtr(),
-                                          ::testutils::someEVP_PKEY(),
-                                          "label",
-                                          "1001"),
-                 P11Exception);
+    EXPECT_THROW(testPubStoreHelper(mode, -1), P11Exception);
 }
 
-/* Test successful _PKCS11_store_public_key(). */
+/* Test successful public storage. */
 TEST_F(P11WrapperTest, goodPubStore)
 {
-    EXPECT_CALL(_mock(),
-                P11_PKCS11_store_public_key(
-                        ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), _, _, _))
-            .WillOnce(Return(0));
+    SessionMode mode = ReadWrite;
 
-    EXPECT_NO_THROW(_PKCS11_store_public_key(
-            ::testutils::somePKCS11TokenPtr(), ::testutils::someEVP_PKEY(), "label", "1001"));
+    EXPECT_NO_THROW(testPubStoreHelper(mode, 0));
+}
+
+void P11WrapperTest::testKeyGenHelper(SessionMode mode, int retVal)
+{
+    std::string pin = "1002";
+    P11_Session session = testCreateSessionHelper(::testutils::somePKCS11SlotPtr(), pin, mode, 0);
+
+    EXPECT_CALL(_mock(),
+                P11_PKCS11_generate_key(::testutils::somePKCS11TokenPtr(), _, 2048, _, _, _))
+            .WillOnce(Return(retVal));
+
+    _PKCS11_generate_key(session, 2048, "label", "1001");
 }
 
 /* Test _PKCS11_generate_key() with error return value. */
 TEST_F(P11WrapperTest, badKeyGen)
 {
-    EXPECT_CALL(_mock(),
-                P11_PKCS11_generate_key(::testutils::somePKCS11TokenPtr(), _, 2048, _, _, _))
-            .WillOnce(Return(-1));
+    SessionMode mode = ReadWrite;
 
-    EXPECT_THROW(_PKCS11_generate_key(::testutils::somePKCS11TokenPtr(), 2048, "label", "1001"),
-                 P11Exception);
+    EXPECT_THROW(testKeyGenHelper(mode, -1);, P11Exception);
 }
 
 /* Test successful _PKCS11_generate_key(). */
 TEST_F(P11WrapperTest, goodKeyGen)
 {
-    EXPECT_CALL(_mock(),
-                P11_PKCS11_generate_key(::testutils::somePKCS11TokenPtr(), _, 2048, _, _, _))
-            .WillOnce(Return(0));
+    SessionMode mode = ReadWrite;
 
-    EXPECT_NO_THROW(_PKCS11_generate_key(::testutils::somePKCS11TokenPtr(), 2048, "label", "1001"));
+    EXPECT_NO_THROW(testKeyGenHelper(mode, 0));
 }


### PR DESCRIPTION
In effort to support the PKCS11 HSM interface, this PR adds P11 API function wrappers so that they may be used by MoCOCrW.

The p11_lib.h and p11_wrap.h are intermediary layers; they wrap LibP11's C API and particularly `p11_wrap.h`, is intended to be used internally by MoCOCrW. Crucially, their functions are not intended to be called directly by the user.

Tests are also included with this PR.
