### PR TITLE
Add HSM Test Setup to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,11 @@ jobs:
           docker run --rm -e SOFTHSM2_CONF="${{ matrix.softhsm2_conf }}" \
             -u "$UID"${{ matrix.softhsm2_grp }} \
             -v "$PWD:/src:rw" -w /src/build ${{ matrix.docker_tag }}  bash -c \
-            'if [ ${{ matrix.hsm_flag }} = "HSM_ENABLED=ON" ]; then \
+            'if [ "${{ matrix.hsm_flag }}" = "HSM_ENABLED=ON" ]; then \
                 softhsm2-util --init-token --free --label ${{ env.TOKEN_LABEL }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
             fi \
             && ctest --verbose -j $(nproc) \
-            && if [ ${{ matrix.hsm_flag }} = "HSM_ENABLED=ON" ]; then \
+            && if [ "${{ matrix.hsm_flag }}" = "HSM_ENABLED=ON" ]; then \
                 softhsm2-util --delete-token --token ${{ env.TOKEN_LABEL }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
             fi'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ env:
 
   DOCKER_WITH_HSM_TAG: buildenv_with_hsm
   DOCKER_WITH_HSM_FILE_PATH: ./docker-build-env/Dockerfile-With-HSM
+ 
+  TOKEN_LABEL: token-label
+  USER_PIN: 1234
+  SO_PIN: 4321
 
 jobs:
   check-format:
@@ -87,4 +91,11 @@ jobs:
           docker run --rm -e SOFTHSM2_CONF="${{ matrix.softhsm2_conf }}" \
             -u "$UID"${{ matrix.softhsm2_grp }} \
             -v "$PWD:/src:rw" -w /src/build ${{ matrix.docker_tag }}  bash -c \
-            'ctest -j $(nproc)'
+            'if [ ${{ matrix.hsm_flag }} = "HSM_ENABLED=ON" ]; then \
+                softhsm2-util --init-token --free --label ${{ env.TOKEN_LABEL }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
+            fi \
+            && ctest --verbose -j $(nproc) \
+            && if [ ${{ matrix.hsm_flag }} = "HSM_ENABLED=ON" ]; then \
+                softhsm2-util --delete-token --token ${{ env.TOKEN_LABEL }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
+            fi'
+


### PR DESCRIPTION
Adds setup and tear down for HSM tests to CI. In particular commands are added to initialise and destroy a SoftHSM2 token prior to and after the invocation of ctests.