### PR TITLE
Fix front HSM interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ env:
   TOKEN_LABEL: token-label
   USER_PIN: 1234
   SO_PIN: 4321
+  KEY_LABEL: key_label
+  KEY_ID: 1001
 
 jobs:
   check-format:
@@ -104,6 +106,8 @@ jobs:
             -v "$PWD:/src:rw" -w /src/build ${{ matrix.docker_tag }}  bash -c \
             'if [ "${{ matrix.hsm_flag }}" = "HSM_ENABLED=ON" ]; then \
                 softhsm2-util --init-token --free --label ${{ env.TOKEN_LABEL }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
+                pkcs11-tool --module $MY_MOCOCRW_INSTALL/lib/softhsm/libsofthsm2.so -l --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }} \
+                    --token-label ${{ env.TOKEN_LABEL }} -k --key-type EC:prime256v1 --id ${{ env.KEY_ID }} --label ${{ env.KEY_LABEL }};
             fi \
             && ctest --verbose -j $(nproc) \
             && if [ "${{ matrix.hsm_flag }}" = "HSM_ENABLED=ON" ]; then \

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,6 +26,23 @@ add_test(
     COMMAND hash-example
 )
 
+# Only build HSM example if HSM features have been enabled.
+#
+# TODO: Make the HSM flag be an imported variable so users
+# can easily determine its status.
+if(HSM_ENABLED)
+    add_executable(hsm-example hsm-example.cpp)
+    target_link_libraries(hsm-example PUBLIC MoCOCrW::mococrw)
+    target_compile_definitions(hsm-example PUBLIC HSM_ENABLED)
+
+    add_test(
+        NAME hsmExample
+        COMMAND hsm-example
+    )
+else()
+    message(WARNING "Skipping HSM example, as HSM features are disabled.")
+endif()
+
 add_executable(kdf-example kdf-example.cpp)
 target_link_libraries(kdf-example PUBLIC MoCOCrW::mococrw)
 add_test(

--- a/examples/hsm-example.cpp
+++ b/examples/hsm-example.cpp
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <mococrw/asymmetric_crypto_ctx.h>
+#include <mococrw/hsm.h>
+#include <iostream>
+
+/* This example demonstrates how to create a PKCS11 engine object,
+ * and store a key inside the HSM.
+ */
+
+using namespace mococrw;
+
+int main(void)
+{
+    // Information for engine loading and key management.
+    std::string id("pkcs11");
+    std::string modulePath("/usr/lib/softhsm/libsofthsm2.so");
+    std::string pin("1234");
+    std::string keyID("1001");
+
+    // Step 2: Initialise the PKCS11 Engine.
+    HsmEngine hsmEngine(id, modulePath, pin);
+
+    // Step 4: Load the key from the HSM and print it.
+    auto pubKey = AsymmetricPublicKey::readPublicKeyFromHSM(hsmEngine, keyID);
+    std::cout << "Loaded key: \n\n" << pubKey.publicKeyToPem() << "\n\n" << std::endl;
+
+    return 0;
+}

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -22,13 +22,8 @@ namespace mococrw
 {
 using namespace openssl;
 
-const std::string &HSM::getName() { return _name; }
-
-HsmEngine::HsmEngine(const std::string &name,
-                     const std::string &id,
-                     const std::string &modulePath,
-                     const std::string &pin)
-        : HSM(name), _id(id), _modulePath(modulePath), _pin(pin)
+HsmEngine::HsmEngine(const std::string &id, const std::string &modulePath, const std::string &pin)
+        : HSM(), _id(id), _modulePath(modulePath), _pin(pin)
 {
     // Fetch engine via ID.
     _engine = _ENGINE_by_id(_id);

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -1,7 +1,7 @@
 /*
  * #%L
  * %%
- * Copyright (C) 2018 BMW Car IT GmbH
+ * Copyright (C) 2022 BMW Car IT GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,6 +106,14 @@ AsymmetricPublicKey AsymmetricPublicKey::readPublicKeyFromPEM(const std::string 
     return AsymmetricPublicKey{std::move(key)};
 }
 
+#ifdef HSM_ENABLED
+AsymmetricPublicKey AsymmetricPublicKey::readPublicKeyFromHSM(HSM &hsm, const std::string &keyID)
+{
+    auto key = hsm.loadPublicKey(keyID);
+    return AsymmetricPublicKey{std::move(key)};
+}
+#endif
+
 AsymmetricPublicKey AsymmetricPublicKey::fromECPoint(const std::shared_ptr<ECCSpec> keySpec,
                                                      const std::vector<uint8_t> &point)
 {
@@ -176,6 +184,14 @@ AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromPEM(const std::string &pe
     auto key = _PEM_read_bio_PrivateKey(bio.internal(), password.c_str());
     return AsymmetricKeypair{std::move(key)};
 }
+
+#ifdef HSM_ENABLED
+AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromHSM(HSM &hsm, const std::string &keyID)
+{
+    auto key = hsm.loadPrivateKey(keyID);
+    return AsymmetricKeypair{std::move(key)};
+}
+#endif
 
 AsymmetricKey RSASpec::generate() const
 {

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -31,17 +31,15 @@ namespace mococrw
 class HSM
 {
 public:
-    HSM(const std::string &name) : _name(name) {}
     virtual ~HSM() = default;
 
-    /**
-     * Returns the name of the HSM.
-     */
-    const std::string &getName();
+    // Many of protected functions provided by the HSM class are seen
+    // as internal, not to be used by the User of MoCOCrW but specific
+    // friends:
+    friend class AsymmetricPublicKey;
+    friend class AsymmetricKeypair;
 
 protected:
-    const std::string &_name;
-
     /**
      *  Loads public key from HSM.
      *
@@ -50,46 +48,11 @@ protected:
     virtual openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) = 0;
 
     /**
-     * Stores public key to HSM.
-     *
-     * @param key The public key to store.
-     * @param label The label of the key to store.
-     * @param keyID The ID of the key to store.
-     */
-    virtual void storePublicKey(EVP_PKEY *key,
-                                const std::string &label,
-                                const std::string &keyID) = 0;
-
-    /**
      * Loads private key from HSM.
      *
      * @param keyID The ID of the private key to load.
      */
     virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) = 0;
-
-    /**
-     * Stores private key to HSM.
-     *
-     * @param key The private key to store.
-     * @param label The label of the key to store.
-     * @param keyID The ID of the key to store.
-     */
-    virtual void storePrivateKey(EVP_PKEY *key,
-                                 const std::string &label,
-                                 const std::string &keyID) = 0;
-
-    /**
-     * Generates a key pair via HSM.
-     *
-     * @param bits Specifies key size.
-     * @param label The label of the key to generate.
-     * @param id The ID of the key to generate.
-     *
-     * \note Currently, RSA keys are only supported.
-     */
-    virtual void generateKey(unsigned int bits,
-                             const std::string &label,
-                             const std::string &id) = 0;
 };
 
 /**
@@ -98,21 +61,18 @@ protected:
 class HsmEngine : public HSM
 {
 public:
-    HsmEngine(const std::string &name,
-              const std::string &id,
-              const std::string &modulePath,
-              const std::string &pin);
+    HsmEngine(const std::string &id, const std::string &modulePath, const std::string &pin);
     virtual ~HsmEngine();
 
 protected:
     /** Pointer to OpenSSL ENGINE. */
     openssl::SSL_ENGINE_Ptr _engine;
     /** Engine ID. */
-    const std::string &_id;
+    const std::string _id;
     /** Path to Module. */
-    const std::string &_modulePath;
+    const std::string _modulePath;
     /** Pin to access PKCS11 Engine. */
-    const std::string &_pin;
+    const std::string _pin;
 
     openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) override;
 

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -1,7 +1,7 @@
 /*
  * #%L
  * %%
- * Copyright (C) 2018 BMW Car IT GmbH
+ * Copyright (C) 2022 BMW Car IT GmbH
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,9 @@
  * #L%
  */
 #pragma once
+#ifdef HSM_ENABLED
+#include "mococrw/hsm.h"
+#endif
 #include "openssl_wrap.h"
 
 namespace mococrw
@@ -82,6 +85,14 @@ public:
      * @throws This method may throw an OpenSSLException if OpenSSL indicates an error
      */
     static AsymmetricPublicKey readPublicKeyFromPEM(const std::string& pem);
+
+#ifdef HSM_ENABLED
+    /**
+     * Loads a public key from an HSM, creating an @ref AsymmetricPublicKey
+     * object as a result.
+     */
+    static AsymmetricPublicKey readPublicKeyFromHSM(HSM& hsm, const std::string& keyID);
+#endif
 
     /**
      * @brief Returns a public key object based on the provided EC point
@@ -253,6 +264,14 @@ public:
 
     static AsymmetricKeypair readPrivateKeyFromPEM(const std::string& pem,
                                                    const std::string& password);
+
+#ifdef HSM_ENABLED
+    /**
+     * Loads a private key from an HSM, creating an @ref AsymmetricPublicKey
+     * object as a result.
+     */
+    static AsymmetricKeypair readPrivateKeyFromHSM(HSM& hsm, const std::string& keyID);
+#endif
 
 private:
     AsymmetricKeypair(AsymmetricKey&& key) : AsymmetricPublicKey{std::move(key)} {}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -30,6 +30,12 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
 
     add_executable(openssltest test_opensslwrapper.cpp ${MOCK_SOURCES})
 
+    if(HSM_ENABLED)
+        add_executable(hsmtest test_hsm.cpp
+                               "${SRC_DIR}/hsm.cpp"
+                               ${MOCK_SOURCES})
+    endif()
+
     add_executable(asn1timetests test_asn1time.cpp ${REAL_SOURCES})
     add_executable(keytests test_key.cpp ${REAL_SOURCES})
     add_executable(csrtests test_csr.cpp "${SRC_DIR}/key.cpp" ${REAL_SOURCES})
@@ -140,6 +146,11 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     # Cannot link to imported OpenSSL and leverage implicit include-dir-propagation, as openssltest uses mocks.
     target_include_directories(openssltest PUBLIC ${OPENSSL_INCLUDE_DIR})
 
+    if(HSM_ENABLED)
+        target_link_libraries(hsmtest ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+        target_include_directories(hsmtest PUBLIC ${OPENSSL_INCLUDE_DIR})
+    endif()
+
     target_link_libraries(asn1timetests
         ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
     target_link_libraries(keytests
@@ -181,10 +192,21 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     target_link_libraries(eciestests
 	${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} OpenSSL::Crypto OpenSSL::SSL Boost::boost)
 
+    if(HSM_ENABLED)
+        target_compile_definitions(keytests PUBLIC HSM_ENABLED)
+    endif()
+
     add_test(
         NAME OpenSSLTest
         COMMAND openssltest
     )
+
+    if(HSM_ENABLED)
+        add_test(
+            NAME HSMTest
+            COMMAND hsmtest
+        )
+    endif()
 
     add_test(
         NAME Asn1TimeTests

--- a/tests/unit/hsm_mock.h
+++ b/tests/unit/hsm_mock.h
@@ -1,0 +1,38 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#pragma once
+
+#include "mococrw/hsm.h"
+
+#include <mutex>
+
+namespace mococrw
+{
+/**
+ * GMock class to mock the HSM interface.
+ *
+ */
+class HSMMock final : public HSM
+{
+public:
+    MOCK_METHOD1(loadPublicKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
+    MOCK_METHOD1(loadPrivateKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
+};
+
+}  // namespace mococrw

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -1,0 +1,105 @@
+/*
+ * #%L
+ * %%
+ * Copyright (C) 2022 BMW Car IT GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+
+// #include "key.cpp"
+#include "mococrw/hsm.h"
+#include "openssl_lib_mock.h"
+
+using namespace ::mococrw;
+using namespace ::std::string_literals;
+
+using ::testing::_;
+using ::testing::Mock;
+using ::testing::Return;
+using ::testing::StrEq;
+
+class HSMTest : public ::testing::Test
+{
+public:
+    void SetUp() override;
+    void TearDown() override;
+
+protected:
+    std::string _defaultErrorMessage{"bla bla bla"};
+    const unsigned long _defaultErrorCode = 1L;
+    openssl::OpenSSLLibMock& _mock() const
+    {
+        return openssl::OpenSSLLibMockManager::getMockInterface();
+    }
+};
+
+namespace testutils
+{
+ENGINE* someEnginePtr()
+{
+    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
+    static char dummyBuf[42] = {};
+    return reinterpret_cast<ENGINE*>(&dummyBuf);
+}
+}  // namespace testutils
+
+void HSMTest::SetUp()
+{
+    /*
+     * Like test_opensslwrapper.cpp, we instrument the mock, so that error-handling code
+     * will always have well-defined behavior.
+     */
+    openssl::OpenSSLLibMockManager::resetMock();
+    ON_CALL(_mock(), SSL_ERR_get_error()).WillByDefault(Return(_defaultErrorCode));
+    ON_CALL(_mock(), SSL_ERR_error_string(_, nullptr))
+            .WillByDefault(Return(const_cast<char*>(_defaultErrorMessage.c_str())));
+    // TODO: Get rid of the uninteresting calls by default here somehow...
+}
+
+void HSMTest::TearDown() { openssl::OpenSSLLibMockManager::destroy(); }
+
+TEST_F(HSMTest, testHSMEngine)
+{
+    std::string engineID("engine_id");
+    std::string modulePath("/test_path.so");
+    std::string pin("1234");
+
+    EXPECT_CALL(_mock(), SSL_ENGINE_by_id(StrEq(engineID.c_str())))
+            .WillOnce(Return(::testutils::someEnginePtr()));
+
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_ctrl_cmd_string(::testutils::someEnginePtr(),
+                                           StrEq("MODULE_PATH"),
+                                           StrEq(modulePath.c_str()),
+                                           0 /*non-optional*/))
+            .WillOnce(Return(1));
+
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_ctrl_cmd_string(::testutils::someEnginePtr(),
+                                           StrEq("PIN"),
+                                           StrEq(pin.c_str()),
+                                           0 /*non-optional*/))
+            .WillOnce(Return(1));
+
+    EXPECT_CALL(_mock(), SSL_ENGINE_init(::testutils::someEnginePtr())).WillOnce(Return(1));
+
+    EXPECT_CALL(_mock(), SSL_ENGINE_finish(::testutils::someEnginePtr())).WillOnce(Return(1));
+
+    EXPECT_NO_THROW((HsmEngine(engineID, modulePath, pin)));
+}


### PR DESCRIPTION
Converts the HSMEngine class, which makes use of OpenSSL's ENGINE API to interact with HSMs, from an abstract to a concrete class. Virtual functions which cannot be implemented due to current lack of support (e.g., key storage) are removed for now.

Adds readPrivateKeyFromHSM() and readPublicKeyFromHSM() to the MoCOCrW interface. Tests for loading keys are also included in this PR.