### PR TITLE
Make CI consider L/ASAN options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,10 @@ env:
 
   DOCKER_WITH_HSM_TAG: buildenv_with_hsm
   DOCKER_WITH_HSM_FILE_PATH: ./docker-build-env/Dockerfile-With-HSM
- 
+
   TOKEN_LABEL: token-label
   USER_PIN: 1234
   SO_PIN: 4321
-  
-  # Include suppression list to avoid false positives reported by LSAN.
-  LSAN_OPTIONS: "suppressions=/src/lsan_suppression.txt"
-  # Disable fast unwind to have clean stack-traces for better suppression.
-  ASAN_OPTIONS: "fast_unwind_on_malloc=false"
 
 jobs:
   check-format:
@@ -50,6 +45,16 @@ jobs:
         hsm_flag: ["HSM_ENABLED=ON", "HSM_ENABLED=OFF"]
 
         include:
+          - build_type: "ASAN"
+            # Disable fast unwind to have clean stack-traces for better suppression.
+            ASAN_OPTIONS: "fast_unwind_on_malloc=false"
+            # Include suppression list to avoid false positives reported by LSAN.
+            LSAN_OPTIONS: "suppressions=/src/lsan_suppression.txt"
+
+          - build_type: ""
+            ASAN_OPTIONS: ""
+            LSAN_OPTIONS: ""
+
           - hsm_flag: "HSM_ENABLED=ON"
             docker_tag: "buildenv_with_hsm"
             softhsm2_conf: "/usr/share/softhsm/softhsm2.conf"
@@ -93,7 +98,7 @@ jobs:
 
       - name: "Run tests"
         run: |
-          docker run --rm -e ASAN_OPTIONS="${{ env.ASAN_OPTIONS }}" -e LSAN_OPTIONS="${{ env.LSAN_OPTIONS }}" \
+          docker run --rm -e ASAN_OPTIONS="${{ matrix.ASAN_OPTIONS }}" -e LSAN_OPTIONS="${{ matrix.LSAN_OPTIONS }}" \
             -e SOFTHSM2_CONF="${{ matrix.softhsm2_conf }}" \
             -u "$UID"${{ matrix.softhsm2_grp }} \
             -v "$PWD:/src:rw" -w /src/build ${{ matrix.docker_tag }}  bash -c \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ env:
   TOKEN_LABEL: token-label
   USER_PIN: 1234
   SO_PIN: 4321
+  
+  # Include suppression list to avoid false positives reported by LSAN.
+  LSAN_OPTIONS: "suppressions=/src/lsan_suppression.txt"
+  # Disable fast unwind to have clean stack-traces for better suppression.
+  ASAN_OPTIONS: "fast_unwind_on_malloc=false"
 
 jobs:
   check-format:
@@ -88,7 +93,8 @@ jobs:
 
       - name: "Run tests"
         run: |
-          docker run --rm -e SOFTHSM2_CONF="${{ matrix.softhsm2_conf }}" \
+          docker run --rm -e ASAN_OPTIONS="${{ env.ASAN_OPTIONS }}" -e LSAN_OPTIONS="${{ env.LSAN_OPTIONS }}" \
+            -e SOFTHSM2_CONF="${{ matrix.softhsm2_conf }}" \
             -u "$UID"${{ matrix.softhsm2_grp }} \
             -v "$PWD:/src:rw" -w /src/build ${{ matrix.docker_tag }}  bash -c \
             'if [ "${{ matrix.hsm_flag }}" = "HSM_ENABLED=ON" ]; then \

--- a/docker-build-env/Dockerfile
+++ b/docker-build-env/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         googletest \
         libboost-all-dev \
         libssl-dev \
+        # For llvm-symbolizer (used by ASAN).
+        llvm \
         make \
         ninja-build \
         pkg-config \

--- a/docker-build-env/Dockerfile
+++ b/docker-build-env/Dockerfile
@@ -11,7 +11,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         googletest \
         libboost-all-dev \
         libssl-dev \
-        # For llvm-symbolizer (used by ASAN).
+        # For llvm-symbolizer (used by A/LSAN).
+        # In particular, LLVM's symboliser is needed to print clearer
+        # stack-traces for more accurate suppressions.
         llvm \
         make \
         ninja-build \

--- a/lsan_suppression.txt
+++ b/lsan_suppression.txt
@@ -1,2 +1,2 @@
-# Leak arises from OpenSSL usage of MoCOCrW and SoftHSM2.
+# Leak arises from OpenSSL p11 and SoftHSM2, where an engine is allocated during initilisation.
 leak:OPENSSL_init_crypto

--- a/lsan_suppression.txt
+++ b/lsan_suppression.txt
@@ -1,2 +1,27 @@
-# Leak arises from OpenSSL p11 and SoftHSM2, where an engine is allocated during initilisation.
+# Leak arises from OpenSSL, where an engine is allocated during initilisation.
+# =================================================================
+# ==77==ERROR: LeakSanitizer: detected memory leaks
+#
+# Direct leak of 216 byte(s) in 1 object(s) allocated from:
+#     #0 0x495c9d in malloc (/src/build/examples/hsm-store-example+0x495c9d)
+#     #1 0x7fa88c020c0d in CRYPTO_zalloc (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x17bc0d)
+#     #2 0x7fa88bff89ef in ENGINE_new (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x1539ef)
+#     #3 0x7fa88bffa69d  (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x15569d)
+#     #4 0x7fa88c01c47c  (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x17747c)
+#     #5 0x7fa88bb4d4de in __pthread_once_slow (/lib/x86_64-linux-gnu/libpthread.so.0+0x114de)
+#     #6 0x7fa88c087aac in CRYPTO_THREAD_run_once (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x1e2aac)
+#     #7 0x7fa88c01cc0c in OPENSSL_init_crypto (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x177c0c)
+#     #8 0x7fa88bf85a3c  (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0xe0a3c)
+#     #9 0x7fa88c01c4f3  (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x1774f3)
+#     #10 0x7fa88bb4d4de in __pthread_once_slow (/lib/x86_64-linux-gnu/libpthread.so.0+0x114de)
+#     #11 0x7fa88c087aac in CRYPTO_THREAD_run_once (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x1e2aac)
+#     #12 0x7fa88c01cb77 in OPENSSL_init_crypto (/lib/x86_64-linux-gnu/libcrypto.so.1.1+0x177b77)
+#     #13 0x7fa88c1b1574 in OPENSSL_init_ssl (/lib/x86_64-linux-gnu/libssl.so.1.1+0x36574)
+#     #14 0x7fa88c3a67c1 in mococrw::openssl::lib::OpenSSLLib::SSL_SSL_load_error_strings() /src/build/../src/openssl_lib.cpp:61:58
+#     #15 0x7fa88c3a675d in mococrw::openssl::$_0::operator()() const /src/build/../src/openssl_lib.cpp:45:5
+#     #16 0x7fa88c338f98 in __cxx_global_var_init /src/build/../src/openssl_lib.cpp:42:43
+#     #17 0x7fa88c338fa8 in _GLOBAL__sub_I_openssl_lib.cpp /src/build/../src/openssl_lib.cpp
+#     #18 0x7fa88c498b99  (/lib64/ld-linux-x86-64.so.2+0x11b99)
+#     #19 0x7fa88c498ca0  (/lib64/ld-linux-x86-64.so.2+0x11ca0)
+#     #20 0x7fa88c488139  (/lib64/ld-linux-x86-64.so.2+0x1139)
 leak:OPENSSL_init_crypto

--- a/lsan_suppression.txt
+++ b/lsan_suppression.txt
@@ -1,0 +1,2 @@
+# Leak arises from OpenSSL usage of MoCOCrW and SoftHSM2.
+leak:OPENSSL_init_crypto


### PR DESCRIPTION
Adds a suppression list to avoid LSAN from complaining about known false positives. To achieve this, we rely on the settings of LSAN and ASAN options. 