### PR TITLE
Adds main abstract classes related to HSMs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,14 @@ set(LIBRARY_SOURCES
     x509.cpp
 )
 
+# Add additional source files if HSM features are enabled.
+if(HSM_ENABLED)
+  set(LIBRARY_SOURCES
+      ${LIBRARY_SOURCES}
+      hsm.cpp
+  )
+endif()
+
 set(LIBRARY_PUBLIC_HEADERS
     mococrw/asn1time.h
     mococrw/asymmetric_crypto_ctx.h
@@ -64,6 +72,13 @@ set(LIBRARY_PUBLIC_HEADERS
     mococrw/x509.h
 )
 
+# Add additional header files if HSM features are enabled.
+if(HSM_ENABLED)
+  set(LIBRARY_PUBLIC_HEADERS
+      ${LIBRARY_PUBLIC_HEADERS}
+      mococrw/hsm.h
+  )
+endif()
 
 add_library(${LIBRARY_NAME} SHARED ${LIBRARY_SOURCES} ${LIBRARY_PUBLIC_HEADERS})
 add_library(${PROJECT_NAME}::${LIBRARY_NAME} ALIAS ${LIBRARY_NAME})

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include "mococrw/hsm.h"
+#include <boost/format.hpp>
+
+namespace mococrw
+{
+using namespace openssl;
+
+HSM::HSM() {}
+
+HsmEngine::HsmEngine(const std::string &id, const std::string &modulePath, const std::string &pin)
+        : _id(id), _modulePath(modulePath), _pin(pin)
+{
+    // Fetch engine via ID.
+    _engine = _ENGINE_by_id(_id);
+
+    _ENGINE_ctrl_cmd_string(_engine.get(), "MODULE_PATH", _modulePath);
+    _ENGINE_ctrl_cmd_string(_engine.get(), "PIN", _pin);
+    _ENGINE_init(_engine.get());
+}
+
+HsmEngine::~HsmEngine() { _ENGINE_finish(_engine.get()); }
+
+openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPublicKey(const std::string &keyID)
+{
+    return _ENGINE_load_public_key(_engine.get(), keyID);
+}
+
+openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPrivateKey(const std::string &keyID)
+{
+    return _ENGINE_load_private_key(_engine.get(), keyID);
+}
+
+}  // namespace mococrw

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -17,16 +17,18 @@
  * #L%
  */
 #include "mococrw/hsm.h"
-#include <boost/format.hpp>
 
 namespace mococrw
 {
 using namespace openssl;
 
-HSM::HSM() {}
+const std::string &HSM::getName() { return _name; }
 
-HsmEngine::HsmEngine(const std::string &id, const std::string &modulePath, const std::string &pin)
-        : _id(id), _modulePath(modulePath), _pin(pin)
+HsmEngine::HsmEngine(const std::string &name,
+                     const std::string &id,
+                     const std::string &modulePath,
+                     const std::string &pin)
+        : HSM(name), _id(id), _modulePath(modulePath), _pin(pin)
 {
     // Fetch engine via ID.
     _engine = _ENGINE_by_id(_id);

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -1,0 +1,111 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#pragma once
+
+#include <boost/optional/optional.hpp>
+#include "openssl_wrap.h"
+
+namespace mococrw
+{
+/**
+ * Driver for Hardware Security Modules (HSMs).
+ */
+class HSM
+{
+public:
+    HSM();
+    virtual ~HSM() {}
+
+protected:
+    /**
+     * Returns the name of the HSM driver.
+     */
+    virtual const std::string getName() = 0;
+
+    /**
+     *  Loads public key from HSM.
+     */
+    virtual openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) = 0;
+
+    /**
+     * Stores public key to HSM.
+     */
+    virtual void storePublicKey(EVP_PKEY *key,
+                                const std::string &label,
+                                const std::string &keyID) = 0;
+
+    /**
+     * Loads private key from HSM.
+     */
+    virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) = 0;
+
+    /**
+     * Stores private key to HSM.
+     */
+    virtual void storePrivateKey(EVP_PKEY *key,
+                                 const std::string &label,
+                                 const std::string &keyID) = 0;
+
+    /**
+     * Generates a key pair via HSM.
+     *
+     * \note Currently, RSA keys are only supported.
+     */
+    virtual void generateKey(unsigned int bits,
+                             const std::string &label,
+                             const std::string &id) = 0;
+
+    // Many of protected functions provided by the HSM class are seen
+    // as internal, not to be used by the User of MoCOCrW but specific
+    // friends:
+    friend class AsymmetricPublicKey;
+    friend class AsymmetricKeypair;
+    friend class RSASpec;
+};
+
+/**
+ * HSM driver implemented using OpenSSL's engine interface.
+ */
+class HsmEngine : public HSM
+{
+public:
+    HsmEngine(const std::string &id, const std::string &modulePath, const std::string &pin);
+    virtual ~HsmEngine();
+
+    ENGINE *internal();
+    const ENGINE *internal() const;
+
+protected:
+    /** Pointer to OpenSSL ENGINE. */
+    openssl::SSL_ENGINE_Ptr _engine;
+    /** Engine ID. */
+    const std::string &_id;
+    /** Path to Module. */
+    const std::string &_modulePath;
+    /** Pin to access PKCS11 Engine. */
+    const std::string &_pin;
+
+    virtual const std::string getName() override = 0;
+
+    virtual openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) override;
+
+    virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) override;
+};
+
+}  // namespace mococrw

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -40,11 +40,17 @@ protected:
 
     /**
      *  Loads public key from HSM.
+     *
+     *  @param keyID The ID of the public key to load.
      */
     virtual openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) = 0;
 
     /**
      * Stores public key to HSM.
+     *
+     * @param key The public key to store.
+     * @param label The label of the key to store.
+     * @param keyID The ID of the key to store.
      */
     virtual void storePublicKey(EVP_PKEY *key,
                                 const std::string &label,
@@ -52,11 +58,17 @@ protected:
 
     /**
      * Loads private key from HSM.
+     *
+     * @param keyID The ID of the private key to load.
      */
     virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) = 0;
 
     /**
      * Stores private key to HSM.
+     *
+     * @param key The private key to store.
+     * @param label The label of the key to store.
+     * @param keyID The ID of the key to store.
      */
     virtual void storePrivateKey(EVP_PKEY *key,
                                  const std::string &label,
@@ -65,22 +77,19 @@ protected:
     /**
      * Generates a key pair via HSM.
      *
+     * @param bits Specifies key size.
+     * @param label The label of the key to generate.
+     * @param id The ID of the key to generate.
+     *
      * \note Currently, RSA keys are only supported.
      */
     virtual void generateKey(unsigned int bits,
                              const std::string &label,
                              const std::string &id) = 0;
-
-    // Many of protected functions provided by the HSM class are seen
-    // as internal, not to be used by the User of MoCOCrW but specific
-    // friends:
-    friend class AsymmetricPublicKey;
-    friend class AsymmetricKeypair;
-    friend class RSASpec;
 };
 
 /**
- * HSM driver implemented using OpenSSL's engine interface.
+ * HSM driver that leverages OpenSSL's ENGINE_* API interface.
  */
 class HsmEngine : public HSM
 {


### PR DESCRIPTION
Adds two main abstract classes concerning HSMs. The `HSM` class is the highest abstract class in the hierarchy; all HSM implementations should inherit it either directly or indirectly. The second abstract class is the `HsmEngine` class which extends `HSM` and adds functionality based on OpenSSL's `ENGINE_* API`.

Since these two classes are both abstract, no concrete implementation of an HSM is provided in this PR. Such an implementation will be provided in a subsequent PR to ease review.