### PR TITLE
openssl3.0: Fix compile errors

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 # Install MoCOCrW dependencies (except OpenSSL)
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
         ca-certificates \
         clang \
-        clang-format-10 \
+        clang-format-11 \
         cmake \
         g++ \
         git \

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -374,7 +374,7 @@ public:
                                    size_t tbslen) noexcept;
     static int SSL_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept;
     static int SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int len) noexcept;
-    static EC_KEY *SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) noexcept;
+    static const EC_KEY *SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) noexcept;
     static int SSL_EVP_DigestSignInit(EVP_MD_CTX *ctx,
                                       EVP_PKEY_CTX **pctx,
                                       const EVP_MD *type,

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -1467,7 +1467,7 @@ enum class EllipticCurvePointConversionForm {
 
 };
 
-EC_KEY *_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey);
+const EC_KEY *_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey);
 
 void _PKCS5_PBKDF2_HMAC(const std::vector<uint8_t> pass,
                         const std::vector<uint8_t> salt,

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -793,7 +793,7 @@ int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD
     return EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, md);
 }
 
-EC_KEY *OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) noexcept
+const EC_KEY *OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY* pkey) noexcept
 {
     return EVP_PKEY_get0_EC_KEY(pkey);
 }

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -1354,7 +1354,7 @@ void _RAND_bytes(unsigned char *buf, int num)
 
 void _CRYPTO_malloc_init() { return lib::OpenSSLLib::SSL_CRYPTO_malloc_init(); }
 
-EC_KEY *_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey)
+const EC_KEY *_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey)
 {
     return OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY, pkey);
 }
@@ -1525,7 +1525,8 @@ std::vector<uint8_t> _EC_KEY_key2buf(const EVP_PKEY *evp, point_conversion_form_
      */
     EVP_PKEY *evp_ = const_cast<EVP_PKEY *>(evp);
     unsigned char *pbuf;
-    EC_KEY *key = OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY, evp_);
+    const EC_KEY *key =
+            OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY, evp_);
     size_t length = OpensslCallIsPositive::callChecked(
             lib::OpenSSLLib::SSL_EC_KEY_key2buf, key, form, &pbuf, nullptr);
     std::vector<uint8_t> result(pbuf, pbuf + length);

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -917,7 +917,7 @@ int OpenSSLLib::SSL_EVP_MD_size(const EVP_MD *md) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_MD_size(md);
 }
-EC_KEY *OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) noexcept
+const EC_KEY *OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_get0_EC_KEY(pkey);
 }

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -438,7 +438,7 @@ TEST_F(KeyHandlingTests, testGetSize)
     EXPECT_EQ(_eccKeyPairSecp521r1.getKeySize(), 521);
     EXPECT_EQ(_eccKeyPairSect571r1.getKeySize(), 570);
     EXPECT_EQ(_Ed448KeyPair.getKeySize(), 456);
-    EXPECT_EQ(_Ed25519KeyPair.getKeySize(), 253);
+    EXPECT_EQ(_Ed25519KeyPair.getKeySize(), 256);
     auto rsaKey1024 = AsymmetricKeypair::generate(mococrw::RSASpec{1024});
     EXPECT_EQ(rsaKey1024.getKeySize(), 1024);
 }


### PR DESCRIPTION
The compile errors are fixed.
These were mainly const correctness problems.

However the >200 warnings are not fixed, yet.
Most of them are deprecation warnings.

The docker container for test execution is updated from focal (20.04 LTS) to Jammy (22.04 LTS) as Jammy already ships openssl3.0.x.