### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ All notable changes to this project will be documented in this file.
   before won't be issued anymore. Certificates with these properties were already rejected
   by CertificateAuthority::signCSR but with a rather misleading and generic error message.
   This change just improves the error reporting.
+* Clang-Format has been applied to the existing code-base of MoCOCrW and a `.clang-format`
+  file has been included to format the code of of future PRs.
+* A foundational PKCS#11 HSM interface, based OpenSSL's ENGINE API, has been introduced
+  to MoCOCrW. Currently, the following functionality is supported:
+    - Loading Public Keys
+    - Loading Private Keys
 
 # Release 4.1.1
 


### PR DESCRIPTION
Updates MoCOCrW's CHANGELOG file to reflect recent additions to MoCOCrW, particularly HSM PKCS11 support.