### PR TITLE
Arrange Pointer Alignment Setting in Clang Format Config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -42,7 +42,6 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
@@ -70,7 +69,7 @@ PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
+PointerAlignment: Right
 ReflowComments:  true
 SortIncludes:    true
 SpaceAfterCStyleCast: false

--- a/src/distinguished_name.cpp
+++ b/src/distinguished_name.cpp
@@ -27,8 +27,8 @@ namespace mococrw
 using namespace openssl;
 
 void DistinguishedName::_addString(
-        SSL_X509_NAME_Ptr& x509Name,
-        const boost::optional<DistinguishedName::Attribute>& attribute) const
+        SSL_X509_NAME_Ptr &x509Name,
+        const boost::optional<DistinguishedName::Attribute> &attribute) const
 {
     if (!x509Name.get()) {
         throw std::runtime_error(ERROR_STRING("Received a nullptr as X509_NAME."));
@@ -42,10 +42,10 @@ void DistinguishedName::_addString(
             x509Name.get(), attribute->id, ASN1_Name_Entry_Type::ASCIIString, vec);
 }
 
-void DistinguishedName::populateX509Name(SSL_X509_NAME_Ptr& subject) const
+void DistinguishedName::populateX509Name(SSL_X509_NAME_Ptr &subject) const
 {
     if (_customAttributeOrderFlag) {
-        for (const auto& it : _attributes) {
+        for (const auto &it : _attributes) {
             _addString(subject, it);
         }
     } else {
@@ -63,7 +63,7 @@ void DistinguishedName::populateX509Name(SSL_X509_NAME_Ptr& subject) const
     }
 }
 
-std::string _getEntryByNIDAsString(X509_NAME* x509, ASN1_NID nid)
+std::string _getEntryByNIDAsString(X509_NAME *x509, ASN1_NID nid)
 {
     if (!x509) {
         throw std::runtime_error(ERROR_STRING("nullptr"));
@@ -80,7 +80,7 @@ std::string _getEntryByNIDAsString(X509_NAME* x509, ASN1_NID nid)
     return _X509_NAME_ENTRY_get_data(entry);
 }
 
-DistinguishedName DistinguishedName::fromX509Name(X509_NAME* x509)
+DistinguishedName DistinguishedName::fromX509Name(X509_NAME *x509)
 {
     Builder builder{};
     builder.commonName(_getEntryByNIDAsString(x509, ASN1_NID::CommonName));
@@ -97,7 +97,7 @@ DistinguishedName DistinguishedName::fromX509Name(X509_NAME* x509)
     return builder.build();
 }
 
-auto _createTuple(const DistinguishedName& dn)
+auto _createTuple(const DistinguishedName &dn)
 {
     return std::make_tuple(dn.commonName(),
                            dn.countryName(),
@@ -112,7 +112,7 @@ auto _createTuple(const DistinguishedName& dn)
                            dn.title());
 }
 
-bool DistinguishedName::operator==(const DistinguishedName& other) const
+bool DistinguishedName::operator==(const DistinguishedName &other) const
 {
     if (_customAttributeOrderFlag && other._customAttributeOrderFlag) {
         // order matters now
@@ -120,7 +120,7 @@ bool DistinguishedName::operator==(const DistinguishedName& other) const
                           _attributes.end(),
                           other._attributes.begin(),
                           other._attributes.end(),
-                          [](const auto& left, const auto& right) {
+                          [](const auto &left, const auto &right) {
                               return left.id == right.id && left.name == right.name;
                           });
     } else {
@@ -145,7 +145,7 @@ boost::optional<DistinguishedName::Attribute> DistinguishedName::_getAttributeBy
     // returns the last occurence in case there is duplicates
     const auto it = std::find_if(_attributes.rbegin(),
                                  _attributes.rend(),
-                                 [id](const auto& attribute) { return attribute.id == id; });
+                                 [id](const auto &attribute) { return attribute.id == id; });
     if (it != _attributes.rend()) {
         ret = *it;
     };

--- a/src/format_utils.h
+++ b/src/format_utils.h
@@ -39,9 +39,9 @@ namespace util
  * @return a vector with all PEMs, in the same order that they appeared in the chain.
  * @throw MoCOCrWException if the string didn't contain a list of PEMs.
  */
-inline std::vector<std::string> splitPEMChain(const std::string& pemChain,
-                                              const std::string& beginMarker,
-                                              const std::string& endMarker)
+inline std::vector<std::string> splitPEMChain(const std::string &pemChain,
+                                              const std::string &beginMarker,
+                                              const std::string &endMarker)
 {
     std::string::size_type pos = 0;
     std::size_t index = 0;

--- a/src/kdf.cpp
+++ b/src/kdf.cpp
@@ -33,12 +33,12 @@ public:
 
     ~Impl() = default;
 
-    std::vector<uint8_t> deriveKey(const std::vector<uint8_t>& password,
+    std::vector<uint8_t> deriveKey(const std::vector<uint8_t> &password,
                                    const size_t outputLength,
-                                   const std::vector<uint8_t>& salt)
+                                   const std::vector<uint8_t> &salt)
     {
         std::vector<uint8_t> derivedKey(outputLength);
-        const EVP_MD* digestFn = openssl::_getMDPtrFromDigestType(_hashFunction);
+        const EVP_MD *digestFn = openssl::_getMDPtrFromDigestType(_hashFunction);
         openssl::_PKCS5_PBKDF2_HMAC(password, salt, _iterations, digestFn, derivedKey);
 
         return derivedKey;
@@ -56,24 +56,24 @@ PBKDF2::PBKDF2(openssl::DigestTypes hashFunction, uint32_t iterations)
 
 PBKDF2::~PBKDF2() = default;
 
-std::vector<uint8_t> PBKDF2::deriveKey(const std::vector<uint8_t>& password,
+std::vector<uint8_t> PBKDF2::deriveKey(const std::vector<uint8_t> &password,
                                        const size_t outputLength,
-                                       const std::vector<uint8_t>& salt)
+                                       const std::vector<uint8_t> &salt)
 {
     return _impl->deriveKey(password, outputLength, salt);
 }
 
-PBKDF2::PBKDF2(PBKDF2&& other) = default;
+PBKDF2::PBKDF2(PBKDF2 &&other) = default;
 
-PBKDF2& PBKDF2::operator=(PBKDF2&& other)
+PBKDF2 &PBKDF2::operator=(PBKDF2 &&other)
 {
     this->_impl = std::move(other._impl);
     return *this;
 }
 
-PBKDF2::PBKDF2(const PBKDF2& other) : _impl(std::make_unique<PBKDF2::Impl>(*other._impl)) {}
+PBKDF2::PBKDF2(const PBKDF2 &other) : _impl(std::make_unique<PBKDF2::Impl>(*other._impl)) {}
 
-PBKDF2& PBKDF2::operator=(const PBKDF2& other)
+PBKDF2 &PBKDF2::operator=(const PBKDF2 &other)
 {
     this->_impl = std::make_unique<PBKDF2::Impl>(*other._impl);
     return *this;
@@ -86,12 +86,12 @@ public:
 
     ~Impl() = default;
 
-    std::vector<uint8_t> deriveKey(const std::vector<uint8_t>& password,
+    std::vector<uint8_t> deriveKey(const std::vector<uint8_t> &password,
                                    const size_t outputLength,
-                                   const std::vector<uint8_t>& salt)
+                                   const std::vector<uint8_t> &salt)
     {
         std::vector<uint8_t> derivedKey(outputLength);
-        const EVP_MD* digestFn = openssl::_getMDPtrFromDigestType(_hashFunction);
+        const EVP_MD *digestFn = openssl::_getMDPtrFromDigestType(_hashFunction);
         openssl::_ECDH_KDF_X9_63(derivedKey, password, salt, digestFn);
         return derivedKey;
     }
@@ -107,24 +107,24 @@ X963KDF::X963KDF(openssl::DigestTypes hashFunction)
 
 X963KDF::~X963KDF() = default;
 
-std::vector<uint8_t> X963KDF::deriveKey(const std::vector<uint8_t>& password,
+std::vector<uint8_t> X963KDF::deriveKey(const std::vector<uint8_t> &password,
                                         const size_t outputLength,
-                                        const std::vector<uint8_t>& salt)
+                                        const std::vector<uint8_t> &salt)
 {
     return _impl->deriveKey(password, outputLength, salt);
 }
 
-X963KDF::X963KDF(X963KDF&& other) = default;
+X963KDF::X963KDF(X963KDF &&other) = default;
 
-X963KDF::X963KDF(const X963KDF& other) : _impl(std::make_unique<X963KDF::Impl>(*other._impl)) {}
+X963KDF::X963KDF(const X963KDF &other) : _impl(std::make_unique<X963KDF::Impl>(*other._impl)) {}
 
-X963KDF& X963KDF::operator=(X963KDF&& other)
+X963KDF &X963KDF::operator=(X963KDF &&other)
 {
     this->_impl = std::move(other._impl);
     return *this;
 }
 
-X963KDF& X963KDF::operator=(const X963KDF& other)
+X963KDF &X963KDF::operator=(const X963KDF &other)
 {
     this->_impl = std::make_unique<X963KDF::Impl>(*other._impl);
     return *this;

--- a/src/mococrw/asymmetric_crypto_ctx.h
+++ b/src/mococrw/asymmetric_crypto_ctx.h
@@ -45,7 +45,7 @@ public:
      * @returns The encrypted message
      * @throw MoCOCrWException If the encryption operation fails.
      */
-    virtual std::vector<uint8_t> encrypt(const std::vector<uint8_t>& message) = 0;
+    virtual std::vector<uint8_t> encrypt(const std::vector<uint8_t> &message) = 0;
 };
 
 /**
@@ -68,7 +68,7 @@ public:
      * @returns The decrypted message
      * @throw MoCOCrWException If the decryption operation fails.
      */
-    virtual std::vector<uint8_t> decrypt(const std::vector<uint8_t>& message) = 0;
+    virtual std::vector<uint8_t> decrypt(const std::vector<uint8_t> &message) = 0;
 };
 
 /**
@@ -95,7 +95,7 @@ public:
      * @throw MoCOCrWException If key is not an RSA private key
      */
     RSAEncryptionPrivateKeyCtx(
-            const AsymmetricPrivateKey& key,
+            const AsymmetricPrivateKey &key,
             std::shared_ptr<RSAEncryptionPadding> padding = std::make_shared<OAEPPadding>());
     /**
      * @brief Destructor
@@ -105,14 +105,14 @@ public:
     /**
      * @brief Copy Constructor
      */
-    RSAEncryptionPrivateKeyCtx(const RSAEncryptionPrivateKeyCtx& other);
+    RSAEncryptionPrivateKeyCtx(const RSAEncryptionPrivateKeyCtx &other);
 
     /**
      * @brief Copy Assignment
      */
-    RSAEncryptionPrivateKeyCtx& operator=(const RSAEncryptionPrivateKeyCtx& other);
+    RSAEncryptionPrivateKeyCtx &operator=(const RSAEncryptionPrivateKeyCtx &other);
 
-    std::vector<uint8_t> decrypt(const std::vector<uint8_t>& message) override;
+    std::vector<uint8_t> decrypt(const std::vector<uint8_t> &message) override;
 
 private:
     /**
@@ -151,7 +151,7 @@ public:
      * @throw MoCOCrWException If key is not an RSA public key
      */
     RSAEncryptionPublicKeyCtx(
-            const AsymmetricPublicKey& key,
+            const AsymmetricPublicKey &key,
             std::shared_ptr<RSAEncryptionPadding> padding = std::make_shared<OAEPPadding>());
     /**
      * @brief Constructor
@@ -160,25 +160,25 @@ public:
      * @throw MoCOCrWException If cert doesn't contain an RSA public key
      */
     RSAEncryptionPublicKeyCtx(
-            const X509Certificate& cert,
+            const X509Certificate &cert,
             std::shared_ptr<RSAEncryptionPadding> padding = std::make_shared<OAEPPadding>());
 
     /**
      * @brief Copy Constructor
      */
-    RSAEncryptionPublicKeyCtx(const RSAEncryptionPublicKeyCtx& other);
+    RSAEncryptionPublicKeyCtx(const RSAEncryptionPublicKeyCtx &other);
 
     /**
      * @brief Copy Assignment
      */
-    RSAEncryptionPublicKeyCtx& operator=(const RSAEncryptionPublicKeyCtx& other);
+    RSAEncryptionPublicKeyCtx &operator=(const RSAEncryptionPublicKeyCtx &other);
 
     /**
      * @brief Destructor
      */
     ~RSAEncryptionPublicKeyCtx();
 
-    std::vector<uint8_t> encrypt(const std::vector<uint8_t>& message) override;
+    std::vector<uint8_t> encrypt(const std::vector<uint8_t> &message) override;
 
 private:
     /**
@@ -214,7 +214,7 @@ public:
      * @throw MoCOCrWException If the sign operation fails.
      * @throw MoCOCrWException If digest size doesn't match the expected digest size.
      */
-    virtual std::vector<uint8_t> signDigest(const std::vector<uint8_t>& messageDigest) = 0;
+    virtual std::vector<uint8_t> signDigest(const std::vector<uint8_t> &messageDigest) = 0;
 };
 
 /**
@@ -238,7 +238,7 @@ public:
      * @return The created signature
      * @throw MoCOCrWException If the sign operation fails.
      */
-    virtual std::vector<uint8_t> signMessage(const std::vector<uint8_t>& message) = 0;
+    virtual std::vector<uint8_t> signMessage(const std::vector<uint8_t> &message) = 0;
 };
 
 /**
@@ -261,8 +261,8 @@ public:
      * @param digest The signed digest
      * @throw MoCOCrWException If the verification fails.
      */
-    virtual void verifyDigest(const std::vector<uint8_t>& signature,
-                              const std::vector<uint8_t>& digest) = 0;
+    virtual void verifyDigest(const std::vector<uint8_t> &signature,
+                              const std::vector<uint8_t> &digest) = 0;
 };
 
 /**
@@ -285,8 +285,8 @@ public:
      * @param message The signed message
      * @throw MoCOCrWException If the verification fails.
      */
-    virtual void verifyMessage(const std::vector<uint8_t>& signature,
-                               const std::vector<uint8_t>& message) = 0;
+    virtual void verifyMessage(const std::vector<uint8_t> &signature,
+                               const std::vector<uint8_t> &message) = 0;
 };
 
 /**
@@ -313,28 +313,28 @@ public:
      * @throw MoCOCrWException If key is not an RSA private key
      */
     RSASignaturePrivateKeyCtx(
-            const AsymmetricPrivateKey& key,
+            const AsymmetricPrivateKey &key,
             openssl::DigestTypes hashFunction,
             std::shared_ptr<RSASignaturePadding> padding = std::make_shared<PSSPadding>());
 
     /**
      * @brief Copy Constructor
      */
-    RSASignaturePrivateKeyCtx(const RSASignaturePrivateKeyCtx& other);
+    RSASignaturePrivateKeyCtx(const RSASignaturePrivateKeyCtx &other);
 
     /**
      * @brief Copy Assignment
      */
-    RSASignaturePrivateKeyCtx& operator=(const RSASignaturePrivateKeyCtx& other);
+    RSASignaturePrivateKeyCtx &operator=(const RSASignaturePrivateKeyCtx &other);
 
     /**
      * @brief Destructor
      */
     ~RSASignaturePrivateKeyCtx();
 
-    std::vector<uint8_t> signDigest(const std::vector<uint8_t>& messageDigest) override;
+    std::vector<uint8_t> signDigest(const std::vector<uint8_t> &messageDigest) override;
 
-    std::vector<uint8_t> signMessage(const std::vector<uint8_t>& message) override;
+    std::vector<uint8_t> signMessage(const std::vector<uint8_t> &message) override;
 
 private:
     /**
@@ -373,7 +373,7 @@ public:
      * @throw MoCOCrWException If key is not an RSA public key
      */
     RSASignaturePublicKeyCtx(
-            const AsymmetricPublicKey& key,
+            const AsymmetricPublicKey &key,
             openssl::DigestTypes hashFunction,
             std::shared_ptr<RSASignaturePadding> padding = std::make_shared<PSSPadding>());
 
@@ -385,30 +385,30 @@ public:
      * @throw MoCOCrWException If cert doesn't contain an RSA public key
      */
     RSASignaturePublicKeyCtx(
-            const X509Certificate& cert,
+            const X509Certificate &cert,
             openssl::DigestTypes hashFunction,
             std::shared_ptr<RSASignaturePadding> padding = std::make_shared<PSSPadding>());
 
     /**
      * @brief Copy Constructor
      */
-    RSASignaturePublicKeyCtx(const RSASignaturePublicKeyCtx& other);
+    RSASignaturePublicKeyCtx(const RSASignaturePublicKeyCtx &other);
 
     /**
      * @brief Copy Assignment
      */
-    RSASignaturePublicKeyCtx& operator=(const RSASignaturePublicKeyCtx& other);
+    RSASignaturePublicKeyCtx &operator=(const RSASignaturePublicKeyCtx &other);
 
     /**
      * @brief Destructor
      */
     ~RSASignaturePublicKeyCtx();
 
-    void verifyDigest(const std::vector<uint8_t>& signature,
-                      const std::vector<uint8_t>& digest) override;
+    void verifyDigest(const std::vector<uint8_t> &signature,
+                      const std::vector<uint8_t> &digest) override;
 
-    void verifyMessage(const std::vector<uint8_t>& signature,
-                       const std::vector<uint8_t>& message) override;
+    void verifyMessage(const std::vector<uint8_t> &signature,
+                       const std::vector<uint8_t> &message) override;
 
 private:
     /**
@@ -459,7 +459,7 @@ public:
      * @param hashFunction The hash function to be used
      * @throw MoCOCrWException If key is not an ECC private key
      */
-    ECDSASignaturePrivateKeyCtx(const AsymmetricPrivateKey& key,
+    ECDSASignaturePrivateKeyCtx(const AsymmetricPrivateKey &key,
                                 openssl::DigestTypes hashFunction = openssl::DigestTypes::SHA256);
 
     /**
@@ -470,28 +470,28 @@ public:
      * @param sigFormat The format of the generated signature
      * @throw MoCOCrWException If key is not an ECC private key
      */
-    ECDSASignaturePrivateKeyCtx(const AsymmetricPrivateKey& key,
+    ECDSASignaturePrivateKeyCtx(const AsymmetricPrivateKey &key,
                                 openssl::DigestTypes hashFunction,
                                 ECDSASignatureFormat sigFormat);
 
     /**
      * @brief Copy Constructor
      */
-    ECDSASignaturePrivateKeyCtx(const ECDSASignaturePrivateKeyCtx& other);
+    ECDSASignaturePrivateKeyCtx(const ECDSASignaturePrivateKeyCtx &other);
 
     /**
      * @brief Copy Assignment
      */
-    ECDSASignaturePrivateKeyCtx& operator=(const ECDSASignaturePrivateKeyCtx& other);
+    ECDSASignaturePrivateKeyCtx &operator=(const ECDSASignaturePrivateKeyCtx &other);
 
     /**
      * @brief Destructor
      */
     ~ECDSASignaturePrivateKeyCtx();
 
-    std::vector<uint8_t> signDigest(const std::vector<uint8_t>& messageDigest) override;
+    std::vector<uint8_t> signDigest(const std::vector<uint8_t> &messageDigest) override;
 
-    std::vector<uint8_t> signMessage(const std::vector<uint8_t>& message) override;
+    std::vector<uint8_t> signMessage(const std::vector<uint8_t> &message) override;
 
 private:
     /**
@@ -522,7 +522,7 @@ public:
      * @param hashFunction The hash function to be used
      * @throw MoCOCrWException If key is not an ECC public key
      */
-    ECDSASignaturePublicKeyCtx(const AsymmetricPublicKey& key,
+    ECDSASignaturePublicKeyCtx(const AsymmetricPublicKey &key,
                                openssl::DigestTypes hashFunction = openssl::DigestTypes::SHA256);
 
     /**
@@ -538,7 +538,7 @@ public:
      */
     [[deprecated(
             "Replaced by ECDSASignaturePublicKeyCtx() which expects ECDSASignatureFormat instead "
-            "of ECSDASignatureFormat")]] ECDSASignaturePublicKeyCtx(const AsymmetricPublicKey& key,
+            "of ECSDASignatureFormat")]] ECDSASignaturePublicKeyCtx(const AsymmetricPublicKey &key,
                                                                     openssl::DigestTypes
                                                                             hashFunction,
                                                                     ECSDASignatureFormat sigFormat);
@@ -551,7 +551,7 @@ public:
      * @param sigFormat The format that in which signatures are provided
      * @throw MoCOCrWException If key is not an ECC public key
      */
-    ECDSASignaturePublicKeyCtx(const AsymmetricPublicKey& key,
+    ECDSASignaturePublicKeyCtx(const AsymmetricPublicKey &key,
                                openssl::DigestTypes hashFunction,
                                ECDSASignatureFormat sigFormat);
 
@@ -562,7 +562,7 @@ public:
      * @param hashFunction The hash function to be used
      * @throw MoCOCrWException If cert doesn't contain an ECC public key
      */
-    ECDSASignaturePublicKeyCtx(const X509Certificate& cert,
+    ECDSASignaturePublicKeyCtx(const X509Certificate &cert,
                                openssl::DigestTypes hashFunction = openssl::DigestTypes::SHA256);
 
     /**
@@ -578,7 +578,7 @@ public:
      */
     [[deprecated(
             "Replaced by ECDSASignaturePublicKeyCtx() which expects ECDSASignatureFormat instead "
-            "of ECSDASignatureFormat")]] ECDSASignaturePublicKeyCtx(const X509Certificate& cert,
+            "of ECSDASignatureFormat")]] ECDSASignaturePublicKeyCtx(const X509Certificate &cert,
                                                                     openssl::DigestTypes
                                                                             hashFunction,
                                                                     ECSDASignatureFormat sigFormat);
@@ -591,30 +591,30 @@ public:
      * @param sigFormat The format that in which signatures are provided
      * @throw MoCOCrWException If cert doesn't contain an ECC public key
      */
-    ECDSASignaturePublicKeyCtx(const X509Certificate& cert,
+    ECDSASignaturePublicKeyCtx(const X509Certificate &cert,
                                openssl::DigestTypes hashFunction,
                                ECDSASignatureFormat sigFormat);
 
     /**
      * @brief Copy Constructor
      */
-    ECDSASignaturePublicKeyCtx(const ECDSASignaturePublicKeyCtx& other);
+    ECDSASignaturePublicKeyCtx(const ECDSASignaturePublicKeyCtx &other);
 
     /**
      * @brief Copy Assignment
      */
-    ECDSASignaturePublicKeyCtx& operator=(const ECDSASignaturePublicKeyCtx& other);
+    ECDSASignaturePublicKeyCtx &operator=(const ECDSASignaturePublicKeyCtx &other);
 
     /**
      * @brief Destructor
      */
     ~ECDSASignaturePublicKeyCtx();
 
-    void verifyDigest(const std::vector<uint8_t>& signature,
-                      const std::vector<uint8_t>& digest) override;
+    void verifyDigest(const std::vector<uint8_t> &signature,
+                      const std::vector<uint8_t> &digest) override;
 
-    void verifyMessage(const std::vector<uint8_t>& signature,
-                       const std::vector<uint8_t>& message) override;
+    void verifyMessage(const std::vector<uint8_t> &signature,
+                       const std::vector<uint8_t> &message) override;
 
 private:
     /**
@@ -642,7 +642,7 @@ public:
      * @param key The private key to be used
      * @throw MoCOCrWException If key is not an Ed448 or Ed25519 private key
      */
-    EdDSASignaturePrivateKeyCtx(const AsymmetricPrivateKey& key);
+    EdDSASignaturePrivateKeyCtx(const AsymmetricPrivateKey &key);
 
     /**
      * @brief Destructor
@@ -652,14 +652,14 @@ public:
     /**
      * @brief Copy Constructor
      */
-    EdDSASignaturePrivateKeyCtx(const EdDSASignaturePrivateKeyCtx& other);
+    EdDSASignaturePrivateKeyCtx(const EdDSASignaturePrivateKeyCtx &other);
 
     /**
      * @brief Copy Assignment
      */
-    EdDSASignaturePrivateKeyCtx& operator=(const EdDSASignaturePrivateKeyCtx& other);
+    EdDSASignaturePrivateKeyCtx &operator=(const EdDSASignaturePrivateKeyCtx &other);
 
-    std::vector<uint8_t> signMessage(const std::vector<uint8_t>& message) override;
+    std::vector<uint8_t> signMessage(const std::vector<uint8_t> &message) override;
 
 private:
     /**
@@ -687,14 +687,14 @@ public:
      * @param key The public key to be used
      * @throw MoCOCrWException If key is not an Ed448 or Ed25519 public key
      */
-    EdDSASignaturePublicKeyCtx(const AsymmetricPublicKey& key);
+    EdDSASignaturePublicKeyCtx(const AsymmetricPublicKey &key);
 
     /**
      * @brief Constructor
      * @param cert The certificate containing the publiy key to be used
      * @throw MoCOCrWException If the certificate does not contain an Ed448 or Ed25519 public key
      */
-    EdDSASignaturePublicKeyCtx(const X509Certificate& cert);
+    EdDSASignaturePublicKeyCtx(const X509Certificate &cert);
 
     /**
      * @brief Destructor
@@ -704,15 +704,15 @@ public:
     /**
      * @brief Copy Constructor
      */
-    EdDSASignaturePublicKeyCtx(const EdDSASignaturePublicKeyCtx& other);
+    EdDSASignaturePublicKeyCtx(const EdDSASignaturePublicKeyCtx &other);
 
     /**
      * @brief Copy Assignment
      */
-    EdDSASignaturePublicKeyCtx& operator=(const EdDSASignaturePublicKeyCtx& other);
+    EdDSASignaturePublicKeyCtx &operator=(const EdDSASignaturePublicKeyCtx &other);
 
-    void verifyMessage(const std::vector<uint8_t>& signature,
-                       const std::vector<uint8_t>& message) override;
+    void verifyMessage(const std::vector<uint8_t> &signature,
+                       const std::vector<uint8_t> &message) override;
 
 private:
     /**

--- a/src/mococrw/crl.h
+++ b/src/mococrw/crl.h
@@ -57,7 +57,7 @@ public:
      * @param signer the certificate that issued this CRL (and therefore signed it).
      * @throw MoCOCrWException if the verification failed.
      */
-    void verify(const X509Certificate& signer) const;
+    void verify(const X509Certificate &signer) const;
 
     /**
      * Creates a PEM representation of this CRL.
@@ -68,35 +68,35 @@ public:
      * Creates a CertificateRevocationList from a PEM representation.
      * @throw openssl::OpenSSLException if the PEM was invalid.
      */
-    static CertificateRevocationList fromPEM(const std::string& pem);
+    static CertificateRevocationList fromPEM(const std::string &pem);
 
     /**
      * Creates a CertificateRevocationList from a PEM representation in a file.
      * @throw openssl::OpenSSLException if the PEM was invalid or the file could not be read.
      */
-    static CertificateRevocationList fromPEMFile(const std::string& filename);
+    static CertificateRevocationList fromPEMFile(const std::string &filename);
 
     /**
      * Creates a CertificateRevocationList from a DER representation.
      * @throw openssl::OpenSSLException if the DER was invalid.
      */
-    static CertificateRevocationList fromDER(const std::vector<uint8_t>& derData);
+    static CertificateRevocationList fromDER(const std::vector<uint8_t> &derData);
 
     /**
      * Creates a CertificateRevocationList from a DER representation in a file.
      * @throw openssl::OpenSSLException if the DER was invalid or the file could not be read.
      */
-    static CertificateRevocationList fromDERFile(const std::string& filename);
+    static CertificateRevocationList fromDERFile(const std::string &filename);
 
     /**
      * Grants access to the internal OpenSSL object that is wrapped by this class.
      */
-    X509_CRL* internal();
+    X509_CRL *internal();
 
     /**
      * Grants access to the internal OpenSSL object that is wrapped by this class.
      */
-    const X509_CRL* internal() const;
+    const X509_CRL *internal() const;
 
 private:
     CertificateRevocationList(openssl::SSL_X509_CRL_Ptr crl) : _crl{std::move(crl)} {}
@@ -115,7 +115,7 @@ namespace util
  *         PEM string
  * @throw MoCOCrWException if the input or one of the included CRLs is invalid
  */
-std::vector<CertificateRevocationList> loadCrlPEMChain(const std::string& pemChain);
+std::vector<CertificateRevocationList> loadCrlPEMChain(const std::string &pemChain);
 
 }  // namespace util
 

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -51,8 +51,8 @@ public:
 
     std::unique_ptr<Spec> getKeySpec() const;
 
-    inline const openssl::SSL_EVP_PKEY_SharedPtr& internal() const { return _key; }
-    inline openssl::SSL_EVP_PKEY_SharedPtr& internal() { return _key; }
+    inline const openssl::SSL_EVP_PKEY_SharedPtr &internal() const { return _key; }
+    inline openssl::SSL_EVP_PKEY_SharedPtr &internal() { return _key; }
 
 private:
     openssl::SSL_EVP_PKEY_SharedPtr _key;
@@ -84,14 +84,14 @@ public:
      * @return the AsymmetricPublicKey object created form the PEM string
      * @throws This method may throw an OpenSSLException if OpenSSL indicates an error
      */
-    static AsymmetricPublicKey readPublicKeyFromPEM(const std::string& pem);
+    static AsymmetricPublicKey readPublicKeyFromPEM(const std::string &pem);
 
 #ifdef HSM_ENABLED
     /**
      * Loads a public key from an HSM, creating an @ref AsymmetricPublicKey
      * object as a result.
      */
-    static AsymmetricPublicKey readPublicKeyFromHSM(HSM& hsm, const std::string& keyID);
+    static AsymmetricPublicKey readPublicKeyFromHSM(HSM &hsm, const std::string &keyID);
 #endif
 
     /**
@@ -110,7 +110,7 @@ public:
      * @return An asymmetric public key
      */
     static AsymmetricPublicKey fromECPoint(const std::shared_ptr<ECCSpec> keySpec,
-                                           const std::vector<uint8_t>& point);
+                                           const std::vector<uint8_t> &point);
 
     /**
      * @brief This returns the point(s) of the current AsymmetricPublicKey in octet representation.
@@ -142,8 +142,8 @@ public:
     /**
      * Getters for the internal openSSL object.
      */
-    inline EVP_PKEY* internal() { return _key.internal().get(); }
-    inline const EVP_PKEY* internal() const { return _key.internal().get(); }
+    inline EVP_PKEY *internal() { return _key.internal().get(); }
+    inline const EVP_PKEY *internal() const { return _key.internal().get(); }
 
     /**
      * Gets the type of the asymmetric key or key pair, @see AsymmetricKey::KeyTypes for the
@@ -167,14 +167,14 @@ public:
      */
     int getKeySize() const { return _key.getKeySize(); }
 
-    inline bool operator==(const AsymmetricPublicKey& rhs) const
+    inline bool operator==(const AsymmetricPublicKey &rhs) const
     {
         return openssl::_EVP_PKEY_cmp(internal(), rhs.internal());
     }
-    inline bool operator!=(const AsymmetricPublicKey& rhs) const { return !(*this == rhs); }
+    inline bool operator!=(const AsymmetricPublicKey &rhs) const { return !(*this == rhs); }
 
 protected:
-    AsymmetricPublicKey(AsymmetricKey&& key) : _key{std::move(key)} {}
+    AsymmetricPublicKey(AsymmetricKey &&key) : _key{std::move(key)} {}
 
     AsymmetricKey _key;
 };
@@ -221,7 +221,7 @@ public:
      * @throws This method may throw an OpenSSLException if OpenSSL
      *      indicates an error
      */
-    static AsymmetricKeypair generate(const AsymmetricKey::Spec&);
+    static AsymmetricKeypair generate(const AsymmetricKey::Spec &);
 
     /**
      * Generate a RSA asymmetric keypair with default Spec.
@@ -260,21 +260,21 @@ public:
      * @throw OpenSSLException if OpenSSL indicates an error during the serialization
      *                         procedure
      */
-    std::string privateKeyToPem(const std::string& pwd) const;
+    std::string privateKeyToPem(const std::string &pwd) const;
 
-    static AsymmetricKeypair readPrivateKeyFromPEM(const std::string& pem,
-                                                   const std::string& password);
+    static AsymmetricKeypair readPrivateKeyFromPEM(const std::string &pem,
+                                                   const std::string &password);
 
 #ifdef HSM_ENABLED
     /**
      * Loads a private key from an HSM, creating an @ref AsymmetricPublicKey
      * object as a result.
      */
-    static AsymmetricKeypair readPrivateKeyFromHSM(HSM& hsm, const std::string& keyID);
+    static AsymmetricKeypair readPrivateKeyFromHSM(HSM &hsm, const std::string &keyID);
 #endif
 
 private:
-    AsymmetricKeypair(AsymmetricKey&& key) : AsymmetricPublicKey{std::move(key)} {}
+    AsymmetricKeypair(AsymmetricKey &&key) : AsymmetricPublicKey{std::move(key)} {}
 };
 
 /**

--- a/src/mococrw/key_usage.h
+++ b/src/mococrw/key_usage.h
@@ -97,12 +97,12 @@ private:
     }
 
 public:
-    bool operator==(const KeyUsageExtension& other) const
+    bool operator==(const KeyUsageExtension &other) const
     {
         return _makeTuple() == other._makeTuple();
     }
 
-    bool operator!=(const KeyUsageExtension& other) const { return !operator==(other); }
+    bool operator!=(const KeyUsageExtension &other) const { return !operator==(other); }
 
     std::string getConfigurationString() const override
     {
@@ -152,55 +152,55 @@ private:
 class KeyUsageExtension::Builder
 {
 public:
-    Builder& decipherOnly()
+    Builder &decipherOnly()
     {
         _ku._decipherOnly = true;
         return *this;
     }
 
-    Builder& encipherOnly()
+    Builder &encipherOnly()
     {
         _ku._encipherOnly = true;
         return *this;
     }
 
-    Builder& cRLSign()
+    Builder &cRLSign()
     {
         _ku._cRLSign = true;
         return *this;
     }
 
-    Builder& keyCertSign()
+    Builder &keyCertSign()
     {
         _ku._keyCertSign = true;
         return *this;
     }
 
-    Builder& keyAgreement()
+    Builder &keyAgreement()
     {
         _ku._keyAgreement = true;
         return *this;
     }
 
-    Builder& dataEncipherment()
+    Builder &dataEncipherment()
     {
         _ku._dataEncipherment = true;
         return *this;
     }
 
-    Builder& keyEncipherment()
+    Builder &keyEncipherment()
     {
         _ku._keyEncipherment = true;
         return *this;
     }
 
-    Builder& nonRepudiation()
+    Builder &nonRepudiation()
     {
         _ku._nonRepudiation = true;
         return *this;
     }
 
-    Builder& digitalSignature()
+    Builder &digitalSignature()
     {
         _ku._digitalSignature = true;
         return *this;

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -59,123 +59,123 @@ namespace lib
 class OpenSSLLib
 {
 public:
-    static int SSL_ENGINE_free(ENGINE* e) noexcept;
-    static int SSL_ENGINE_finish(ENGINE* e) noexcept;
-    static ENGINE* SSL_ENGINE_by_id(const char* id) noexcept;
-    static int SSL_ENGINE_init(ENGINE* e) noexcept;
-    static int SSL_ENGINE_ctrl_cmd_string(ENGINE* e,
-                                          const char* cmd_name,
-                                          const char* cmd_arg,
+    static int SSL_ENGINE_free(ENGINE *e) noexcept;
+    static int SSL_ENGINE_finish(ENGINE *e) noexcept;
+    static ENGINE *SSL_ENGINE_by_id(const char *id) noexcept;
+    static int SSL_ENGINE_init(ENGINE *e) noexcept;
+    static int SSL_ENGINE_ctrl_cmd_string(ENGINE *e,
+                                          const char *cmd_name,
+                                          const char *cmd_arg,
                                           int cmd_optional) noexcept;
-    static EVP_PKEY* SSL_ENGINE_load_public_key(ENGINE* e,
-                                                const char* key_id,
-                                                UI_METHOD* ui_method,
-                                                void* callback_data) noexcept;
-    static EVP_PKEY* SSL_ENGINE_load_private_key(ENGINE* e,
-                                                 const char* key_id,
-                                                 UI_METHOD* ui_method,
-                                                 void* callback_data) noexcept;
-    static ECDSA_SIG* SSL_d2i_ECDSA_SIG(ECDSA_SIG** sig,
-                                        const unsigned char** pp,
+    static EVP_PKEY *SSL_ENGINE_load_public_key(ENGINE *e,
+                                                const char *key_id,
+                                                UI_METHOD *ui_method,
+                                                void *callback_data) noexcept;
+    static EVP_PKEY *SSL_ENGINE_load_private_key(ENGINE *e,
+                                                 const char *key_id,
+                                                 UI_METHOD *ui_method,
+                                                 void *callback_data) noexcept;
+    static ECDSA_SIG *SSL_d2i_ECDSA_SIG(ECDSA_SIG **sig,
+                                        const unsigned char **pp,
                                         long len) noexcept;
-    static int SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char** pp) noexcept;
-    static int SSL_ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s) noexcept;
-    static const BIGNUM* SSL_ECDSA_SIG_get0_s(const ECDSA_SIG* sig) noexcept;
-    static const BIGNUM* SSL_ECDSA_SIG_get0_r(const ECDSA_SIG* sig) noexcept;
-    static void SSL_ECDSA_SIG_free(ECDSA_SIG* sig) noexcept;
-    static ECDSA_SIG* SSL_ECDSA_SIG_new() noexcept;
-    static BIGNUM* SSL_BN_bin2bn(const unsigned char* s, int len, BIGNUM* ret) noexcept;
-    static int SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) noexcept;
-    static int SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) noexcept;
-    static X509_REQ* SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) noexcept;
-    static const char* SSL_EVP_CIPHER_name(const EVP_CIPHER* cipher) noexcept;
-    static int SSL_EVP_CIPHER_key_length(const EVP_CIPHER* cipher) noexcept;
-    static int SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX* c, int pad) noexcept;
-    static int SSL_EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX* c) noexcept;
-    static int SSL_RAND_bytes(unsigned char* buf, int num) noexcept;
-    static int SSL_EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX* ctx) noexcept;
-    static int SSL_EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX* ctx) noexcept;
-    static int SSL_EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX* ctx, int type, int arg, void* ptr) noexcept;
-    static void SSL_EVP_CIPHER_CTX_free(EVP_CIPHER_CTX* c) noexcept;
-    static EVP_CIPHER_CTX* SSL_EVP_CIPHER_CTX_new() noexcept;
-    static int SSL_EVP_CipherInit_ex(EVP_CIPHER_CTX* ctx,
-                                     const EVP_CIPHER* cipher,
-                                     ENGINE* impl,
-                                     const unsigned char* key,
-                                     const unsigned char* iv,
+    static int SSL_i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp) noexcept;
+    static int SSL_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) noexcept;
+    static const BIGNUM *SSL_ECDSA_SIG_get0_s(const ECDSA_SIG *sig) noexcept;
+    static const BIGNUM *SSL_ECDSA_SIG_get0_r(const ECDSA_SIG *sig) noexcept;
+    static void SSL_ECDSA_SIG_free(ECDSA_SIG *sig) noexcept;
+    static ECDSA_SIG *SSL_ECDSA_SIG_new() noexcept;
+    static BIGNUM *SSL_BN_bin2bn(const unsigned char *s, int len, BIGNUM *ret) noexcept;
+    static int SSL_BN_bn2binpad(const BIGNUM *a, unsigned char *to, int tolen) noexcept;
+    static int SSL_i2d_X509_REQ_bio(BIO *bp, X509_REQ *req) noexcept;
+    static X509_REQ *SSL_d2i_X509_REQ_bio(BIO *bp, X509_REQ **req) noexcept;
+    static const char *SSL_EVP_CIPHER_name(const EVP_CIPHER *cipher) noexcept;
+    static int SSL_EVP_CIPHER_key_length(const EVP_CIPHER *cipher) noexcept;
+    static int SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *c, int pad) noexcept;
+    static int SSL_EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *c) noexcept;
+    static int SSL_RAND_bytes(unsigned char *buf, int num) noexcept;
+    static int SSL_EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx) noexcept;
+    static int SSL_EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX *ctx) noexcept;
+    static int SSL_EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr) noexcept;
+    static void SSL_EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *c) noexcept;
+    static EVP_CIPHER_CTX *SSL_EVP_CIPHER_CTX_new() noexcept;
+    static int SSL_EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx,
+                                     const EVP_CIPHER *cipher,
+                                     ENGINE *impl,
+                                     const unsigned char *key,
+                                     const unsigned char *iv,
                                      int enc) noexcept;
-    static int SSL_EVP_CipherFinal_ex(EVP_CIPHER_CTX* ctx, unsigned char* outm, int* outl) noexcept;
-    static int SSL_EVP_CipherUpdate(EVP_CIPHER_CTX* ctx,
-                                    unsigned char* out,
-                                    int* outl,
-                                    const unsigned char* in,
+    static int SSL_EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl) noexcept;
+    static int SSL_EVP_CipherUpdate(EVP_CIPHER_CTX *ctx,
+                                    unsigned char *out,
+                                    int *outl,
+                                    const unsigned char *in,
                                     int inl) noexcept;
-    static int SSL_EVP_MD_CTX_reset(EVP_MD_CTX* ctx) noexcept;
-    static int SSL_EVP_DigestFinal_ex(EVP_MD_CTX* ctx, unsigned char* md, unsigned int* s) noexcept;
-    static int SSL_EVP_DigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt) noexcept;
-    static int SSL_EVP_DigestInit_ex(EVP_MD_CTX* ctx, const EVP_MD* type, ENGINE* impl) noexcept;
-    static void SSL_EVP_MD_CTX_init(EVP_MD_CTX* ctx) noexcept;
-    static void SSL_X509_STORE_CTX_set_time(X509_STORE_CTX* ctx,
+    static int SSL_EVP_MD_CTX_reset(EVP_MD_CTX *ctx) noexcept;
+    static int SSL_EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) noexcept;
+    static int SSL_EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt) noexcept;
+    static int SSL_EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl) noexcept;
+    static void SSL_EVP_MD_CTX_init(EVP_MD_CTX *ctx) noexcept;
+    static void SSL_X509_STORE_CTX_set_time(X509_STORE_CTX *ctx,
                                             unsigned long flags,
                                             time_t t) noexcept;
-    static ASN1_TIME* SSL_ASN1_TIME_adj(ASN1_TIME* s,
+    static ASN1_TIME *SSL_ASN1_TIME_adj(ASN1_TIME *s,
                                         time_t t,
                                         int offset_day,
                                         long offset_sec) noexcept;
-    static int SSL_sk_X509_CRL_push(STACK_OF(X509_CRL) * stack, const X509_CRL* crl) noexcept;
+    static int SSL_sk_X509_CRL_push(STACK_OF(X509_CRL) * stack, const X509_CRL *crl) noexcept;
     static STACK_OF(X509_CRL) * SSL_sk_X509_CRL_new_null() noexcept;
     static void SSL_sk_X509_CRL_free(STACK_OF(X509_CRL) * stack) noexcept;
-    static void SSL_X509_STORE_CTX_set0_crls(X509_STORE_CTX* ctx,
+    static void SSL_X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx,
                                              STACK_OF(X509_CRL) * crls) noexcept;
-    static X509_CRL* SSL_X509_CRL_new() noexcept;
-    static void SSL_X509_CRL_free(X509_CRL* a) noexcept;
-    static X509_CRL* SSL_d2i_X509_CRL_bio(BIO* bp, X509_CRL** crl) noexcept;
-    static int SSL_PEM_write_bio_X509_CRL(BIO* bp, X509_CRL* x) noexcept;
-    static X509_CRL* SSL_PEM_read_bio_X509_CRL(BIO* bp,
-                                               X509_CRL** x,
-                                               pem_password_cb* cb,
-                                               void* u) noexcept;
-    static const ASN1_TIME* SSL_X509_CRL_get_lastUpdate(const X509_CRL* x) noexcept;
-    static const ASN1_TIME* SSL_X509_CRL_get_nextUpdate(const X509_CRL* x) noexcept;
-    static int SSL_X509_CRL_verify(X509_CRL* a, EVP_PKEY* r) noexcept;
-    static X509_NAME* SSL_X509_CRL_get_issuer(const X509_CRL* crl) noexcept;
-    static ASN1_STRING* SSL_ASN1_STRING_dup(const ASN1_STRING* str) noexcept;
-    static ASN1_TIME* SSL_ASN1_TIME_new() noexcept;
-    static int SSL_ASN1_TIME_set_string(ASN1_TIME* s, const char* str) noexcept;
-    static int SSL_BN_num_bytes(const BIGNUM* a) noexcept;
-    static int SSL_BN_bn2bin(const BIGNUM* a, unsigned char* to) noexcept;
-    static ASN1_INTEGER* SSL_ASN1_INTEGER_new() noexcept;
-    static void SSL_ASN1_INTEGER_free(ASN1_INTEGER* a) noexcept;
-    static void* SSL_OPENSSL_malloc(int num) noexcept;
-    static void SSL_OPENSSL_free(void* addr) noexcept;
-    static char* SSL_BN_bn2dec(const BIGNUM* a) noexcept;
-    static void SSL_BN_free(BIGNUM* a) noexcept;
-    static BIGNUM* SSL_ASN1_INTEGER_to_BN(const ASN1_INTEGER* ai, BIGNUM* bn) noexcept;
-    static int SSL_ASN1_INTEGER_cmp(const ASN1_INTEGER* x, const ASN1_INTEGER* y) noexcept;
-    static long SSL_ASN1_INTEGER_get(const ASN1_INTEGER* a) noexcept;
-    static int SSL_ASN1_INTEGER_set(ASN1_INTEGER* a, long value) noexcept;
-    static ASN1_INTEGER* SSL_X509_get_serialNumber(X509* x) noexcept;
-    static int SSL_X509_set_serialNumber(X509* x, ASN1_INTEGER* serial) noexcept;
-    static void SSL_X509V3_set_ctx(X509V3_CTX* ctx,
-                                   X509* issuer,
-                                   X509* subject,
-                                   X509_REQ* req,
-                                   X509_CRL* crl,
+    static X509_CRL *SSL_X509_CRL_new() noexcept;
+    static void SSL_X509_CRL_free(X509_CRL *a) noexcept;
+    static X509_CRL *SSL_d2i_X509_CRL_bio(BIO *bp, X509_CRL **crl) noexcept;
+    static int SSL_PEM_write_bio_X509_CRL(BIO *bp, X509_CRL *x) noexcept;
+    static X509_CRL *SSL_PEM_read_bio_X509_CRL(BIO *bp,
+                                               X509_CRL **x,
+                                               pem_password_cb *cb,
+                                               void *u) noexcept;
+    static const ASN1_TIME *SSL_X509_CRL_get_lastUpdate(const X509_CRL *x) noexcept;
+    static const ASN1_TIME *SSL_X509_CRL_get_nextUpdate(const X509_CRL *x) noexcept;
+    static int SSL_X509_CRL_verify(X509_CRL *a, EVP_PKEY *r) noexcept;
+    static X509_NAME *SSL_X509_CRL_get_issuer(const X509_CRL *crl) noexcept;
+    static ASN1_STRING *SSL_ASN1_STRING_dup(const ASN1_STRING *str) noexcept;
+    static ASN1_TIME *SSL_ASN1_TIME_new() noexcept;
+    static int SSL_ASN1_TIME_set_string(ASN1_TIME *s, const char *str) noexcept;
+    static int SSL_BN_num_bytes(const BIGNUM *a) noexcept;
+    static int SSL_BN_bn2bin(const BIGNUM *a, unsigned char *to) noexcept;
+    static ASN1_INTEGER *SSL_ASN1_INTEGER_new() noexcept;
+    static void SSL_ASN1_INTEGER_free(ASN1_INTEGER *a) noexcept;
+    static void *SSL_OPENSSL_malloc(int num) noexcept;
+    static void SSL_OPENSSL_free(void *addr) noexcept;
+    static char *SSL_BN_bn2dec(const BIGNUM *a) noexcept;
+    static void SSL_BN_free(BIGNUM *a) noexcept;
+    static BIGNUM *SSL_ASN1_INTEGER_to_BN(const ASN1_INTEGER *ai, BIGNUM *bn) noexcept;
+    static int SSL_ASN1_INTEGER_cmp(const ASN1_INTEGER *x, const ASN1_INTEGER *y) noexcept;
+    static long SSL_ASN1_INTEGER_get(const ASN1_INTEGER *a) noexcept;
+    static int SSL_ASN1_INTEGER_set(ASN1_INTEGER *a, long value) noexcept;
+    static ASN1_INTEGER *SSL_X509_get_serialNumber(X509 *x) noexcept;
+    static int SSL_X509_set_serialNumber(X509 *x, ASN1_INTEGER *serial) noexcept;
+    static void SSL_X509V3_set_ctx(X509V3_CTX *ctx,
+                                   X509 *issuer,
+                                   X509 *subject,
+                                   X509_REQ *req,
+                                   X509_CRL *crl,
                                    int flags) noexcept;
-    static void SSL_X509V3_set_ctx_nodb(X509V3_CTX* ctx) noexcept;
-    static void SSL_X509_EXTENSION_free(X509_EXTENSION* a) noexcept;
-    static int SSL_X509_add_ext(X509* x, X509_EXTENSION* ex, int loc) noexcept;
-    static X509_EXTENSION* SSL_X509V3_EXT_conf_nid(lhash_st_CONF_VALUE* conf,
-                                                   X509V3_CTX* ctx,
+    static void SSL_X509V3_set_ctx_nodb(X509V3_CTX *ctx) noexcept;
+    static void SSL_X509_EXTENSION_free(X509_EXTENSION *a) noexcept;
+    static int SSL_X509_add_ext(X509 *x, X509_EXTENSION *ex, int loc) noexcept;
+    static X509_EXTENSION *SSL_X509V3_EXT_conf_nid(lhash_st_CONF_VALUE *conf,
+                                                   X509V3_CTX *ctx,
                                                    int ext_nid,
-                                                   char* value) noexcept;
+                                                   char *value) noexcept;
 
-    static const EVP_CIPHER* SSL_EVP_aes_128_cbc() noexcept;
-    static const EVP_CIPHER* SSL_EVP_aes_256_cbc() noexcept;
+    static const EVP_CIPHER *SSL_EVP_aes_128_cbc() noexcept;
+    static const EVP_CIPHER *SSL_EVP_aes_256_cbc() noexcept;
 
-    static int SSL_BIO_write(BIO* b, const void* buf, int len) noexcept;
-    static int SSL_BIO_read(BIO* b, void* buf, int len) noexcept;
-    static BIO* SSL_BIO_new_file(const char* filename, const char* mode) noexcept;
+    static int SSL_BIO_write(BIO *b, const void *buf, int len) noexcept;
+    static int SSL_BIO_read(BIO *b, void *buf, int len) noexcept;
+    static BIO *SSL_BIO_new_file(const char *filename, const char *mode) noexcept;
 
     /* Initialization */
     static void SSL_ERR_load_crypto_strings() noexcept;
@@ -184,275 +184,275 @@ public:
     static void SSL_CRYPTO_malloc_init() noexcept;
 
     /* Key Generation */
-    static EVP_PKEY* SSL_EVP_PKEY_new() noexcept;
-    static void SSL_EVP_PKEY_free(EVP_PKEY* ptr) noexcept;
-    static int SSL_EVP_PKEY_keygen(EVP_PKEY_CTX* ctx, EVP_PKEY** ppkey) noexcept;
-    static int SSL_EVP_PKEY_keygen_init(EVP_PKEY_CTX* ctx) noexcept;
-    static EVP_PKEY_CTX* SSL_EVP_PKEY_CTX_new(EVP_PKEY* pkey, ENGINE* engine) noexcept;
-    static EVP_PKEY_CTX* SSL_EVP_PKEY_CTX_new_id(int id, ENGINE* engine) noexcept;
-    static void SSL_EVP_PKEY_CTX_free(EVP_PKEY_CTX* ptr) noexcept;
-    static int SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits) noexcept;
-    static int SSL_EVP_PKEY_cmp(const EVP_PKEY* a, const EVP_PKEY* b) noexcept;
-    static int SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX* ctx) noexcept;
-    static int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX* ctx, EVP_PKEY** ppkey) noexcept;
-    static int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX* ctx, int nid) noexcept;
-    static int SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX* ctx, int param_enc) noexcept;
-    static const EC_GROUP* SSL_EC_KEY_get0_group(const EC_KEY* key) noexcept;
-    static int SSL_EC_GROUP_get_curve_name(const EC_GROUP* group) noexcept;
-    static int SSL_EC_GROUP_get_degree(const EC_GROUP* group) noexcept;
+    static EVP_PKEY *SSL_EVP_PKEY_new() noexcept;
+    static void SSL_EVP_PKEY_free(EVP_PKEY *ptr) noexcept;
+    static int SSL_EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept;
+    static int SSL_EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx) noexcept;
+    static EVP_PKEY_CTX *SSL_EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *engine) noexcept;
+    static EVP_PKEY_CTX *SSL_EVP_PKEY_CTX_new_id(int id, ENGINE *engine) noexcept;
+    static void SSL_EVP_PKEY_CTX_free(EVP_PKEY_CTX *ptr) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX *ctx, int mbits) noexcept;
+    static int SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) noexcept;
+    static int SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) noexcept;
+    static int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) noexcept;
+    static const EC_GROUP *SSL_EC_KEY_get0_group(const EC_KEY *key) noexcept;
+    static int SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) noexcept;
+    static int SSL_EC_GROUP_get_degree(const EC_GROUP *group) noexcept;
     static int SSL_EVP_PKEY_type(int type) noexcept;
-    static int SSL_EVP_PKEY_id(const EVP_PKEY* pkey) noexcept;
-    static int SSL_EVP_PKEY_size(EVP_PKEY* pkey) noexcept;
+    static int SSL_EVP_PKEY_id(const EVP_PKEY *pkey) noexcept;
+    static int SSL_EVP_PKEY_size(EVP_PKEY *pkey) noexcept;
 
     /* Error handling */
-    static char* SSL_ERR_error_string(unsigned long error, char* buf) noexcept;
+    static char *SSL_ERR_error_string(unsigned long error, char *buf) noexcept;
     static unsigned long SSL_ERR_get_error() noexcept;
 
     /* BIO Stuff */
-    static const BIO_METHOD* SSL_BIO_s_mem() noexcept;
-    static void SSL_BIO_free_all(BIO* ptr) noexcept;
-    static BIO* SSL_BIO_new(const BIO_METHOD* method) noexcept;
-    static int SSL_BIO_gets(BIO* bio, char* buf, int size) noexcept;
-    static int SSL_BIO_puts(BIO* bio, char* buf) noexcept;
-    static int SSL_PEM_write_bio_X509_REQ(BIO* bio, X509_REQ* req) noexcept;
-    static X509_REQ* SSL_PEM_read_bio_X509_REQ(BIO* bp,
-                                               X509_REQ** x,
-                                               pem_password_cb* cb,
-                                               void* u) noexcept;
+    static const BIO_METHOD *SSL_BIO_s_mem() noexcept;
+    static void SSL_BIO_free_all(BIO *ptr) noexcept;
+    static BIO *SSL_BIO_new(const BIO_METHOD *method) noexcept;
+    static int SSL_BIO_gets(BIO *bio, char *buf, int size) noexcept;
+    static int SSL_BIO_puts(BIO *bio, char *buf) noexcept;
+    static int SSL_PEM_write_bio_X509_REQ(BIO *bio, X509_REQ *req) noexcept;
+    static X509_REQ *SSL_PEM_read_bio_X509_REQ(BIO *bp,
+                                               X509_REQ **x,
+                                               pem_password_cb *cb,
+                                               void *u) noexcept;
 
-    static int SSL_PEM_write_bio_PKCS8PrivateKey(BIO* bp,
-                                                 EVP_PKEY* x,
-                                                 const EVP_CIPHER* enc,
-                                                 char* kstr,
+    static int SSL_PEM_write_bio_PKCS8PrivateKey(BIO *bp,
+                                                 EVP_PKEY *x,
+                                                 const EVP_CIPHER *enc,
+                                                 char *kstr,
                                                  int klen,
-                                                 pem_password_cb* cb,
-                                                 void* u) noexcept;
-    static int SSL_PEM_write_bio_PUBKEY(BIO* bp, EVP_PKEY* x) noexcept;
+                                                 pem_password_cb *cb,
+                                                 void *u) noexcept;
+    static int SSL_PEM_write_bio_PUBKEY(BIO *bp, EVP_PKEY *x) noexcept;
 
-    static EVP_PKEY* SSL_PEM_read_bio_PUBKEY(BIO* bio,
-                                             EVP_PKEY** pkey,
-                                             pem_password_cb* cb,
-                                             void* u) noexcept;
+    static EVP_PKEY *SSL_PEM_read_bio_PUBKEY(BIO *bio,
+                                             EVP_PKEY **pkey,
+                                             pem_password_cb *cb,
+                                             void *u) noexcept;
 
-    static EVP_PKEY* SSL_PEM_read_bio_PrivateKey(BIO* bio,
-                                                 EVP_PKEY** pkey,
-                                                 pem_password_cb* cb,
-                                                 void* u) noexcept;
-    static X509* SSL_PEM_read_bio_X509(BIO* bio, X509** x, pem_password_cb*, void* pwd) noexcept;
-    static int SSL_PEM_write_bio_X509(BIO* bp, X509* x) noexcept;
-    static X509* SSL_d2i_X509_bio(BIO* bp, X509** x509) noexcept;
-    static int SSL_i2d_X509_bio(BIO* bp, X509* x) noexcept;
+    static EVP_PKEY *SSL_PEM_read_bio_PrivateKey(BIO *bio,
+                                                 EVP_PKEY **pkey,
+                                                 pem_password_cb *cb,
+                                                 void *u) noexcept;
+    static X509 *SSL_PEM_read_bio_X509(BIO *bio, X509 **x, pem_password_cb *, void *pwd) noexcept;
+    static int SSL_PEM_write_bio_X509(BIO *bp, X509 *x) noexcept;
+    static X509 *SSL_d2i_X509_bio(BIO *bp, X509 **x509) noexcept;
+    static int SSL_i2d_X509_bio(BIO *bp, X509 *x) noexcept;
 
     /* X509 */
-    static X509* SSL_X509_new() noexcept;
-    static int SSL_X509_set_pubkey(X509* ptr, EVP_PKEY* pkey) noexcept;
-    static int SSL_X509_set_issuer_name(X509* x, X509_NAME* name) noexcept;
-    static int SSL_X509_set_subject_name(X509* x, X509_NAME* name) noexcept;
-    static int SSL_X509_set_notBefore(X509* x, const ASN1_TIME* t) noexcept;
-    static int SSL_X509_set_notAfter(X509* x, const ASN1_TIME* t) noexcept;
-    static int SSL_X509_sign(X509* x, EVP_PKEY* pkey, const EVP_MD* md) noexcept;
-    static void SSL_X509_free(X509* ptr) noexcept;
-    static X509_NAME* SSL_X509_get_subject_name(X509* ptr) noexcept;
-    static X509_NAME* SSL_X509_get_issuer_name(X509* ptr) noexcept;
-    static EVP_PKEY* SSL_X509_get_pubkey(X509* x) noexcept;
-    static ASN1_TIME* SSL_X509_get_notBefore(X509* x) noexcept;
-    static ASN1_TIME* SSL_X509_get_notAfter(X509* x) noexcept;
+    static X509 *SSL_X509_new() noexcept;
+    static int SSL_X509_set_pubkey(X509 *ptr, EVP_PKEY *pkey) noexcept;
+    static int SSL_X509_set_issuer_name(X509 *x, X509_NAME *name) noexcept;
+    static int SSL_X509_set_subject_name(X509 *x, X509_NAME *name) noexcept;
+    static int SSL_X509_set_notBefore(X509 *x, const ASN1_TIME *t) noexcept;
+    static int SSL_X509_set_notAfter(X509 *x, const ASN1_TIME *t) noexcept;
+    static int SSL_X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md) noexcept;
+    static void SSL_X509_free(X509 *ptr) noexcept;
+    static X509_NAME *SSL_X509_get_subject_name(X509 *ptr) noexcept;
+    static X509_NAME *SSL_X509_get_issuer_name(X509 *ptr) noexcept;
+    static EVP_PKEY *SSL_X509_get_pubkey(X509 *x) noexcept;
+    static ASN1_TIME *SSL_X509_get_notBefore(X509 *x) noexcept;
+    static ASN1_TIME *SSL_X509_get_notAfter(X509 *x) noexcept;
 
     /* ASN1_TIME */
-    static void SSL_ASN1_TIME_free(ASN1_TIME* x) noexcept;
-    static int SSL_ASN1_TIME_diff(int* pday,
-                                  int* psec,
-                                  const ASN1_TIME* from,
-                                  const ASN1_TIME* to) noexcept;
-    static ASN1_TIME* SSL_ASN1_TIME_set(ASN1_TIME* s, time_t t) noexcept;
+    static void SSL_ASN1_TIME_free(ASN1_TIME *x) noexcept;
+    static int SSL_ASN1_TIME_diff(int *pday,
+                                  int *psec,
+                                  const ASN1_TIME *from,
+                                  const ASN1_TIME *to) noexcept;
+    static ASN1_TIME *SSL_ASN1_TIME_set(ASN1_TIME *s, time_t t) noexcept;
 
     /* X509_REQ */
-    static int SSL_X509_REQ_sign_ctx(X509_REQ* req, EVP_MD_CTX* ctx) noexcept;
-    static int SSL_X509_REQ_set_pubkey(X509_REQ* req, EVP_PKEY* pkey) noexcept;
-    static int SSL_X509_REQ_set_version(X509_REQ* req, unsigned long version) noexcept;
-    static int SSL_X509_REQ_set_subject_name(X509_REQ* req, X509_NAME* name) noexcept;
-    static void SSL_X509_REQ_free(X509_REQ* ptr) noexcept;
-    static X509_REQ* SSL_X509_REQ_new() noexcept;
-    static X509_NAME* SSL_X509_REQ_get_subject_name(const X509_REQ* req) noexcept;
-    static EVP_PKEY* SSL_X509_REQ_get_pubkey(X509_REQ* req) noexcept;
-    static int SSL_X509_REQ_verify(X509_REQ* a, EVP_PKEY* r) noexcept;
-    static const EVP_MD* SSL_EVP_sha1() noexcept;
-    static const EVP_MD* SSL_EVP_sha256() noexcept;
-    static const EVP_MD* SSL_EVP_sha384() noexcept;
-    static const EVP_MD* SSL_EVP_sha512() noexcept;
-    static const EVP_MD* SSL_EVP_sha3_256() noexcept;
-    static const EVP_MD* SSL_EVP_sha3_384() noexcept;
-    static const EVP_MD* SSL_EVP_sha3_512() noexcept;
+    static int SSL_X509_REQ_sign_ctx(X509_REQ *req, EVP_MD_CTX *ctx) noexcept;
+    static int SSL_X509_REQ_set_pubkey(X509_REQ *req, EVP_PKEY *pkey) noexcept;
+    static int SSL_X509_REQ_set_version(X509_REQ *req, unsigned long version) noexcept;
+    static int SSL_X509_REQ_set_subject_name(X509_REQ *req, X509_NAME *name) noexcept;
+    static void SSL_X509_REQ_free(X509_REQ *ptr) noexcept;
+    static X509_REQ *SSL_X509_REQ_new() noexcept;
+    static X509_NAME *SSL_X509_REQ_get_subject_name(const X509_REQ *req) noexcept;
+    static EVP_PKEY *SSL_X509_REQ_get_pubkey(X509_REQ *req) noexcept;
+    static int SSL_X509_REQ_verify(X509_REQ *a, EVP_PKEY *r) noexcept;
+    static const EVP_MD *SSL_EVP_sha1() noexcept;
+    static const EVP_MD *SSL_EVP_sha256() noexcept;
+    static const EVP_MD *SSL_EVP_sha384() noexcept;
+    static const EVP_MD *SSL_EVP_sha512() noexcept;
+    static const EVP_MD *SSL_EVP_sha3_256() noexcept;
+    static const EVP_MD *SSL_EVP_sha3_384() noexcept;
+    static const EVP_MD *SSL_EVP_sha3_512() noexcept;
 
     /* X509_NAME */
-    static X509_NAME* SSL_X509_NAME_new() noexcept;
-    static void SSL_X509_NAME_free(X509_NAME*) noexcept;
-    static int SSL_X509_NAME_add_entry_by_NID(X509_NAME* name,
+    static X509_NAME *SSL_X509_NAME_new() noexcept;
+    static void SSL_X509_NAME_free(X509_NAME *) noexcept;
+    static int SSL_X509_NAME_add_entry_by_NID(X509_NAME *name,
                                               int nid,
                                               int type,
-                                              unsigned char* bytes,
+                                              unsigned char *bytes,
                                               int len,
                                               int loc,
                                               int set) noexcept;
-    static int SSL_X509_NAME_get_index_by_NID(X509_NAME* name, int nid, int lastpos) noexcept;
-    static X509_NAME_ENTRY* SSL_X509_NAME_get_entry(X509_NAME* name, int loc) noexcept;
+    static int SSL_X509_NAME_get_index_by_NID(X509_NAME *name, int nid, int lastpos) noexcept;
+    static X509_NAME_ENTRY *SSL_X509_NAME_get_entry(X509_NAME *name, int loc) noexcept;
 
     /* X509_NAME_ENTRY */
-    static ASN1_STRING* SSL_X509_NAME_ENTRY_get_data(X509_NAME_ENTRY* ne) noexcept;
+    static ASN1_STRING *SSL_X509_NAME_ENTRY_get_data(X509_NAME_ENTRY *ne) noexcept;
 
     /* ASN1_STRING */
     /**
      * Returns number of characters written or -1 on error.
      *
      */
-    static int SSL_ASN1_STRING_print_ex(BIO* out, ASN1_STRING* str, unsigned long flags) noexcept;
+    static int SSL_ASN1_STRING_print_ex(BIO *out, ASN1_STRING *str, unsigned long flags) noexcept;
 
     /* X509 Certificate validation */
-    static X509_STORE* SSL_X509_STORE_new() noexcept;
-    static void SSL_X509_STORE_free(X509_STORE* v) noexcept;
-    static int SSL_X509_STORE_add_cert(X509_STORE* ctx, X509* x) noexcept;
+    static X509_STORE *SSL_X509_STORE_new() noexcept;
+    static void SSL_X509_STORE_free(X509_STORE *v) noexcept;
+    static int SSL_X509_STORE_add_cert(X509_STORE *ctx, X509 *x) noexcept;
 
-    static X509_STORE_CTX* SSL_X509_STORE_CTX_new() noexcept;
-    static int SSL_X509_STORE_CTX_init(X509_STORE_CTX* ctx,
-                                       X509_STORE* store,
-                                       X509* x509,
+    static X509_STORE_CTX *SSL_X509_STORE_CTX_new() noexcept;
+    static int SSL_X509_STORE_CTX_init(X509_STORE_CTX *ctx,
+                                       X509_STORE *store,
+                                       X509 *x509,
                                        STACK_OF(X509) * chain) noexcept;
-    static void SSL_X509_STORE_CTX_free(X509_STORE_CTX* ctx) noexcept;
+    static void SSL_X509_STORE_CTX_free(X509_STORE_CTX *ctx) noexcept;
 
-    static X509_VERIFY_PARAM* SSL_X509_STORE_CTX_get0_param(X509_STORE_CTX* ctx) noexcept;
-    static int SSL_X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM* param,
+    static X509_VERIFY_PARAM *SSL_X509_STORE_CTX_get0_param(X509_STORE_CTX *ctx) noexcept;
+    static int SSL_X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param,
                                                unsigned long flags) noexcept;
 
-    static int SSL_X509_verify_cert(X509_STORE_CTX* ctx) noexcept;
-    static const char* SSL_X509_verify_cert_error_string(long n) noexcept;
-    static int SSL_X509_STORE_CTX_get_error(X509_STORE_CTX* ctx) noexcept;
+    static int SSL_X509_verify_cert(X509_STORE_CTX *ctx) noexcept;
+    static const char *SSL_X509_verify_cert_error_string(long n) noexcept;
+    static int SSL_X509_STORE_CTX_get_error(X509_STORE_CTX *ctx) noexcept;
 
-    static int SSL_X509_check_ca(X509* cert) noexcept;
+    static int SSL_X509_check_ca(X509 *cert) noexcept;
 
     /* stack of X509 */
     static STACK_OF(X509) * SSL_sk_X509_new_null() noexcept;
-    static int SSL_sk_X509_push(STACK_OF(X509) * stack, const X509* crt) noexcept;
+    static int SSL_sk_X509_push(STACK_OF(X509) * stack, const X509 *crt) noexcept;
     static void SSL_sk_X509_free(STACK_OF(X509) * stack) noexcept;
 
     /* EVP_MD */
-    static EVP_MD_CTX* SSL_EVP_MD_CTX_create() noexcept;
-    static void SSL_EVP_MD_CTX_destroy(EVP_MD_CTX* ptr) noexcept;
+    static EVP_MD_CTX *SSL_EVP_MD_CTX_create() noexcept;
+    static void SSL_EVP_MD_CTX_destroy(EVP_MD_CTX *ptr) noexcept;
 
     /* Signatures */
-    static int SSL_EVP_PKEY_sign(EVP_PKEY_CTX* ctx,
-                                 unsigned char* sig,
-                                 size_t* siglen,
-                                 const unsigned char* tbs,
+    static int SSL_EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
+                                 unsigned char *sig,
+                                 size_t *siglen,
+                                 const unsigned char *tbs,
                                  size_t tbslen) noexcept;
-    static int SSL_EVP_PKEY_sign_init(EVP_PKEY_CTX* ctx) noexcept;
-    static int SSL_EVP_PKEY_verify_init(EVP_PKEY_CTX* ctx) noexcept;
-    static int SSL_EVP_PKEY_verify(EVP_PKEY_CTX* ctx,
-                                   const unsigned char* sig,
+    static int SSL_EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx) noexcept;
+    static int SSL_EVP_PKEY_verify_init(EVP_PKEY_CTX *ctx) noexcept;
+    static int SSL_EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
+                                   const unsigned char *sig,
                                    size_t siglen,
-                                   const unsigned char* tbs,
+                                   const unsigned char *tbs,
                                    size_t tbslen) noexcept;
-    static int SSL_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) noexcept;
-    static int SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX* ctx, int len) noexcept;
-    static EC_KEY* SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY* pkey) noexcept;
-    static int SSL_EVP_DigestSignInit(EVP_MD_CTX* ctx,
-                                      EVP_PKEY_CTX** pctx,
-                                      const EVP_MD* type,
-                                      ENGINE* e,
-                                      EVP_PKEY* pkey) noexcept;
-    static int SSL_EVP_DigestSign(EVP_MD_CTX* ctx,
-                                  unsigned char* sigret,
-                                  size_t* siglen,
-                                  const unsigned char* tbs,
+    static int SSL_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int len) noexcept;
+    static EC_KEY *SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) noexcept;
+    static int SSL_EVP_DigestSignInit(EVP_MD_CTX *ctx,
+                                      EVP_PKEY_CTX **pctx,
+                                      const EVP_MD *type,
+                                      ENGINE *e,
+                                      EVP_PKEY *pkey) noexcept;
+    static int SSL_EVP_DigestSign(EVP_MD_CTX *ctx,
+                                  unsigned char *sigret,
+                                  size_t *siglen,
+                                  const unsigned char *tbs,
                                   size_t tbslen) noexcept;
-    static int SSL_EVP_DigestVerify(EVP_MD_CTX* ctx,
-                                    const unsigned char* sigret,
+    static int SSL_EVP_DigestVerify(EVP_MD_CTX *ctx,
+                                    const unsigned char *sigret,
                                     size_t siglen,
-                                    const unsigned char* tbs,
+                                    const unsigned char *tbs,
                                     size_t tbslen) noexcept;
-    static int SSL_EVP_DigestVerifyInit(EVP_MD_CTX* ctx,
-                                        EVP_PKEY_CTX** pctx,
-                                        const EVP_MD* type,
-                                        ENGINE* e,
-                                        EVP_PKEY* pkey) noexcept;
+    static int SSL_EVP_DigestVerifyInit(EVP_MD_CTX *ctx,
+                                        EVP_PKEY_CTX **pctx,
+                                        const EVP_MD *type,
+                                        ENGINE *e,
+                                        EVP_PKEY *pkey) noexcept;
 
     /* Encryption */
-    static int SSL_EVP_PKEY_encrypt_init(EVP_PKEY_CTX* ctx) noexcept;
-    static int SSL_EVP_PKEY_encrypt(EVP_PKEY_CTX* ctx,
-                                    unsigned char* out,
-                                    size_t* outlen,
-                                    const unsigned char* in,
+    static int SSL_EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx) noexcept;
+    static int SSL_EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
+                                    unsigned char *out,
+                                    size_t *outlen,
+                                    const unsigned char *in,
                                     size_t inlen) noexcept;
-    static int SSL_EVP_PKEY_decrypt_init(EVP_PKEY_CTX* ctx) noexcept;
-    static int SSL_EVP_PKEY_decrypt(EVP_PKEY_CTX* ctx,
-                                    unsigned char* out,
-                                    size_t* outlen,
-                                    const unsigned char* in,
+    static int SSL_EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx) noexcept;
+    static int SSL_EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
+                                    unsigned char *out,
+                                    size_t *outlen,
+                                    const unsigned char *in,
                                     size_t inlen) noexcept;
-    static int SSL_EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) noexcept;
-    static int SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX* ctx,
-                                                   unsigned char* l,
+    static int SSL_EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx,
+                                                   unsigned char *l,
                                                    int llen) noexcept;
-    static int SSL_RSA_size(const RSA* r) noexcept;
-    static int SSL_EVP_MD_size(const EVP_MD* md) noexcept;
-    static int SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) noexcept;
-    static int SSL_EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX* ctx, int pad) noexcept;
+    static int SSL_RSA_size(const RSA *r) noexcept;
+    static int SSL_EVP_MD_size(const EVP_MD *md) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad) noexcept;
 
     /* KDF */
-    static int SSL_PKCS5_PBKDF2_HMAC(const char* pass,
+    static int SSL_PKCS5_PBKDF2_HMAC(const char *pass,
                                      int passlen,
-                                     const unsigned char* salt,
+                                     const unsigned char *salt,
                                      int saltlen,
                                      int iter,
-                                     const EVP_MD* digest,
+                                     const EVP_MD *digest,
                                      int keylen,
-                                     unsigned char* out) noexcept;
+                                     unsigned char *out) noexcept;
 
-    static int SSL_ECDH_KDF_X9_63(unsigned char* out,
+    static int SSL_ECDH_KDF_X9_63(unsigned char *out,
                                   size_t outlen,
-                                  const unsigned char* Z,
+                                  const unsigned char *Z,
                                   size_t Zlen,
-                                  const unsigned char* sinfo,
+                                  const unsigned char *sinfo,
                                   size_t sinfolen,
-                                  const EVP_MD* md) noexcept;
+                                  const EVP_MD *md) noexcept;
 
     /* HMAC */
-    static void SSL_HMAC_CTX_free(HMAC_CTX* ctx) noexcept;
-    static HMAC_CTX* SSL_HMAC_CTX_new() noexcept;
-    static int SSL_HMAC_Final(HMAC_CTX* ctx, unsigned char* md, unsigned int* len) noexcept;
-    static int SSL_HMAC_Update(HMAC_CTX* ctx, const unsigned char* data, int len) noexcept;
+    static void SSL_HMAC_CTX_free(HMAC_CTX *ctx) noexcept;
+    static HMAC_CTX *SSL_HMAC_CTX_new() noexcept;
+    static int SSL_HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len) noexcept;
+    static int SSL_HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, int len) noexcept;
     static int SSL_HMAC_Init_ex(
-            HMAC_CTX* ctx, const void* key, int key_len, const EVP_MD* md, ENGINE* impl) noexcept;
+            HMAC_CTX *ctx, const void *key, int key_len, const EVP_MD *md, ENGINE *impl) noexcept;
 
     /* CMAC */
-    static CMAC_CTX* SSL_CMAC_CTX_new() noexcept;
-    static void SSL_CMAC_CTX_cleanup(CMAC_CTX* ctx) noexcept;
-    static void SSL_CMAC_CTX_free(CMAC_CTX* ctx) noexcept;
-    static EVP_CIPHER_CTX* SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX* ctx) noexcept;
-    static int SSL_CMAC_CTX_copy(CMAC_CTX* out, const CMAC_CTX* in) noexcept;
-    static int SSL_CMAC_Init(CMAC_CTX* ctx,
-                             const void* key,
+    static CMAC_CTX *SSL_CMAC_CTX_new() noexcept;
+    static void SSL_CMAC_CTX_cleanup(CMAC_CTX *ctx) noexcept;
+    static void SSL_CMAC_CTX_free(CMAC_CTX *ctx) noexcept;
+    static EVP_CIPHER_CTX *SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX *ctx) noexcept;
+    static int SSL_CMAC_CTX_copy(CMAC_CTX *out, const CMAC_CTX *in) noexcept;
+    static int SSL_CMAC_Init(CMAC_CTX *ctx,
+                             const void *key,
                              size_t keylen,
-                             const EVP_CIPHER* cipher,
-                             ENGINE* impl) noexcept;
-    static int SSL_CMAC_Update(CMAC_CTX* ctx, const void* data, size_t dlen) noexcept;
-    static int SSL_CMAC_Final(CMAC_CTX* ctx, unsigned char* out, size_t* poutlen) noexcept;
-    static int SSL_CMAC_resume(CMAC_CTX* ctx) noexcept;
+                             const EVP_CIPHER *cipher,
+                             ENGINE *impl) noexcept;
+    static int SSL_CMAC_Update(CMAC_CTX *ctx, const void *data, size_t dlen) noexcept;
+    static int SSL_CMAC_Final(CMAC_CTX *ctx, unsigned char *out, size_t *poutlen) noexcept;
+    static int SSL_CMAC_resume(CMAC_CTX *ctx) noexcept;
 
     /* EC Point import and export */
-    static size_t SSL_EC_KEY_key2buf(const EC_KEY* eckey,
+    static size_t SSL_EC_KEY_key2buf(const EC_KEY *eckey,
                                      point_conversion_form_t form,
-                                     unsigned char** pbuf,
-                                     BN_CTX* ctx) noexcept;
-    static int SSL_EVP_PKEY_set1_EC_KEY(EVP_PKEY* pkey, EC_KEY* key) noexcept;
-    static EC_KEY* SSL_EC_KEY_new_by_curve_name(int nid) noexcept;
-    static void SSL_EC_KEY_free(EC_KEY* key) noexcept;
-    static EC_KEY* SSL_EC_KEY_new() noexcept;
-    static int SSL_EC_KEY_oct2key(EC_KEY* eckey, const unsigned char* buf, size_t len) noexcept;
+                                     unsigned char **pbuf,
+                                     BN_CTX *ctx) noexcept;
+    static int SSL_EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) noexcept;
+    static EC_KEY *SSL_EC_KEY_new_by_curve_name(int nid) noexcept;
+    static void SSL_EC_KEY_free(EC_KEY *key) noexcept;
+    static EC_KEY *SSL_EC_KEY_new() noexcept;
+    static int SSL_EC_KEY_oct2key(EC_KEY *eckey, const unsigned char *buf, size_t len) noexcept;
 
     /* ECC: compute on elliptic curves */
-    static int SSL_EVP_PKEY_derive(EVP_PKEY_CTX* ctx, unsigned char* key, size_t* keylen) noexcept;
-    static int SSL_EVP_PKEY_derive_set_peer(EVP_PKEY_CTX* ctx, EVP_PKEY* peer) noexcept;
-    static int SSL_EVP_PKEY_derive_init(EVP_PKEY_CTX* ctx) noexcept;
+    static int SSL_EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen) noexcept;
+    static int SSL_EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer) noexcept;
+    static int SSL_EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx) noexcept;
 };
 }  // namespace lib
 }  // namespace openssl

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -63,11 +63,11 @@ using CmacCipherTypes = mococrw::CmacCipherTypes;
  * into a functor so that a std::unique_ptr
  * can use them.
  */
-template <class P, void(Func)(P*)>
+template <class P, void(Func)(P *)>
 struct SSLDeleter
 {
     template <class T>
-    void operator()(T* ptr) const noexcept
+    void operator()(T *ptr) const noexcept
     {
         if (ptr) {
             Func(ptr);
@@ -82,11 +82,11 @@ struct SSLDeleter
  * We could have modified SSLDeleter to take arbitrary return
  * types, but this might result in an unwanted ABI change.
  */
-template <class R, class P, R(Func)(P*)>
+template <class R, class P, R(Func)(P *)>
 struct SSLRetDeleter
 {
     template <class T>
-    void operator()(T* ptr) const noexcept
+    void operator()(T *ptr) const noexcept
     {
         if (ptr) {
             Func(ptr);
@@ -102,7 +102,7 @@ struct SSLRetDeleter
 template <class P>
 struct SSLFree
 {
-    void operator()(P* ptr)
+    void operator()(P *ptr)
     {
         if (ptr) {
             lib::OpenSSLLib::SSL_OPENSSL_free(ptr);
@@ -119,7 +119,7 @@ class OpenSSLException final : public std::exception
 {
 public:
     template <class StringType>
-    explicit OpenSSLException(StringType&& message) : _message{std::forward<StringType>(message)}
+    explicit OpenSSLException(StringType &&message) : _message{std::forward<StringType>(message)}
     {
     }
 
@@ -130,7 +130,7 @@ public:
      */
     OpenSSLException() : _message{generateOpenSSLErrorString()} {}
 
-    const char* what() const noexcept override { return _message.c_str(); }
+    const char *what() const noexcept override { return _message.c_str(); }
 
 private:
     static std::string generateOpenSSLErrorString();
@@ -242,22 +242,22 @@ using SSL_ENGINE_SharedPtr = utility::SharedPtrTypeFromUniquePtr<SSL_ENGINE_Ptr>
 /*
  * Retrieve the digest value from ctx and places it in md.
  */
-void _EVP_DigestFinal_ex(EVP_MD_CTX* ctx, unsigned char* md, unsigned int* s);
+void _EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
 
 /*
  * Hash cnt bytes of data at d into the digest context ctx.
  */
-void _EVP_DigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt);
+void _EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
 
 /*
  * Set up digest context ctx to use a digest type from ENGINE impl.
  */
-void _EVP_DigestInit_ex(EVP_MD_CTX* ctx, const EVP_MD* type, ENGINE* impl);
+void _EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
 
 /*
  * Initialize digest context ctx.
  */
-void _EVP_MD_CTX_init(EVP_MD_CTX* ctx);
+void _EVP_MD_CTX_init(EVP_MD_CTX *ctx);
 
 /**
  * Create a new EVP_PKEY instance.
@@ -282,7 +282,7 @@ SSL_X509_REQ_Ptr _X509_REQ_new();
  * The ENGINE parameter is currently unused, which is why this parameter has not been included
  * (thankfully C++ supports overloading which is why it can always be added later).
  */
-SSL_EVP_PKEY_CTX_Ptr _EVP_PKEY_CTX_new(EVP_PKEY* pkey);
+SSL_EVP_PKEY_CTX_Ptr _EVP_PKEY_CTX_new(EVP_PKEY *pkey);
 
 /**
  * Create an EVP_PKEY_CTX instance for the given ID. The IDs come from OpenSSLs native headers.
@@ -302,14 +302,14 @@ SSL_EVP_PKEY_CTX_Ptr _EVP_PKEY_CTX_new_id(int id);
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-SSL_EVP_PKEY_Ptr _EVP_PKEY_keygen(EVP_PKEY_CTX* ctx);
+SSL_EVP_PKEY_Ptr _EVP_PKEY_keygen(EVP_PKEY_CTX *ctx);
 
 /**
  * Initialize the context for key-generation.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _EVP_PKEY_keygen_init(EVP_PKEY_CTX* ctx);
+void _EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx);
 
 /**
  * Set the number of bits the RSA key should have.
@@ -319,14 +319,14 @@ void _EVP_PKEY_keygen_init(EVP_PKEY_CTX* ctx);
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits);
+void _EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX *ctx, int mbits);
 
 /**
  * Initializes the key context so we can set the appropriate parameters for the key generation
  * @param ctx [out] initialized context
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _EVP_PKEY_paramgen_init(EVP_PKEY_CTX* ctx);
+void _EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx);
 
 /**
  * Generates the parameters to be used on the key generation.
@@ -334,7 +334,7 @@ void _EVP_PKEY_paramgen_init(EVP_PKEY_CTX* ctx);
  * @return the generated parameters to be used on the key generation
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-SSL_EVP_PKEY_Ptr _EVP_PKEY_paramgen(EVP_PKEY_CTX* ctx);
+SSL_EVP_PKEY_Ptr _EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx);
 
 /**
  * Set the the elliptic curve used to generate the key pair
@@ -343,7 +343,7 @@ SSL_EVP_PKEY_Ptr _EVP_PKEY_paramgen(EVP_PKEY_CTX* ctx);
  * @param nid [in] Identifier of the curve to be used.
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX* ctx, int nid);
+void _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);
 
 /**
  * Sets the the elliptic curve parameter encoding when generating
@@ -353,23 +353,23 @@ void _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX* ctx, int nid);
  * @param param_enc [in] Type of parameter encoding to be used
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX* ctx, int param_enc);
+void _EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc);
 
 /**
  * Gets the EC group of a given EC key
  */
-const EC_GROUP* _EC_KEY_get0_group(const EC_KEY* key);
+const EC_GROUP *_EC_KEY_get0_group(const EC_KEY *key);
 
 /**
  * EC_GROUP_get_degree gets the degree of the field. For Fp fields this will be the number of bits
  * in p. For F2^m fields this will be the value m.
  */
-int _EC_GROUP_get_degree(const EC_GROUP* group);
+int _EC_GROUP_get_degree(const EC_GROUP *group);
 
 /**
  * Gets the NID of the elliptic curve used to generate the EC key.
  */
-int _EC_GROUP_get_curve_name(const EC_GROUP* group);
+int _EC_GROUP_get_curve_name(const EC_GROUP *group);
 
 /**
  * Gets the type of a give PKey oject.
@@ -378,7 +378,7 @@ int _EC_GROUP_get_curve_name(const EC_GROUP* group);
  * @return Returns the PKEY type being used
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-int _EVP_PKEY_type(const EVP_PKEY* key);
+int _EVP_PKEY_type(const EVP_PKEY *key);
 
 /**
  * Gets the size in bytes of a pkey object
@@ -386,7 +386,7 @@ int _EVP_PKEY_type(const EVP_PKEY* key);
  * @return the size of provided key
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-int _EVP_PKEY_size(EVP_PKEY* pkey);
+int _EVP_PKEY_size(EVP_PKEY *pkey);
 
 /*
  * Check if two public keys are the same. Please note that this function
@@ -396,7 +396,7 @@ int _EVP_PKEY_size(EVP_PKEY* pkey);
  * @return true if the public keys are the same
  * @throw OpenSSLException if there was an error while comparing the keys
  */
-bool _EVP_PKEY_cmp(const EVP_PKEY* a, const EVP_PKEY* b);
+bool _EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b);
 
 SSL_X509_NAME_Ptr _X509_NAME_new();
 
@@ -439,73 +439,73 @@ enum class X509Extension_NID : int {
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _X509_NAME_add_entry_by_NID(X509_NAME* name,
+void _X509_NAME_add_entry_by_NID(X509_NAME *name,
                                  ASN1_NID nid,
                                  ASN1_Name_Entry_Type type,
-                                 std::vector<unsigned char>& bytes);
+                                 std::vector<unsigned char> &bytes);
 
 /**
  * Set the subject-name for the given X509_REQ object.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _X509_REQ_set_subject_name(X509_REQ* req, X509_NAME* name);
+void _X509_REQ_set_subject_name(X509_REQ *req, X509_NAME *name);
 
 /**
  * Set the public key for the given X509_REQ object.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _X509_REQ_set_pubkey(X509_REQ* req, EVP_PKEY* pkey);
+void _X509_REQ_set_pubkey(X509_REQ *req, EVP_PKEY *pkey);
 
 /**
  * Set the X509 version for the given X509_REQ object.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _X509_REQ_set_version(X509_REQ* req, unsigned long version);
+void _X509_REQ_set_version(X509_REQ *req, unsigned long version);
 
 /**
  * @result pointer to the internal X509_NAME structure.
  *
  * NOTE this result *MUST NOT BE FREED*.
  */
-X509_NAME* _X509_REQ_get_subject_name(const X509_REQ* req);
+X509_NAME *_X509_REQ_get_subject_name(const X509_REQ *req);
 
 /**
  * Get the public key for the given X509_REQ object.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-SSL_EVP_PKEY_Ptr _X509_REQ_get_public_key(X509_REQ* req);
+SSL_EVP_PKEY_Ptr _X509_REQ_get_public_key(X509_REQ *req);
 
 /**
  * Verifies the given X509_REQ object against the given public key.
  *
  * @throw OpenSSLException if the verification fails.
  */
-void _X509_REQ_verify(X509_REQ* req, EVP_PKEY* key);
+void _X509_REQ_verify(X509_REQ *req, EVP_PKEY *key);
 
 /**
  * Write the X509_REQ to PEM format into the given BIO object.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _PEM_write_bio_X509_REQ(BIO* bio, X509_REQ* req);
+void _PEM_write_bio_X509_REQ(BIO *bio, X509_REQ *req);
 
 /**
  * Write the X509 to PEM format into the given BIO object.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _PEM_write_bio_X509(BIO* bio, X509* x);
+void _PEM_write_bio_X509(BIO *bio, X509 *x);
 
 /**
  * Read the X509_REQ in PEM format from the given BIO object.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-SSL_X509_REQ_Ptr _PEM_read_bio_X509_REQ(BIO* bio);
+SSL_X509_REQ_Ptr _PEM_read_bio_X509_REQ(BIO *bio);
 
 /**
  *
@@ -516,12 +516,12 @@ SSL_X509_REQ_Ptr _PEM_read_bio_X509_REQ(BIO* bio);
  *
  * Presumably this points to static memory.
  */
-const BIO_METHOD* _BIO_s_mem();
+const BIO_METHOD *_BIO_s_mem();
 
 /**
  * Create a new BIO instance for the given method.
  */
-SSL_BIO_Ptr _BIO_new(const BIO_METHOD* method);
+SSL_BIO_Ptr _BIO_new(const BIO_METHOD *method);
 
 /**
  * Create a new file-backed BIO object
@@ -529,7 +529,7 @@ SSL_BIO_Ptr _BIO_new(const BIO_METHOD* method);
  * @throw OpenSSLException if an error occurs. In particular, if the file
  *                         cannot be accessed in the desired mode.
  */
-SSL_BIO_Ptr _BIO_new_file(const char* filename, const char* mode);
+SSL_BIO_Ptr _BIO_new_file(const char *filename, const char *mode);
 
 /**
  * Return value of 0 or -1 are possible without inidicating an error.
@@ -543,7 +543,7 @@ SSL_BIO_Ptr _BIO_new_file(const char* filename, const char* mode);
  *      depends on the method of the 'bio' (@see _BIO_new()).
  * @throw OpenSSLException if BIO_gets is not supported for the method of 'bio'
  */
-int _BIO_gets(BIO* bio, std::vector<char>& buf);
+int _BIO_gets(BIO *bio, std::vector<char> &buf);
 
 /**
  * Return value of 0 or -1 are possible without inidicating an error.
@@ -557,7 +557,7 @@ int _BIO_gets(BIO* bio, std::vector<char>& buf);
  *      depends on the method of the 'bio' (@see _BIO_new()).
  * @throw OpenSSLException if BIO_gets is not supported for the method of 'bio'
  */
-int _BIO_puts(BIO* bio, std::string buf);
+int _BIO_puts(BIO *bio, std::string buf);
 
 /**
  * Return value of 0 or -1 are possible without indicating an error.
@@ -571,7 +571,7 @@ int _BIO_puts(BIO* bio, std::string buf);
  *      depends on the method of the 'bio' (@see _BIO_new()).
  * @throw OpenSSLException if BIO_gets is not supported for the method of 'bio'
  */
-int _BIO_write(BIO* bio, const std::vector<uint8_t>& data);
+int _BIO_write(BIO *bio, const std::vector<uint8_t> &data);
 
 /**
  * Tries to read numBytes from the BIO object. It resizes the vector
@@ -591,49 +591,49 @@ int _BIO_write(BIO* bio, const std::vector<uint8_t>& data);
  *      depends on the method of the 'bio' (@see _BIO_new()).
  * @throw OpenSSLException if BIO_gets is not supported for the method of 'bio'
  */
-int _BIO_read(BIO* bio, std::vector<uint8_t>& buf, std::size_t numBytes);
+int _BIO_read(BIO *bio, std::vector<uint8_t> &buf, std::size_t numBytes);
 
 /*
  * Read a DER encoded X509 certificate from a bio
  *
  * @throw OpenSSLException if an OpenSSL internal error occurs.
  */
-SSL_X509_Ptr _d2i_X509_bio(BIO* bp);
+SSL_X509_Ptr _d2i_X509_bio(BIO *bp);
 
 /*
  * Read a DER encoded X509 certificate request from a bio
  *
  * @throw OpenSSLException if an OpenSSL internal error occurs.
  */
-SSL_X509_REQ_Ptr _d2i_X509_REQ_bio(BIO* bp);
+SSL_X509_REQ_Ptr _d2i_X509_REQ_bio(BIO *bp);
 
 /*
  * Write an X509 certificate in DER encoded form to a bio
  *
  * @throw OpenSSLException if an OpenSSL internal error occurs.
  */
-void _i2d_X509_bio(BIO* bp, X509* x);
+void _i2d_X509_bio(BIO *bp, X509 *x);
 
 /*
  * Write an X509 certification request in DER encoded form to a bio
  *
  * @throw OpenSSLException if an OpenSSL internal error occurs.
  */
-void _i2d_X509_REQ_bio(BIO* bp, X509_REQ* x);
+void _i2d_X509_REQ_bio(BIO *bp, X509_REQ *x);
 
 /**
  * Sign an X509_REQ to obtain a complete CSR.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _X509_REQ_sign_ctx(X509_REQ* req, EVP_MD_CTX* ctx);
+void _X509_REQ_sign_ctx(X509_REQ *req, EVP_MD_CTX *ctx);
 
 /**
  * Get reference to digest function for a given digest type.
  *
  * @throws std::runtime_error if the requested digest function was not found.
  */
-const EVP_MD* _getMDPtrFromDigestType(DigestTypes type);
+const EVP_MD *_getMDPtrFromDigestType(DigestTypes type);
 
 /**
  * Create an MD_CTX object.
@@ -661,11 +661,11 @@ SSL_EVP_MD_CTX_Ptr _EVP_MD_CTX_create();
  * @throws OpenSSLException if an error occurs in the underlying OpenSSL function.
  *
  */
-void _PEM_write_bio_PKCS8PrivateKey(BIO* out,
-                                    EVP_PKEY* pkey,
-                                    const EVP_CIPHER* cipher,
+void _PEM_write_bio_PKCS8PrivateKey(BIO *out,
+                                    EVP_PKEY *pkey,
+                                    const EVP_CIPHER *cipher,
                                     std::string pwd);
-void _PEM_write_bio_PUBKEY(BIO* bp, EVP_PKEY* x);
+void _PEM_write_bio_PUBKEY(BIO *bp, EVP_PKEY *x);
 
 /**
  * Note: The password is intentionally passed by value because openssl does not guarantee the
@@ -679,12 +679,12 @@ void _PEM_write_bio_PUBKEY(BIO* bp, EVP_PKEY* x);
  * @param bio The BIO instance to read the key from.
  * @param pwd The password (as ASCII string) to decrypt the key with.
  */
-SSL_EVP_PKEY_Ptr _PEM_read_bio_PrivateKey(BIO* bio, std::string pwd);
+SSL_EVP_PKEY_Ptr _PEM_read_bio_PrivateKey(BIO *bio, std::string pwd);
 
 /**
  * @param bio The BIO instance to read the key from.
  */
-SSL_EVP_PKEY_Ptr _PEM_read_bio_PUBKEY(BIO* bio);
+SSL_EVP_PKEY_Ptr _PEM_read_bio_PUBKEY(BIO *bio);
 
 /**
  * Read an X509 certificate from BIO instance.
@@ -694,7 +694,7 @@ SSL_EVP_PKEY_Ptr _PEM_read_bio_PUBKEY(BIO* bio);
  * @throws OpenSSLException if an internal OpenSSL error is encountered.
  *
  */
-SSL_X509_Ptr _PEM_read_bio_X509(BIO* bio);
+SSL_X509_Ptr _PEM_read_bio_X509(BIO *bio);
 
 /**
  * Let OpenSSL compute the time difference between two ASN1_TIMEs
@@ -706,7 +706,7 @@ SSL_X509_Ptr _PEM_read_bio_X509(BIO* bio);
  *           psec will be written with a negative value (or 0).
  * @throw OpenSSLException when an error occurs (e.g., wrong ASN1_TIME formats)
  */
-void _ASN1_TIME_diff(int* pday, int* psec, const ASN1_TIME* from, const ASN1_TIME* to);
+void _ASN1_TIME_diff(int *pday, int *psec, const ASN1_TIME *from, const ASN1_TIME *to);
 
 /**
  * Get an ASN1_TIME object from a time_t
@@ -718,7 +718,7 @@ SSL_ASN1_TIME_Ptr _ASN1_TIME_from_time_t(time_t t);
 /**
  * Set the time from a textual representation to an ASN.1 time
  */
-void _ASN1_TIME_set_string(ASN1_TIME* s, const char* str);
+void _ASN1_TIME_set_string(ASN1_TIME *s, const char *str);
 
 /**
  * Add an X509 certificate to an X509 store
@@ -728,7 +728,7 @@ void _ASN1_TIME_set_string(ASN1_TIME* s, const char* str);
  *
  * @throw OpenSSLException when an error occurs while adding the certificate
  */
-void _X509_STORE_add_cert(X509_STORE* store, X509* cert);
+void _X509_STORE_add_cert(X509_STORE *store, X509 *cert);
 
 /**
  * Initialize an X509 store context
@@ -741,9 +741,9 @@ void _X509_STORE_add_cert(X509_STORE* store, X509* cert);
  * @throw OpenSSLException when an error occurs while initializing
  *                         the context
  */
-void _X509_STORE_CTX_init(X509_STORE_CTX* ctx,
-                          X509_STORE* store,
-                          X509* x509,
+void _X509_STORE_CTX_init(X509_STORE_CTX *ctx,
+                          X509_STORE *store,
+                          X509 *x509,
                           STACK_OF(X509) * chain);
 
 /**
@@ -753,14 +753,14 @@ void _X509_STORE_CTX_init(X509_STORE_CTX* ctx,
  *
  * @throw OpenSSLException if an error occurs
  */
-X509_VERIFY_PARAM* _X509_STORE_CTX_get0_param(X509_STORE_CTX* ctx);
+X509_VERIFY_PARAM *_X509_STORE_CTX_get0_param(X509_STORE_CTX *ctx);
 
 /**
  * @brief Verify if the certificate is a CA
  *
  * @return Whether the certificate is a CA or not
  */
-bool _X509_check_ca(X509* cert);
+bool _X509_check_ca(X509 *cert);
 
 class X509VerificationFlags
 {
@@ -779,7 +779,7 @@ public:
  *
  * @throw OpenSSLException if an error occurs
  */
-void _X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM* param, unsigned long flags);
+void _X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param, unsigned long flags);
 
 /**
  * Verify an X509 certificate with the given certification context.
@@ -788,7 +788,7 @@ void _X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM* param, unsigned long flags)
  *
  * @throw OpenSSLException if the verification failed.
  */
-void _X509_verify_cert(X509_STORE_CTX* ctx);
+void _X509_verify_cert(X509_STORE_CTX *ctx);
 
 /**
  * Wrapper to create openssl objects
@@ -799,7 +799,7 @@ void _X509_verify_cert(X509_STORE_CTX* ctx);
  * @throw OpenSSLException when no object could be created
  */
 template <class SslType>
-SslType* createOpenSSLObject();
+SslType *createOpenSSLObject();
 
 template <class SSLSmartPtrType>
 SSLSmartPtrType createManagedOpenSSLObject()
@@ -808,49 +808,49 @@ SSLSmartPtrType createManagedOpenSSLObject()
 }
 
 template <class StackType, class ObjType>
-void addObjectToStack(StackType* stack, const ObjType* obj);
+void addObjectToStack(StackType *stack, const ObjType *obj);
 
 /**
  * @result pointer to the internal X509_NAME structure.
  *
  * NOTE this result *MUST NOT BE FREED*.
  */
-X509_NAME* _X509_get_subject_name(X509* obj);
+X509_NAME *_X509_get_subject_name(X509 *obj);
 
 /**
  * @result pointer to the internal X509_NAME structure.
  *
  * NOTE this result *MUST NOT BE FREED*.
  */
-X509_NAME* _X509_get_issuer_name(X509* obj);
+X509_NAME *_X509_get_issuer_name(X509 *obj);
 
 /**
  * Get not before value of the certificate as system_clock::time_point
  *
  * @throw OpenSSLException if an internal OpenSSL error is encountered
  */
-time_point _X509_get_notBefore(X509* x);
+time_point _X509_get_notBefore(X509 *x);
 
 /**
  * Get not after value of the certificate as system_clock::time_point
  *
  * @throw OpenSSLException if an internal OpenSSL error is encountered
  */
-time_point _X509_get_notAfter(X509* x);
+time_point _X509_get_notAfter(X509 *x);
 
 /**
  * Get not before value of the certificate as ASN1_TIME
  *
  * @throw OpenSSLException if an internal OpenSSL error is encountered
  */
-ASN1_TIME* _X509_get_notBefore_ASN1(X509* x);
+ASN1_TIME *_X509_get_notBefore_ASN1(X509 *x);
 
 /**
  * Get not after value of the certificate as ASN1_TIME
  *
  * @throw OpenSSLException if an internal OpenSSL error is encountered
  */
-ASN1_TIME* _X509_get_notAfter_ASN1(X509* x);
+ASN1_TIME *_X509_get_notAfter_ASN1(X509 *x);
 
 /**
  * Get a pointer to the EVP_PKEY in a certificate.
@@ -862,56 +862,56 @@ ASN1_TIME* _X509_get_notAfter_ASN1(X509* x);
  *
  * @throw OpenSSLException if there is an error in retrieving the key
  */
-SSL_EVP_PKEY_Ptr _X509_get_pubkey(X509* x);
+SSL_EVP_PKEY_Ptr _X509_get_pubkey(X509 *x);
 
 /**
  * Set the subject-name for the given X509 object.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _X509_set_subject_name(X509* x, X509_NAME* name);
+void _X509_set_subject_name(X509 *x, X509_NAME *name);
 
 /**
  * Set the issuer-name for the given X509 object.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _X509_set_issuer_name(X509* x, X509_NAME* name);
+void _X509_set_issuer_name(X509 *x, X509_NAME *name);
 
 /**
  * Set the public key for the given X509 object.
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _X509_set_pubkey(X509* x, EVP_PKEY* key);
+void _X509_set_pubkey(X509 *x, EVP_PKEY *key);
 
 /**
  * Set not before value of the certificate as system_clock::time_point
  *
  * @throw OpenSSLException if an internal OpenSSL error is encountered
  */
-void _X509_set_notBefore(X509* x, const time_point& t);
+void _X509_set_notBefore(X509 *x, const time_point &t);
 
 /**
  * Set not after value of the certificate as system_clock::time_point
  *
  * @throw OpenSSLException if an internal OpenSSL error is encountered
  */
-void _X509_set_notAfter(X509* x, const time_point& t);
+void _X509_set_notAfter(X509 *x, const time_point &t);
 
 /**
  * Set not before value of the certificate as ASN1_TIME
  *
  * @throw OpenSSLException if an internal OpenSSL error is encountered
  */
-void _X509_set_notBefore_ASN1(X509* x, const ASN1_TIME* t);
+void _X509_set_notBefore_ASN1(X509 *x, const ASN1_TIME *t);
 
 /**
  * Set not after value of the certificate as ASN1_TIME
  *
  * @throw OpenSSLException if an internal OpenSSL error is encountered
  */
-void _X509_set_notAfter_ASN1(X509* x, const ASN1_TIME* t);
+void _X509_set_notAfter_ASN1(X509 *x, const ASN1_TIME *t);
 
 /**
  * Creates a new X509 certificate.
@@ -920,7 +920,7 @@ void _X509_set_notAfter_ASN1(X509* x, const ASN1_TIME* t);
  */
 SSL_X509_Ptr _X509_new();
 
-void _X509_sign(X509* x, EVP_PKEY* pkey, DigestTypes type);
+void _X509_sign(X509 *x, EVP_PKEY *pkey, DigestTypes type);
 
 /**
  * Return the list of locations in the structure that contain an entry with
@@ -933,7 +933,7 @@ void _X509_sign(X509* x, EVP_PKEY* pkey, DigestTypes type);
  *
  * @throws OpenSSLException if an internal OpenSSL error is encoutered.
  */
-std::vector<int> _X509_NAME_get_index_by_NID(X509_NAME* name, ASN1_NID nid);
+std::vector<int> _X509_NAME_get_index_by_NID(X509_NAME *name, ASN1_NID nid);
 
 /**
  * Retrieve the entry at the given position.
@@ -949,9 +949,9 @@ std::vector<int> _X509_NAME_get_index_by_NID(X509_NAME* name, ASN1_NID nid);
  * @throws OpenSSLException if an internal OpenSSL error is encoutered.
  *
  */
-X509_NAME_ENTRY* _X509_NAME_get_entry(X509_NAME* name, int loc);
+X509_NAME_ENTRY *_X509_NAME_get_entry(X509_NAME *name, int loc);
 
-std::string _X509_NAME_ENTRY_get_data(X509_NAME_ENTRY* entry);
+std::string _X509_NAME_ENTRY_get_data(X509_NAME_ENTRY *entry);
 
 /**
  * Return name of given cipher
@@ -959,7 +959,7 @@ std::string _X509_NAME_ENTRY_get_data(X509_NAME_ENTRY* entry);
  * @param cipher to get the name for
  * @returns name of cipher
  */
-const std::string _EVP_CIPHER_name(const EVP_CIPHER* cipher);
+const std::string _EVP_CIPHER_name(const EVP_CIPHER *cipher);
 
 /**
  * Return size of key used for given cipher
@@ -967,7 +967,7 @@ const std::string _EVP_CIPHER_name(const EVP_CIPHER* cipher);
  * @param cipher to get the key size for
  * @returns size of key in bytes
  */
-int _EVP_CIPHER_key_length(const EVP_CIPHER* cipher);
+int _EVP_CIPHER_key_length(const EVP_CIPHER *cipher);
 
 using SSL_EVP_CIPHER_CTX_Ptr =
         std::unique_ptr<EVP_CIPHER_CTX,
@@ -984,12 +984,12 @@ SSL_EVP_CIPHER_CTX_Ptr _EVP_CIPHER_CTX_new();
  * Clears all information from a cipher context and free up any allocated memory associated with it,
  * except the ctx itself.
  */
-void _EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX* ctx);
+void _EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *ctx);
 
 /**
  * Allows various cipher specific parameters to be determined and set
  */
-void _EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX* ctx, int type, int arg, void* ptr);
+void _EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
 
 /**
  * Sets up cipher context `ctx` for encryption or decryption.
@@ -1001,11 +1001,11 @@ void _EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX* ctx, int type, int arg, void* ptr);
  * @param iv the IV to use (if necessary),
  * @param enc 1 if context should be initialized for encryption and 0 if fo decryption.
  */
-void _EVP_CipherInit_ex(EVP_CIPHER_CTX* ctx,
-                        const EVP_CIPHER* cipher,
-                        ENGINE* impl,
-                        const unsigned char* key,
-                        const unsigned char* iv,
+void _EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx,
+                        const EVP_CIPHER *cipher,
+                        ENGINE *impl,
+                        const unsigned char *key,
+                        const unsigned char *iv,
                         int enc);
 
 /**
@@ -1026,7 +1026,7 @@ void _EVP_CipherInit_ex(EVP_CIPHER_CTX* ctx,
  * @param inl length of the input buffer.
  */
 void _EVP_CipherUpdate(
-        EVP_CIPHER_CTX* ctx, unsigned char* outm, int* outl, const unsigned char* in, int inl);
+        EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl, const unsigned char *in, int inl);
 
 /**
  * If padding is enabled (the default) this function encrypts/decrypts the "final" data, that is
@@ -1041,14 +1041,14 @@ void _EVP_CipherUpdate(
  * @param outl At the input the function expects size of the \c outm to be placed in \c outl.
  * At the output, the actual amount of data written to \c outm will be stored in this variable.
  */
-void _EVP_CipherFinal_ex(EVP_CIPHER_CTX* ctx, unsigned char* outm, int* outl);
+void _EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
 
 /**
  * Get the key length of a cipher.
  * @param ctx cipher context
  * @return key length of a cipher in bytes.
  */
-int _EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX* ctx);
+int _EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX *ctx);
 
 /**
  * Get the IV length of a cipher.
@@ -1058,7 +1058,7 @@ int _EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX* ctx);
  * @param ctx cipher context
  * @return IV length of a cipher in bytes.
  */
-int _EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX* ctx);
+int _EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx);
 
 /**
  * Enables or disables padding.
@@ -1069,7 +1069,7 @@ int _EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX* ctx);
  * occur.
  */
 
-void _EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX* ctx, int pad);
+void _EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int pad);
 
 /**
  * Get the cipher descriptor for AES 256 in CBC mode.
@@ -1078,7 +1078,7 @@ void _EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX* ctx, int pad);
  * @result A const pointer to the respective EVP_CIPHER struct
  * @throws OpenSSLException if an internal OpenSSL error is encountered
  */
-const EVP_CIPHER* _EVP_aes_256_cbc();
+const EVP_CIPHER *_EVP_aes_256_cbc();
 
 /**
  * Creates a new X509 extension, identified by its NID, from its string representation.
@@ -1088,13 +1088,13 @@ const EVP_CIPHER* _EVP_aes_256_cbc();
  * @param value the value of the extension that should be created
  * @return a unique pointer to the created extension
  */
-SSL_X509_EXTENSION_Ptr _X509V3_EXT_conf_nid(int ext_nid, X509V3_CTX* ctx, std::string value);
+SSL_X509_EXTENSION_Ptr _X509V3_EXT_conf_nid(int ext_nid, X509V3_CTX *ctx, std::string value);
 
 /**
  * Sets that there is no configuration database for a context.
  * @param ctx the context which is set
  */
-void _X509V3_set_ctx_nodb(X509V3_CTX* ctx);
+void _X509V3_set_ctx_nodb(X509V3_CTX *ctx);
 
 /**
  * Sets the information within a context.
@@ -1102,7 +1102,7 @@ void _X509V3_set_ctx_nodb(X509V3_CTX* ctx);
  * @param issuer the issuing certificate for this context
  * @param subject the subject certificate for this context
  */
-void _X509V3_set_ctx(X509V3_CTX* ctx, X509* issuer, X509* subject);
+void _X509V3_set_ctx(X509V3_CTX *ctx, X509 *issuer, X509 *subject);
 
 /**
  * Adds an X509 extension to an X509 certificate.
@@ -1110,21 +1110,21 @@ void _X509V3_set_ctx(X509V3_CTX* ctx, X509* issuer, X509* subject);
  * @param x the certificate
  * @param ex the new extension
  */
-void _X509_add_ext(X509* x, X509_EXTENSION* ex);
+void _X509_add_ext(X509 *x, X509_EXTENSION *ex);
 
 /**
  * Sets the serial number of a certificate.
  * @param x the certificate
  * @param serial the new serial number
  */
-void _X509_set_serialNumber(X509* x, uint64_t serial);
+void _X509_set_serialNumber(X509 *x, uint64_t serial);
 
 /**
  * Gets the serial number of a certificate.
  * @param x the certificate
  * @return the serial number of the passed certificate
  */
-uint64_t _X509_get_serialNumber(X509* x);
+uint64_t _X509_get_serialNumber(X509 *x);
 
 /**
  * Gets the serial number of a certificate with arbitrary precision as a decimal representation in
@@ -1133,7 +1133,7 @@ uint64_t _X509_get_serialNumber(X509* x);
  * @param x the certificate
  * @return the decimal string representation of the serial number
  */
-std::string _X509_get_serialNumber_dec(X509* x);
+std::string _X509_get_serialNumber_dec(X509 *x);
 
 /**
  * Gets the serial number of a certificate with arbitrary precision as a binary representation.
@@ -1141,7 +1141,7 @@ std::string _X509_get_serialNumber_dec(X509* x);
  * @param x the certificate
  * @return the binary representation of the serial number
  */
-std::vector<uint8_t> _X509_get_serialNumber_bin(X509* x);
+std::vector<uint8_t> _X509_get_serialNumber_bin(X509 *x);
 
 /**
  * Creates a new (empty) ASN1_TIME object.
@@ -1154,52 +1154,52 @@ SSL_ASN1_TIME_Ptr _ASN1_TIME_new();
 /**
  * Create a copy of a raw openssl ASN1_TIME objec
  */
-SSL_ASN1_TIME_Ptr _ASN1_TIME_copy(const ASN1_TIME* t);
+SSL_ASN1_TIME_Ptr _ASN1_TIME_copy(const ASN1_TIME *t);
 
 /**
  * Convert an ASN1_TIME object to a C++ time_point
  */
-time_point _asn1TimeToTimePoint(const ASN1_TIME* time);
+time_point _asn1TimeToTimePoint(const ASN1_TIME *time);
 
 /**
  * Gets the time for the next, planned update for a CRL.
  */
-const ASN1_TIME* _X509_CRL_get_nextUpdate(const X509_CRL* crl);
+const ASN1_TIME *_X509_CRL_get_nextUpdate(const X509_CRL *crl);
 
 /**
  * Gets the time for the creation of a CRL.
  */
-const ASN1_TIME* _X509_CRL_get_lastUpdate(const X509_CRL* crl);
+const ASN1_TIME *_X509_CRL_get_lastUpdate(const X509_CRL *crl);
 
 /**
  * Verifies the signature of a crl with a given public key.
  */
-void _X509_CRL_verify(X509_CRL* crl, EVP_PKEY* key);
+void _X509_CRL_verify(X509_CRL *crl, EVP_PKEY *key);
 
 /**
  * Gets the issuer (the issuer name of the CA certificate) of a CRL.
  */
-X509_NAME* _X509_CRL_get_issuer(const X509_CRL* crl);
+X509_NAME *_X509_CRL_get_issuer(const X509_CRL *crl);
 
 /**
  * Writes a CRL as PEM encoded to a BIO object.
  */
-void _PEM_write_bio_X509_CRL(BIO* bio, X509_CRL* crl);
+void _PEM_write_bio_X509_CRL(BIO *bio, X509_CRL *crl);
 
 /**
  * Reads a PEM encoded CRL from a BIO object.
  */
-SSL_X509_CRL_Ptr _PEM_read_bio_X509_CRL(BIO* bp);
+SSL_X509_CRL_Ptr _PEM_read_bio_X509_CRL(BIO *bp);
 
 /**
  * Reads a DER encoded CRL from a BIO object.
  */
-SSL_X509_CRL_Ptr _d2i_X509_CRL_bio(BIO* bp);
+SSL_X509_CRL_Ptr _d2i_X509_CRL_bio(BIO *bp);
 
 /**
  * Sets a list of CRLs for a verification context.
  */
-void _X509_STORE_CTX_set0_crls(X509_STORE_CTX* ctx, STACK_OF(X509_CRL) * crls);
+void _X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx, STACK_OF(X509_CRL) * crls);
 
 /**
  * Adds a specific amount of days and seconds to a time_t and returns it as an ASN1_TIME.
@@ -1209,18 +1209,18 @@ SSL_ASN1_TIME_Ptr _ASN1_TIME_adj(std::time_t t, int days, long seconds);
 /**
  * Prints an ASN1_STRING to a BIO object.
  */
-void _ASN1_STRING_print_ex(BIO* out, const ASN1_STRING* str);
+void _ASN1_STRING_print_ex(BIO *out, const ASN1_STRING *str);
 
 /**
  * Sets the time of verification for a verification context.
  */
-void _X509_STORE_CTX_set_time(X509_STORE_CTX* ctx, std::time_t time);
+void _X509_STORE_CTX_set_time(X509_STORE_CTX *ctx, std::time_t time);
 
 /**
  * Converts an ASN1_TIME to a time_t.
  * @throw OpenSSLException if the ASN1_TIME doesn't fit into a time_t.
  */
-time_t _asn1TimeToTimeT(const ASN1_TIME* time);
+time_t _asn1TimeToTimeT(const ASN1_TIME *time);
 
 enum class RSAPaddingMode {
     NONE = RSA_NO_PADDING,
@@ -1232,29 +1232,29 @@ enum class RSAPaddingMode {
 /**
  * Signs a message
  */
-void _EVP_PKEY_sign(EVP_PKEY_CTX* ctx,
-                    unsigned char* sig,
-                    size_t* siglen,
-                    const unsigned char* tbs,
+void _EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
+                    unsigned char *sig,
+                    size_t *siglen,
+                    const unsigned char *tbs,
                     size_t tbslen);
 
 /**
  * Initializes the context for a signature
  */
-void _EVP_PKEY_sign_init(EVP_PKEY_CTX* ctx);
+void _EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx);
 
 /**
  * Initializes the context for a RSA signature verification
  */
-void _EVP_PKEY_verify_init(EVP_PKEY_CTX* ctx);
+void _EVP_PKEY_verify_init(EVP_PKEY_CTX *ctx);
 
 /**
  * Performs a RSA signature verification
  */
-void _EVP_PKEY_verify(EVP_PKEY_CTX* ctx,
-                      const unsigned char* sig,
+void _EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
+                      const unsigned char *sig,
                       size_t siglen,
-                      const unsigned char* tbs,
+                      const unsigned char *tbs,
                       size_t tbslen);
 
 /**
@@ -1267,7 +1267,7 @@ void _EVP_PKEY_verify(EVP_PKEY_CTX* ctx,
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _EVP_DigestSignInit(EVP_MD_CTX* ctx, DigestTypes md, EVP_PKEY* pkey);
+void _EVP_DigestSignInit(EVP_MD_CTX *ctx, DigestTypes md, EVP_PKEY *pkey);
 
 /**
  * Perform a digital signature of the message and store the signature in signatureBuffer.
@@ -1280,10 +1280,10 @@ void _EVP_DigestSignInit(EVP_MD_CTX* ctx, DigestTypes md, EVP_PKEY* pkey);
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _EVP_DigestSign(EVP_MD_CTX* ctx,
-                     unsigned char* signatureBuffer,
-                     size_t* signatureBufferLength,
-                     const unsigned char* message,
+void _EVP_DigestSign(EVP_MD_CTX *ctx,
+                     unsigned char *signatureBuffer,
+                     size_t *signatureBufferLength,
+                     const unsigned char *message,
                      size_t messageLength);
 
 /**
@@ -1296,7 +1296,7 @@ void _EVP_DigestSign(EVP_MD_CTX* ctx,
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _EVP_DigestVerifyInit(EVP_MD_CTX* ctx, DigestTypes type, EVP_PKEY* pkey);
+void _EVP_DigestVerifyInit(EVP_MD_CTX *ctx, DigestTypes type, EVP_PKEY *pkey);
 
 /**
  * Verifies a given digital signature of the given message.
@@ -1309,88 +1309,88 @@ void _EVP_DigestVerifyInit(EVP_MD_CTX* ctx, DigestTypes type, EVP_PKEY* pkey);
  *
  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
  */
-void _EVP_DigestVerify(EVP_MD_CTX* ctx,
-                       const unsigned char* signature,
+void _EVP_DigestVerify(EVP_MD_CTX *ctx,
+                       const unsigned char *signature,
                        size_t signatureLength,
-                       const unsigned char* message,
+                       const unsigned char *message,
                        size_t messageLength);
 /**
  * Sets the RSA padding
  */
-void _EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX* ctx, int pad);
+void _EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad);
 
 /**
  * Sets the masking algorithm
  */
-void _EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX* ctx, const EVP_MD* md);
+void _EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 /**
  * Sets the salt length
  */
-void _EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX* ctx, int len);
+void _EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int len);
 /**
  * Sets the mgf1
  */
-void _EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX* ctx, const EVP_MD* md);
+void _EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 
 /**
  * Initializes the context for an encryption operation
  */
-void _EVP_PKEY_encrypt_init(EVP_PKEY_CTX* ctx);
+void _EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx);
 
 /**
  * Encrypts a message
  */
-void _EVP_PKEY_encrypt(EVP_PKEY_CTX* ctx,
-                       unsigned char* out,
-                       size_t* outlen,
-                       const unsigned char* in,
+void _EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
+                       unsigned char *out,
+                       size_t *outlen,
+                       const unsigned char *in,
                        size_t inlen);
 
 /**
  * Initializes the context for an decryption operation
  */
-void _EVP_PKEY_decrypt_init(EVP_PKEY_CTX* ctx);
+void _EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx);
 
 /**
  * Decrypts a message
  */
-void _EVP_PKEY_decrypt(EVP_PKEY_CTX* ctx,
-                       unsigned char* out,
-                       size_t* outlen,
-                       const unsigned char* in,
+void _EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
+                       unsigned char *out,
+                       size_t *outlen,
+                       const unsigned char *in,
                        size_t inlen);
 
 /**
  * Sets the OAEP hashing function
  */
-void _EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX* ctx, const EVP_MD* md);
+void _EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 
 /**
  * Sets the OAEP label
  */
-void _EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX* ctx, unsigned char* l, int llen);
+void _EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *l, int llen);
 
 /**
  * Returns the size of an RSA Key
  */
-int _RSA_size(const RSA* r);
+int _RSA_size(const RSA *r);
 
 /**
  * Returns the size of a message digest
  */
-int _EVP_MD_size(const EVP_MD* md);
+int _EVP_MD_size(const EVP_MD *md);
 
 /**
  * Allocates memory
  */
-void* _OPENSSL_malloc(int num);
+void *_OPENSSL_malloc(int num);
 
 /**
  * Generate random data.
  *
  * RAND_bytes() puts num cryptographically strong pseudo-random bytes into buf.
  */
-void _RAND_bytes(unsigned char* buf, int num);
+void _RAND_bytes(unsigned char *buf, int num);
 
 void _CRYPTO_malloc_init();
 
@@ -1425,39 +1425,39 @@ enum class EllipticCurvePointConversionForm {
 
 };
 
-EC_KEY* _EVP_PKEY_get0_EC_KEY(EVP_PKEY* pkey);
+EC_KEY *_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey);
 
 void _PKCS5_PBKDF2_HMAC(const std::vector<uint8_t> pass,
                         const std::vector<uint8_t> salt,
                         int iter,
-                        const EVP_MD* digest,
-                        std::vector<uint8_t>& out);
+                        const EVP_MD *digest,
+                        std::vector<uint8_t> &out);
 
-void _ECDH_KDF_X9_63(std::vector<uint8_t>& out,
-                     const std::vector<uint8_t>& Z,
-                     const std::vector<uint8_t>& sinfo,
-                     const EVP_MD* md);
+void _ECDH_KDF_X9_63(std::vector<uint8_t> &out,
+                     const std::vector<uint8_t> &Z,
+                     const std::vector<uint8_t> &sinfo,
+                     const EVP_MD *md);
 
 /* HMAC */
-void _HMAC_Init_ex(HMAC_CTX* ctx, const std::vector<uint8_t>& key, const EVP_MD* md, ENGINE* impl);
-std::vector<uint8_t> _HMAC_Final(HMAC_CTX* ctx);
-void _HMAC_Update(HMAC_CTX* ctx, const std::vector<uint8_t>& data);
+void _HMAC_Init_ex(HMAC_CTX *ctx, const std::vector<uint8_t> &key, const EVP_MD *md, ENGINE *impl);
+std::vector<uint8_t> _HMAC_Final(HMAC_CTX *ctx);
+void _HMAC_Update(HMAC_CTX *ctx, const std::vector<uint8_t> &data);
 SSL_HMAC_CTX_Ptr _HMAC_CTX_new(void);
 
 /* CMAC */
 SSL_CMAC_CTX_Ptr _CMAC_CTX_new(void);
-void _CMAC_Init(CMAC_CTX* ctx,
-                const std::vector<uint8_t>& key,
-                const EVP_CIPHER* cipher,
-                ENGINE* impl);
-void _CMAC_Update(CMAC_CTX* ctx, const std::vector<uint8_t>& data);
-std::vector<uint8_t> _CMAC_Final(CMAC_CTX* ctx);
-const EVP_CIPHER* _getCipherPtrFromCmacCipherType(CmacCipherTypes cipherType);
+void _CMAC_Init(CMAC_CTX *ctx,
+                const std::vector<uint8_t> &key,
+                const EVP_CIPHER *cipher,
+                ENGINE *impl);
+void _CMAC_Update(CMAC_CTX *ctx, const std::vector<uint8_t> &data);
+std::vector<uint8_t> _CMAC_Final(CMAC_CTX *ctx);
+const EVP_CIPHER *_getCipherPtrFromCmacCipherType(CmacCipherTypes cipherType);
 
-SSL_EC_KEY_Ptr _EC_KEY_oct2key(int nid, const std::vector<uint8_t>& buf);
-void _EVP_PKEY_set1_EC_KEY(EVP_PKEY* pkey, EC_KEY* key);
+SSL_EC_KEY_Ptr _EC_KEY_oct2key(int nid, const std::vector<uint8_t> &buf);
+void _EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key);
 
-std::vector<uint8_t> _EC_KEY_key2buf(const EVP_PKEY* evp, point_conversion_form_t form);
+std::vector<uint8_t> _EC_KEY_key2buf(const EVP_PKEY *evp, point_conversion_form_t form);
 /**
  * @brief _EVP_derive_key calculates a new public key P_new
  *
@@ -1470,33 +1470,33 @@ std::vector<uint8_t> _EC_KEY_key2buf(const EVP_PKEY* evp, point_conversion_form_
  * @param key The private key
  * @return The new public key
  */
-std::vector<uint8_t> _EVP_derive_key(const EVP_PKEY* peerkey, const EVP_PKEY* key);
+std::vector<uint8_t> _EVP_derive_key(const EVP_PKEY *peerkey, const EVP_PKEY *key);
 
 /* ECDSA Special */
 /**
  * Set the r and s signature components from r and s a bignums
  */
-void _ECDSA_SIG_set0(ECDSA_SIG* sig, SSL_BIGNUM_Ptr r, SSL_BIGNUM_Ptr s);
+void _ECDSA_SIG_set0(ECDSA_SIG *sig, SSL_BIGNUM_Ptr r, SSL_BIGNUM_Ptr s);
 
 /**
  * Get the r signature component as bignum
  */
-const BIGNUM* _ECDSA_SIG_get0_r(const ECDSA_SIG* sig);
+const BIGNUM *_ECDSA_SIG_get0_r(const ECDSA_SIG *sig);
 
 /**
  * Get the s signature component as bignum
  */
-const BIGNUM* _ECDSA_SIG_get0_s(const ECDSA_SIG* sig);
+const BIGNUM *_ECDSA_SIG_get0_s(const ECDSA_SIG *sig);
 
 /**
  * Get the serialized ECDSA signature in ASN.1 format from ECDSA_SIG object
  */
-std::vector<uint8_t> _i2d_ECDSA_SIG(const ECDSA_SIG*);
+std::vector<uint8_t> _i2d_ECDSA_SIG(const ECDSA_SIG *);
 
 /**
  * Create ECDSA_SIG object from serialized ECDSA signature.
  */
-SSL_ECDSA_SIG_Ptr _d2i_ECDSA_SIG(const std::vector<uint8_t>& signature);
+SSL_ECDSA_SIG_Ptr _d2i_ECDSA_SIG(const std::vector<uint8_t> &signature);
 
 /* Bignum related */
 
@@ -1507,7 +1507,7 @@ SSL_ECDSA_SIG_Ptr _d2i_ECDSA_SIG(const std::vector<uint8_t>& signature);
  * @return A smart pointer to the bignum object
  * @throw OpenSSLException is a problem occurs during the conversion
  */
-SSL_BIGNUM_Ptr _BN_bin2bn(const uint8_t* data, size_t dataLen);
+SSL_BIGNUM_Ptr _BN_bin2bn(const uint8_t *data, size_t dataLen);
 
 /**
  * Write an OpenSSL bignum in big-endian plain bytes representation of an
@@ -1518,24 +1518,24 @@ SSL_BIGNUM_Ptr _BN_bin2bn(const uint8_t* data, size_t dataLen);
  * @return Vector containing serialized number
  * @throw OpenSSLException if tolen bytes cannot hold bignum
  */
-std::vector<uint8_t> _BN_bn2binpad(const BIGNUM* bignum, int tolen);
+std::vector<uint8_t> _BN_bn2binpad(const BIGNUM *bignum, int tolen);
 
 /* Engine related */
 
 /**
  * Loads an engine based on the passed ID \p engineId.
  */
-SSL_ENGINE_Ptr _ENGINE_by_id(const std::string& engineId);
+SSL_ENGINE_Ptr _ENGINE_by_id(const std::string &engineId);
 
 /**
  * Initialises engine \p e.
  */
-void _ENGINE_init(ENGINE* e);
+void _ENGINE_init(ENGINE *e);
 
 /**
  * Issues a command \p cmdName to the engine \p e. Takes a string \p cmdArg as input data.
  */
-void _ENGINE_ctrl_cmd_string(ENGINE* e, const std::string& cmdName, const std::string& cmdArg);
+void _ENGINE_ctrl_cmd_string(ENGINE *e, const std::string &cmdName, const std::string &cmdArg);
 
 /**
  * Load private key via Engine \p e. Mainly used with HSMs which are modelled as
@@ -1544,7 +1544,7 @@ void _ENGINE_ctrl_cmd_string(ENGINE* e, const std::string& cmdName, const std::s
  * @param e The engine for loading the private key.
  * @param keyId The ID of the key.
  */
-SSL_EVP_PKEY_Ptr _ENGINE_load_private_key(ENGINE* e, const std::string& keyId);
+SSL_EVP_PKEY_Ptr _ENGINE_load_private_key(ENGINE *e, const std::string &keyId);
 
 /**
  * Load private key via Engine \p e. Mainly used with HSMs which are modelled as
@@ -1553,12 +1553,12 @@ SSL_EVP_PKEY_Ptr _ENGINE_load_private_key(ENGINE* e, const std::string& keyId);
  * @param e The engine for loading the private key.
  * @param keyId The ID of the key.
  */
-SSL_EVP_PKEY_Ptr _ENGINE_load_public_key(ENGINE* e, const std::string& keyId);
+SSL_EVP_PKEY_Ptr _ENGINE_load_public_key(ENGINE *e, const std::string &keyId);
 
 /**
  * Clear engine's functional reference.
  */
-void _ENGINE_finish(ENGINE* e);
+void _ENGINE_finish(ENGINE *e);
 
 }  // namespace openssl
 }  // namespace mococrw

--- a/src/mococrw/padding_mode.h
+++ b/src/mococrw/padding_mode.h
@@ -41,13 +41,13 @@ public:
      * @param messageSize The size of the message that will be encrypted
      * @return the maximum size of the data that can be encrypted in bytes.
      */
-    virtual bool checkMessageSize(const AsymmetricPublicKey& key, size_t messageSize) const = 0;
+    virtual bool checkMessageSize(const AsymmetricPublicKey &key, size_t messageSize) const = 0;
 
     /**
      * @brief Prepares the given openssl context with the padding specific parameters.
      * @param ctx OpenSSL PKEY context
      */
-    virtual void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const = 0;
+    virtual void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx) const = 0;
 };
 
 /**
@@ -68,7 +68,7 @@ public:
      * @param ctx OpenSSL context
      * @param hashFunction The hash function to be used
      */
-    virtual void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx,
+    virtual void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx,
                                        openssl::DigestTypes hashFunction) const = 0;
 };
 
@@ -80,9 +80,9 @@ public:
 class NoPadding : public RSAEncryptionPadding
 {
 public:
-    bool checkMessageSize(const AsymmetricPublicKey& key, size_t messageSize) const override;
+    bool checkMessageSize(const AsymmetricPublicKey &key, size_t messageSize) const override;
 
-    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const override;
+    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx) const override;
 };
 
 /**
@@ -94,11 +94,11 @@ public:
 class PKCSPadding : public RSAEncryptionPadding, public RSASignaturePadding
 {
 public:
-    bool checkMessageSize(const AsymmetricPublicKey& key, size_t messageSize) const override;
+    bool checkMessageSize(const AsymmetricPublicKey &key, size_t messageSize) const override;
 
-    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const override;
+    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx) const override;
 
-    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx,
+    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx,
                                openssl::DigestTypes hashFunction) const override;
 
 private:
@@ -119,7 +119,7 @@ public:
      * parameters.
      * @param ctx OpenSSL context
      */
-    virtual void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const = 0;
+    virtual void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx) const = 0;
 };
 
 /**
@@ -142,7 +142,7 @@ public:
 
     virtual ~MGF1();
 
-    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const override;
+    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx) const override;
 
 private:
     /**
@@ -177,26 +177,26 @@ public:
      */
     OAEPPadding(openssl::DigestTypes hashFunction = openssl::DigestTypes::SHA256,
                 std::shared_ptr<MaskGenerationFunction> maskGenerationFunction = nullptr,
-                const std::string& label = "");
+                const std::string &label = "");
 
     /**
      * @brief Copy Constrcutor
      */
-    OAEPPadding(const OAEPPadding& other);
+    OAEPPadding(const OAEPPadding &other);
 
     /**
      * @brief Copy Assignment
      */
-    OAEPPadding& operator=(const OAEPPadding& other);
+    OAEPPadding &operator=(const OAEPPadding &other);
 
     /**
      * @brief Destructor
      */
     ~OAEPPadding();
 
-    bool checkMessageSize(const AsymmetricPublicKey& key, size_t messageSize) const override;
+    bool checkMessageSize(const AsymmetricPublicKey &key, size_t messageSize) const override;
 
-    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const override;
+    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx) const override;
 
 private:
     /**
@@ -236,19 +236,19 @@ public:
     /**
      * @brief Copy Constructor
      */
-    PSSPadding(const PSSPadding& other);
+    PSSPadding(const PSSPadding &other);
 
     /**
      * @brief Copy Assignment
      */
-    PSSPadding& operator=(const PSSPadding& other);
+    PSSPadding &operator=(const PSSPadding &other);
 
     /**
      * @brief Destructor
      */
     ~PSSPadding();
 
-    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx,
+    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx,
                                openssl::DigestTypes hashFunction) const override;
 
 private:

--- a/src/mococrw/sign_params.h
+++ b/src/mococrw/sign_params.h
@@ -64,7 +64,7 @@ public:
      */
     openssl::DigestTypes digestType() const { return _digestType; }
 
-    const std::map<openssl::X509Extension_NID, std::shared_ptr<ExtensionBase> >& extensionMap()
+    const std::map<openssl::X509Extension_NID, std::shared_ptr<ExtensionBase> > &extensionMap()
             const
     {
         return _extensions;
@@ -105,12 +105,12 @@ private:
     }
 
 public:
-    bool operator==(const CertificateSigningParameters& other) const
+    bool operator==(const CertificateSigningParameters &other) const
     {
         return _makeTuple() == other._makeTuple();
     }
 
-    bool operator!=(const CertificateSigningParameters& other) const { return !operator==(other); }
+    bool operator!=(const CertificateSigningParameters &other) const { return !operator==(other); }
 
 private:
     boost::optional<Asn1Time> _notBefore;
@@ -125,28 +125,28 @@ class CertificateSigningParameters::Builder
 {
 public:
     template <class T>
-    Builder& certificateValidity(T&& validity)
+    Builder &certificateValidity(T &&validity)
     {
         _sp._certificateValidity = std::forward<T>(validity);
         return *this;
     }
 
     template <class T>
-    Builder& notBeforeAsn1(T&& notBefore)
+    Builder &notBeforeAsn1(T &&notBefore)
     {
         _sp._notBefore = std::forward<T>(notBefore);
         return *this;
     }
 
     template <class T>
-    Builder& digestType(T&& type)
+    Builder &digestType(T &&type)
     {
         _sp._digestType = std::forward<T>(type);
         return *this;
     }
 
     template <class T>
-    Builder& addExtension(T extension)
+    Builder &addExtension(T extension)
     {
         static_assert(std::is_base_of<ExtensionBase, T>::value,
                       "Extension is not derived from ExtensionBase");
@@ -156,7 +156,7 @@ public:
         return *this;
     }
 
-    Builder& addExtension(std::shared_ptr<ExtensionBase> extension)
+    Builder &addExtension(std::shared_ptr<ExtensionBase> extension)
     {
         auto nid = extension->getNid();
         _sp._extensions[nid] = std::move(extension);

--- a/src/mococrw/symmetric_memory.h
+++ b/src/mococrw/symmetric_memory.h
@@ -44,7 +44,7 @@ public:
 
 private:
     std::vector<uint8_t> _readCompleteBlock();
-    void _readPartialBlock(size_t requestedSize, std::vector<uint8_t>& output);
+    void _readPartialBlock(size_t requestedSize, std::vector<uint8_t> &output);
     std::deque<std::vector<uint8_t>> _queue;
     size_t _totalBytesStored = 0;
 };

--- a/src/mococrw/util.h
+++ b/src/mococrw/util.h
@@ -32,7 +32,7 @@ namespace utility
 template <class T>
 using SharedPtrTypeFromUniquePtr = std::shared_ptr<typename T::element_type>;
 
-std::string toHex(const std::vector<uint8_t>& data);
+std::string toHex(const std::vector<uint8_t> &data);
 
 /**
  * @brief Returns a uint8_t vector representation for a hex string
@@ -41,12 +41,12 @@ std::string toHex(const std::vector<uint8_t>& data);
  * @return A vector containing the data in uint8_t representation
  * @throws MoCOCrWException if there is an error parsing the hex string (invalid characters)
  */
-std::vector<uint8_t> fromHex(const std::string& hexData);
+std::vector<uint8_t> fromHex(const std::string &hexData);
 
 std::vector<uint8_t> cryptoRandomBytes(size_t length);
 
 template <typename T>
-void vectorCleanse(std::vector<T>& vec)
+void vectorCleanse(std::vector<T> &vec)
 {
     // Explicitly overwrite the memory, but check for size() > 0, since
     // std::vector<T>::data() is allowed to return a nullptr if the size is 0.
@@ -69,14 +69,14 @@ public:
      * @param[in] func Function to run on destruction.
      */
     template <class T>
-    Finally(T&& func) : _func(std::forward<T>(func))
+    Finally(T &&func) : _func(std::forward<T>(func))
     {
     }
 
-    Finally(const Finally& other) = delete;
-    Finally(Finally&& other) = delete;
-    Finally& operator=(const Finally& other) = delete;
-    Finally& operator=(Finally&& other) = delete;
+    Finally(const Finally &other) = delete;
+    Finally(Finally &&other) = delete;
+    Finally &operator=(const Finally &other) = delete;
+    Finally &operator=(Finally &&other) = delete;
 
     ~Finally()
     {

--- a/src/mococrw/x509.h
+++ b/src/mococrw/x509.h
@@ -33,10 +33,10 @@ namespace mococrw
 class X509Certificate
 {
 public:
-    static X509Certificate fromPEM(const std::string& pem);
-    static X509Certificate fromPEMFile(const std::string& filename);
-    static X509Certificate fromDER(const std::vector<uint8_t>& derData);
-    static X509Certificate fromDERFile(const std::string& filename);
+    static X509Certificate fromPEM(const std::string &pem);
+    static X509Certificate fromPEMFile(const std::string &filename);
+    static X509Certificate fromDER(const std::vector<uint8_t> &derData);
+    static X509Certificate fromDERFile(const std::string &filename);
 
     /**
      * Return a PEM representation of this certificate.
@@ -132,8 +132,8 @@ public:
      * OpenSSL's native methods is necessary for some
      * reason.
      */
-    const X509* internal() const { return _x509.get(); }
-    X509* internal() { return _x509.get(); }
+    const X509 *internal() const { return _x509.get(); }
+    X509 *internal() { return _x509.get(); }
 
     /**
      * This helper class represents a context of an X509 certificate in which it might be valid
@@ -160,7 +160,7 @@ public:
          * Adds a number of trusted certificates to this VerificationContext.
          */
         template <typename Container = std::initializer_list<X509Certificate>>
-        VerificationContext& addTrustedCertificates(Container&& trustedCerts)
+        VerificationContext &addTrustedCertificates(Container &&trustedCerts)
         {
             _addAll(_trustedCerts, std::forward<Container>(trustedCerts));
             return *this;
@@ -169,7 +169,7 @@ public:
         /**
          * Adds a single trusted certificate to this context.
          */
-        VerificationContext& addTrustedCertificate(X509Certificate trustedCert)
+        VerificationContext &addTrustedCertificate(X509Certificate trustedCert)
         {
             _trustedCerts.emplace_back(std::move(trustedCert));
             return *this;
@@ -179,7 +179,7 @@ public:
          * Adds a number of intermediate certificates to this VerificationContext.
          */
         template <typename Container = std::initializer_list<X509Certificate>>
-        VerificationContext& addIntermediateCertificates(Container&& intermediateCerts)
+        VerificationContext &addIntermediateCertificates(Container &&intermediateCerts)
         {
             _addAll(_intermediateCerts, std::forward<Container>(intermediateCerts));
             return *this;
@@ -188,7 +188,7 @@ public:
         /**
          * Adds a single intermediate certificate to this VerificationContext.
          */
-        VerificationContext& addIntermediateCertificate(X509Certificate intermediateCert)
+        VerificationContext &addIntermediateCertificate(X509Certificate intermediateCert)
         {
             _intermediateCerts.emplace_back(std::move(intermediateCert));
             return *this;
@@ -199,7 +199,7 @@ public:
          * Unless the given container contains no elements, this activates CRL checking.
          */
         template <typename Container = std::initializer_list<CertificateRevocationList>>
-        VerificationContext& addCertificateRevocationLists(Container&& revocationLists)
+        VerificationContext &addCertificateRevocationLists(Container &&revocationLists)
         {
             _addAll(_crls, std::forward<Container>(revocationLists));
             return *this;
@@ -209,7 +209,7 @@ public:
          * Adds a single CRL to this VerificationContext.
          * This activates CRL checking.
          */
-        VerificationContext& addCertificateRevocationList(CertificateRevocationList revocationList)
+        VerificationContext &addCertificateRevocationList(CertificateRevocationList revocationList)
         {
             _crls.emplace_back(std::move(revocationList));
             return *this;
@@ -218,7 +218,7 @@ public:
         /**
          * Sets a flag that the root certificate should be self signed.
          */
-        VerificationContext& enforceSelfSignedRootCertificate()
+        VerificationContext &enforceSelfSignedRootCertificate()
         {
             _enforceSelfSignedRootCertificate = true;
             return *this;
@@ -229,7 +229,7 @@ public:
          * This also requires setting enforceSelfSignedRootCertificate since OpenSSL doesn't support
          * checking CRLs for all CAs without having a self signed root certificate present.
          */
-        VerificationContext& enforceCrlsForAllCAs()
+        VerificationContext &enforceCrlsForAllCAs()
         {
             _enforceCrlForWholeChain = true;
             return *this;
@@ -241,7 +241,7 @@ public:
          * This only supports times that are within range of std::time_t.
          * @throw MoCOCrWException if a time was passed that is outside of std::time_t range.
          */
-        VerificationContext& setVerificationCheckTime(Asn1Time checkTime);
+        VerificationContext &setVerificationCheckTime(Asn1Time checkTime);
 
         /**
          * Does a check to see if the current context is in a good state to verify certificates.
@@ -263,10 +263,10 @@ public:
         boost::optional<std::time_t> _verificationCheckTime;
 
         template <typename Container1, typename Container2>
-        void _addAll(Container1& addTo, Container2&& addThese)
+        void _addAll(Container1 &addTo, Container2 &&addThese)
         {
             using Iterator =
-                    typename std::conditional<std::is_rvalue_reference<Container2&&>::value,
+                    typename std::conditional<std::is_rvalue_reference<Container2 &&>::value,
                                               decltype(std::make_move_iterator(addThese.begin())),
                                               decltype(addThese.begin())>::type;
 
@@ -296,8 +296,8 @@ public:
      *                        used to construct the chain.
      * @throw MoCOCrWException if the validation fails.
      */
-    void verify(const std::vector<X509Certificate>& trustStore,
-                const std::vector<X509Certificate>& intermediateCAs) const;
+    void verify(const std::vector<X509Certificate> &trustStore,
+                const std::vector<X509Certificate> &intermediateCAs) const;
 
     /**
      * @brief Verify the validity of a certificate
@@ -326,13 +326,13 @@ public:
      *                        should be verified.
      * @throw MoCOCrWException if the validation fails.
      */
-    void verify(const VerificationContext& ctx) const;
+    void verify(const VerificationContext &ctx) const;
 
     /**
      * Create a new X509 certificate from an existing openssl certificate.
      * @param ptr a unique pointer to the existing openssl certificate.
      */
-    explicit X509Certificate(openssl::SSL_X509_Ptr&& ptr) : _x509{std::move(ptr)} {}
+    explicit X509Certificate(openssl::SSL_X509_Ptr &&ptr) : _x509{std::move(ptr)} {}
 
 private:
     openssl::SSL_X509_SharedPtr _x509;
@@ -349,7 +349,7 @@ namespace util
  *         PEM string
  * @throw MoCOCrWException if the input or one of the included certificates is invalid
  */
-std::vector<X509Certificate> loadPEMChain(const std::string& pemChain);
+std::vector<X509Certificate> loadPEMChain(const std::string &pemChain);
 }  // namespace util
 
 }  // namespace mococrw

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -62,105 +62,105 @@ void OpenSSLLib::SSL_SSL_load_error_strings() noexcept { SSL_load_error_strings(
 
 void OpenSSLLib::SSL_OpenSSL_add_all_algorithms() noexcept { OpenSSL_add_all_algorithms(); }
 
-void OpenSSLLib::SSL_X509_REQ_free(X509_REQ* ptr) noexcept { X509_REQ_free(ptr); }
+void OpenSSLLib::SSL_X509_REQ_free(X509_REQ *ptr) noexcept { X509_REQ_free(ptr); }
 
-X509_REQ* OpenSSLLib::SSL_X509_REQ_new() noexcept { return X509_REQ_new(); }
+X509_REQ *OpenSSLLib::SSL_X509_REQ_new() noexcept { return X509_REQ_new(); }
 
-EVP_PKEY* OpenSSLLib::SSL_EVP_PKEY_new() noexcept { return EVP_PKEY_new(); }
+EVP_PKEY *OpenSSLLib::SSL_EVP_PKEY_new() noexcept { return EVP_PKEY_new(); }
 
-void OpenSSLLib::SSL_EVP_PKEY_free(EVP_PKEY* ptr) noexcept { EVP_PKEY_free(ptr); }
+void OpenSSLLib::SSL_EVP_PKEY_free(EVP_PKEY *ptr) noexcept { EVP_PKEY_free(ptr); }
 
-int OpenSSLLib::SSL_EVP_PKEY_keygen(EVP_PKEY_CTX* ctx, EVP_PKEY** ppkey) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept
 {
     return EVP_PKEY_keygen(ctx, ppkey);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_keygen_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return EVP_PKEY_keygen_init(ctx);
 }
 
-EVP_PKEY_CTX* OpenSSLLib::SSL_EVP_PKEY_CTX_new(EVP_PKEY* pkey, ENGINE* engine) noexcept
+EVP_PKEY_CTX *OpenSSLLib::SSL_EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *engine) noexcept
 {
     return EVP_PKEY_CTX_new(pkey, engine);
 }
 
-EVP_PKEY_CTX* OpenSSLLib::SSL_EVP_PKEY_CTX_new_id(int id, ENGINE* engine) noexcept
+EVP_PKEY_CTX *OpenSSLLib::SSL_EVP_PKEY_CTX_new_id(int id, ENGINE *engine) noexcept
 {
     return EVP_PKEY_CTX_new_id(id, engine);
 }
 
-void OpenSSLLib::SSL_EVP_PKEY_CTX_free(EVP_PKEY_CTX* ptr) noexcept
+void OpenSSLLib::SSL_EVP_PKEY_CTX_free(EVP_PKEY_CTX *ptr) noexcept
 {
     return EVP_PKEY_CTX_free(ptr);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX *ctx, int mbits) noexcept
 {
     return EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, mbits);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_cmp(const EVP_PKEY* a, const EVP_PKEY* b) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) noexcept
 {
     return EVP_PKEY_cmp(a, b);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return EVP_PKEY_paramgen_init(ctx);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX* ctx, EVP_PKEY** ppkey) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept
 {
     return EVP_PKEY_paramgen(ctx, ppkey);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX* ctx, int nid) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept
 {
     return EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX* ctx, int param_enc) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) noexcept
 {
     return EVP_PKEY_CTX_set_ec_param_enc(ctx, param_enc);
 }
 
-const EC_GROUP* OpenSSLLib::SSL_EC_KEY_get0_group(const EC_KEY* key) noexcept
+const EC_GROUP *OpenSSLLib::SSL_EC_KEY_get0_group(const EC_KEY *key) noexcept
 {
     return EC_KEY_get0_group(key);
 }
 
-int OpenSSLLib::SSL_EC_GROUP_get_degree(const EC_GROUP* group) noexcept
+int OpenSSLLib::SSL_EC_GROUP_get_degree(const EC_GROUP *group) noexcept
 {
     return EC_GROUP_get_degree(group);
 }
 
-int OpenSSLLib::SSL_EC_GROUP_get_curve_name(const EC_GROUP* group) noexcept
+int OpenSSLLib::SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) noexcept
 {
     return EC_GROUP_get_curve_name(group);
 }
 
 int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept { return EVP_PKEY_type(type); }
 
-int OpenSSLLib::SSL_EVP_PKEY_id(const EVP_PKEY* pkey) noexcept { return EVP_PKEY_id(pkey); }
+int OpenSSLLib::SSL_EVP_PKEY_id(const EVP_PKEY *pkey) noexcept { return EVP_PKEY_id(pkey); }
 
-int OpenSSLLib::SSL_EVP_PKEY_size(EVP_PKEY* pkey) noexcept { return EVP_PKEY_size(pkey); }
+int OpenSSLLib::SSL_EVP_PKEY_size(EVP_PKEY *pkey) noexcept { return EVP_PKEY_size(pkey); }
 
-char* OpenSSLLib::SSL_ERR_error_string(unsigned long error, char* buf) noexcept
+char *OpenSSLLib::SSL_ERR_error_string(unsigned long error, char *buf) noexcept
 {
     return ERR_error_string(error, buf);
 }
 
 unsigned long OpenSSLLib::SSL_ERR_get_error() noexcept { return ERR_get_error(); }
 
-X509_NAME* OpenSSLLib::SSL_X509_NAME_new() noexcept { return X509_NAME_new(); }
+X509_NAME *OpenSSLLib::SSL_X509_NAME_new() noexcept { return X509_NAME_new(); }
 
-void OpenSSLLib::SSL_X509_NAME_free(X509_NAME* ptr) noexcept { X509_NAME_free(ptr); }
+void OpenSSLLib::SSL_X509_NAME_free(X509_NAME *ptr) noexcept { X509_NAME_free(ptr); }
 
-int OpenSSLLib::SSL_X509_NAME_add_entry_by_NID(X509_NAME* name,
+int OpenSSLLib::SSL_X509_NAME_add_entry_by_NID(X509_NAME *name,
                                                int nid,
                                                int type,
-                                               unsigned char* bytes,
+                                               unsigned char *bytes,
                                                int len,
                                                int loc,
                                                int set) noexcept
@@ -168,444 +168,444 @@ int OpenSSLLib::SSL_X509_NAME_add_entry_by_NID(X509_NAME* name,
     return X509_NAME_add_entry_by_NID(name, nid, type, bytes, len, loc, set);
 }
 
-int OpenSSLLib::SSL_X509_REQ_set_subject_name(X509_REQ* req, X509_NAME* name) noexcept
+int OpenSSLLib::SSL_X509_REQ_set_subject_name(X509_REQ *req, X509_NAME *name) noexcept
 {
     return X509_REQ_set_subject_name(req, name);
 }
 
-int OpenSSLLib::SSL_X509_REQ_set_pubkey(X509_REQ* req, EVP_PKEY* pkey) noexcept
+int OpenSSLLib::SSL_X509_REQ_set_pubkey(X509_REQ *req, EVP_PKEY *pkey) noexcept
 {
     return X509_REQ_set_pubkey(req, pkey);
 }
 
-int OpenSSLLib::SSL_X509_REQ_set_version(X509_REQ* req, unsigned long version) noexcept
+int OpenSSLLib::SSL_X509_REQ_set_version(X509_REQ *req, unsigned long version) noexcept
 {
     return X509_REQ_set_version(req, version);
 }
 
-X509_NAME* OpenSSLLib::SSL_X509_REQ_get_subject_name(const X509_REQ* req) noexcept
+X509_NAME *OpenSSLLib::SSL_X509_REQ_get_subject_name(const X509_REQ *req) noexcept
 {
     return X509_REQ_get_subject_name(req);
 }
 
-EVP_PKEY* OpenSSLLib::SSL_X509_REQ_get_pubkey(X509_REQ* req) noexcept
+EVP_PKEY *OpenSSLLib::SSL_X509_REQ_get_pubkey(X509_REQ *req) noexcept
 {
     return X509_REQ_get_pubkey(req);
 }
 
-int OpenSSLLib::SSL_X509_REQ_verify(X509_REQ* req, EVP_PKEY* r) noexcept
+int OpenSSLLib::SSL_X509_REQ_verify(X509_REQ *req, EVP_PKEY *r) noexcept
 {
     return X509_REQ_verify(req, r);
 }
 
-int OpenSSLLib::SSL_PEM_write_bio_X509_REQ(BIO* bio, X509_REQ* req) noexcept
+int OpenSSLLib::SSL_PEM_write_bio_X509_REQ(BIO *bio, X509_REQ *req) noexcept
 {
     return PEM_write_bio_X509_REQ(bio, req);
 }
 
-X509_REQ* OpenSSLLib::SSL_PEM_read_bio_X509_REQ(BIO* bp,
-                                                X509_REQ** x,
-                                                pem_password_cb* cb,
-                                                void* u) noexcept
+X509_REQ *OpenSSLLib::SSL_PEM_read_bio_X509_REQ(BIO *bp,
+                                                X509_REQ **x,
+                                                pem_password_cb *cb,
+                                                void *u) noexcept
 {
     return PEM_read_bio_X509_REQ(bp, x, cb, u);
 }
 
-const BIO_METHOD* OpenSSLLib::SSL_BIO_s_mem() noexcept { return BIO_s_mem(); }
+const BIO_METHOD *OpenSSLLib::SSL_BIO_s_mem() noexcept { return BIO_s_mem(); }
 
-void OpenSSLLib::SSL_BIO_free_all(BIO* ptr) noexcept { BIO_free_all(ptr); }
+void OpenSSLLib::SSL_BIO_free_all(BIO *ptr) noexcept { BIO_free_all(ptr); }
 
-BIO* OpenSSLLib::SSL_BIO_new(const BIO_METHOD* method) noexcept { return BIO_new(method); }
+BIO *OpenSSLLib::SSL_BIO_new(const BIO_METHOD *method) noexcept { return BIO_new(method); }
 
-int OpenSSLLib::SSL_BIO_gets(BIO* bio, char* buf, int size) noexcept
+int OpenSSLLib::SSL_BIO_gets(BIO *bio, char *buf, int size) noexcept
 {
     return BIO_gets(bio, buf, size);
 }
 
-int OpenSSLLib::SSL_X509_REQ_sign_ctx(X509_REQ* req, EVP_MD_CTX* ctx) noexcept
+int OpenSSLLib::SSL_X509_REQ_sign_ctx(X509_REQ *req, EVP_MD_CTX *ctx) noexcept
 {
     return X509_REQ_sign_ctx(req, ctx);
 }
 
-EVP_MD_CTX* OpenSSLLib::SSL_EVP_MD_CTX_create() noexcept { return EVP_MD_CTX_create(); }
+EVP_MD_CTX *OpenSSLLib::SSL_EVP_MD_CTX_create() noexcept { return EVP_MD_CTX_create(); }
 
-int OpenSSLLib::SSL_EVP_DigestSignInit(EVP_MD_CTX* ctx,
-                                       EVP_PKEY_CTX** pctx,
-                                       const EVP_MD* type,
-                                       ENGINE* e,
-                                       EVP_PKEY* pkey) noexcept
+int OpenSSLLib::SSL_EVP_DigestSignInit(EVP_MD_CTX *ctx,
+                                       EVP_PKEY_CTX **pctx,
+                                       const EVP_MD *type,
+                                       ENGINE *e,
+                                       EVP_PKEY *pkey) noexcept
 {
     return EVP_DigestSignInit(ctx, pctx, type, e, pkey);
 }
 
-int OpenSSLLib::SSL_EVP_DigestSign(EVP_MD_CTX* ctx,
-                                   unsigned char* sigret,
-                                   size_t* siglen,
-                                   const unsigned char* tbs,
+int OpenSSLLib::SSL_EVP_DigestSign(EVP_MD_CTX *ctx,
+                                   unsigned char *sigret,
+                                   size_t *siglen,
+                                   const unsigned char *tbs,
                                    size_t tbslen) noexcept
 {
     return EVP_DigestSign(ctx, sigret, siglen, tbs, tbslen);
 }
 
-void OpenSSLLib::SSL_EVP_MD_CTX_destroy(EVP_MD_CTX* ptr) noexcept { EVP_MD_CTX_destroy(ptr); }
+void OpenSSLLib::SSL_EVP_MD_CTX_destroy(EVP_MD_CTX *ptr) noexcept { EVP_MD_CTX_destroy(ptr); }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha1() noexcept { return EVP_sha1(); }
+const EVP_MD *OpenSSLLib::SSL_EVP_sha1() noexcept { return EVP_sha1(); }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha256() noexcept { return EVP_sha256(); }
+const EVP_MD *OpenSSLLib::SSL_EVP_sha256() noexcept { return EVP_sha256(); }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha384() noexcept { return EVP_sha384(); }
+const EVP_MD *OpenSSLLib::SSL_EVP_sha384() noexcept { return EVP_sha384(); }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha512() noexcept { return EVP_sha512(); }
+const EVP_MD *OpenSSLLib::SSL_EVP_sha512() noexcept { return EVP_sha512(); }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha3_256() noexcept { return EVP_sha3_256(); }
+const EVP_MD *OpenSSLLib::SSL_EVP_sha3_256() noexcept { return EVP_sha3_256(); }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha3_384() noexcept { return EVP_sha3_384(); }
+const EVP_MD *OpenSSLLib::SSL_EVP_sha3_384() noexcept { return EVP_sha3_384(); }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha3_512() noexcept { return EVP_sha3_512(); }
+const EVP_MD *OpenSSLLib::SSL_EVP_sha3_512() noexcept { return EVP_sha3_512(); }
 
-const EVP_CIPHER* OpenSSLLib::SSL_EVP_aes_128_cbc() noexcept { return EVP_aes_128_cbc(); }
+const EVP_CIPHER *OpenSSLLib::SSL_EVP_aes_128_cbc() noexcept { return EVP_aes_128_cbc(); }
 
-const EVP_CIPHER* OpenSSLLib::SSL_EVP_aes_256_cbc() noexcept { return EVP_aes_256_cbc(); }
+const EVP_CIPHER *OpenSSLLib::SSL_EVP_aes_256_cbc() noexcept { return EVP_aes_256_cbc(); }
 
-int OpenSSLLib::SSL_PEM_write_bio_PKCS8PrivateKey(BIO* bp,
-                                                  EVP_PKEY* x,
-                                                  const EVP_CIPHER* enc,
-                                                  char* kstr,
+int OpenSSLLib::SSL_PEM_write_bio_PKCS8PrivateKey(BIO *bp,
+                                                  EVP_PKEY *x,
+                                                  const EVP_CIPHER *enc,
+                                                  char *kstr,
                                                   int klen,
-                                                  pem_password_cb* cb,
-                                                  void* u) noexcept
+                                                  pem_password_cb *cb,
+                                                  void *u) noexcept
 {
     return PEM_write_bio_PKCS8PrivateKey(bp, x, enc, kstr, klen, cb, u);
 }
 
-int OpenSSLLib::SSL_PEM_write_bio_PUBKEY(BIO* bp, EVP_PKEY* x) noexcept
+int OpenSSLLib::SSL_PEM_write_bio_PUBKEY(BIO *bp, EVP_PKEY *x) noexcept
 {
     return PEM_write_bio_PUBKEY(bp, x);
 }
 
-EVP_PKEY* OpenSSLLib::SSL_PEM_read_bio_PUBKEY(BIO* bio,
-                                              EVP_PKEY** pkey,
-                                              pem_password_cb* cb,
-                                              void* u) noexcept
+EVP_PKEY *OpenSSLLib::SSL_PEM_read_bio_PUBKEY(BIO *bio,
+                                              EVP_PKEY **pkey,
+                                              pem_password_cb *cb,
+                                              void *u) noexcept
 {
     return PEM_read_bio_PUBKEY(bio, pkey, cb, u);
 }
 
-EVP_PKEY* OpenSSLLib::SSL_PEM_read_bio_PrivateKey(BIO* bio,
-                                                  EVP_PKEY** pkey,
-                                                  pem_password_cb* cb,
-                                                  void* u) noexcept
+EVP_PKEY *OpenSSLLib::SSL_PEM_read_bio_PrivateKey(BIO *bio,
+                                                  EVP_PKEY **pkey,
+                                                  pem_password_cb *cb,
+                                                  void *u) noexcept
 {
     return PEM_read_bio_PrivateKey(bio, pkey, cb, u);
 }
 
-int OpenSSLLib::SSL_BIO_puts(BIO* bio, char* buf) noexcept { return BIO_puts(bio, buf); }
+int OpenSSLLib::SSL_BIO_puts(BIO *bio, char *buf) noexcept { return BIO_puts(bio, buf); }
 
-void OpenSSLLib::SSL_X509_free(X509* ptr) noexcept { X509_free(ptr); }
+void OpenSSLLib::SSL_X509_free(X509 *ptr) noexcept { X509_free(ptr); }
 
-X509* OpenSSLLib::SSL_X509_new() noexcept { return X509_new(); }
+X509 *OpenSSLLib::SSL_X509_new() noexcept { return X509_new(); }
 
-int OpenSSLLib::SSL_X509_set_pubkey(X509* ptr, EVP_PKEY* pkey) noexcept
+int OpenSSLLib::SSL_X509_set_pubkey(X509 *ptr, EVP_PKEY *pkey) noexcept
 {
     return X509_set_pubkey(ptr, pkey);
 }
 
-int OpenSSLLib::SSL_X509_set_notBefore(X509* x, const ASN1_TIME* t) noexcept
+int OpenSSLLib::SSL_X509_set_notBefore(X509 *x, const ASN1_TIME *t) noexcept
 {
     return X509_set_notBefore(x, t);
 }
 
-int OpenSSLLib::SSL_X509_set_notAfter(X509* x, const ASN1_TIME* t) noexcept
+int OpenSSLLib::SSL_X509_set_notAfter(X509 *x, const ASN1_TIME *t) noexcept
 {
     return X509_set_notAfter(x, t);
 }
 
-int OpenSSLLib::SSL_X509_sign(X509* x, EVP_PKEY* pkey, const EVP_MD* md) noexcept
+int OpenSSLLib::SSL_X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md) noexcept
 {
     return X509_sign(x, pkey, md);
 }
 
-X509* OpenSSLLib::SSL_PEM_read_bio_X509(BIO* bio, X509** x, pem_password_cb* cb, void* pwd) noexcept
+X509 *OpenSSLLib::SSL_PEM_read_bio_X509(BIO *bio, X509 **x, pem_password_cb *cb, void *pwd) noexcept
 {
     return PEM_read_bio_X509(bio, x, cb, pwd);
 }
 
-int OpenSSLLib::SSL_PEM_write_bio_X509(BIO* bp, X509* x) noexcept
+int OpenSSLLib::SSL_PEM_write_bio_X509(BIO *bp, X509 *x) noexcept
 {
     return PEM_write_bio_X509(bp, x);
 }
 
-X509* OpenSSLLib::SSL_d2i_X509_bio(BIO* bp, X509** x509) noexcept { return d2i_X509_bio(bp, x509); }
+X509 *OpenSSLLib::SSL_d2i_X509_bio(BIO *bp, X509 **x509) noexcept { return d2i_X509_bio(bp, x509); }
 
-int OpenSSLLib::SSL_i2d_X509_bio(BIO* bp, X509* x) noexcept { return i2d_X509_bio(bp, x); }
+int OpenSSLLib::SSL_i2d_X509_bio(BIO *bp, X509 *x) noexcept { return i2d_X509_bio(bp, x); }
 
 /* X509 */
-X509_NAME* OpenSSLLib::SSL_X509_get_subject_name(X509* ptr) noexcept
+X509_NAME *OpenSSLLib::SSL_X509_get_subject_name(X509 *ptr) noexcept
 {
     return X509_get_subject_name(ptr);
 }
 
-X509_NAME* OpenSSLLib::SSL_X509_get_issuer_name(X509* ptr) noexcept
+X509_NAME *OpenSSLLib::SSL_X509_get_issuer_name(X509 *ptr) noexcept
 {
     return X509_get_issuer_name(ptr);
 }
 
-EVP_PKEY* OpenSSLLib::SSL_X509_get_pubkey(X509* x) noexcept { return X509_get_pubkey(x); }
+EVP_PKEY *OpenSSLLib::SSL_X509_get_pubkey(X509 *x) noexcept { return X509_get_pubkey(x); }
 
-int OpenSSLLib::SSL_X509_set_subject_name(X509* x, X509_NAME* name) noexcept
+int OpenSSLLib::SSL_X509_set_subject_name(X509 *x, X509_NAME *name) noexcept
 {
     return X509_set_subject_name(x, name);
 }
 
-int OpenSSLLib::SSL_X509_set_issuer_name(X509* x, X509_NAME* name) noexcept
+int OpenSSLLib::SSL_X509_set_issuer_name(X509 *x, X509_NAME *name) noexcept
 {
     return X509_set_issuer_name(x, name);
 }
 
-int OpenSSLLib::SSL_X509_NAME_get_index_by_NID(X509_NAME* name, int nid, int lastpos) noexcept
+int OpenSSLLib::SSL_X509_NAME_get_index_by_NID(X509_NAME *name, int nid, int lastpos) noexcept
 {
     return X509_NAME_get_index_by_NID(name, nid, lastpos);
 }
 
-X509_NAME_ENTRY* OpenSSLLib::SSL_X509_NAME_get_entry(X509_NAME* name, int loc) noexcept
+X509_NAME_ENTRY *OpenSSLLib::SSL_X509_NAME_get_entry(X509_NAME *name, int loc) noexcept
 {
     return X509_NAME_get_entry(name, loc);
 }
 
-ASN1_STRING* OpenSSLLib::SSL_X509_NAME_ENTRY_get_data(X509_NAME_ENTRY* ne) noexcept
+ASN1_STRING *OpenSSLLib::SSL_X509_NAME_ENTRY_get_data(X509_NAME_ENTRY *ne) noexcept
 {
     return X509_NAME_ENTRY_get_data(ne);
 }
 
-int OpenSSLLib::SSL_ASN1_STRING_print_ex(BIO* out, ASN1_STRING* str, unsigned long flags) noexcept
+int OpenSSLLib::SSL_ASN1_STRING_print_ex(BIO *out, ASN1_STRING *str, unsigned long flags) noexcept
 {
     return ASN1_STRING_print_ex(out, str, flags);
 }
 
-ASN1_TIME* OpenSSLLib::SSL_X509_get_notBefore(X509* x) noexcept { return X509_get_notBefore(x); }
+ASN1_TIME *OpenSSLLib::SSL_X509_get_notBefore(X509 *x) noexcept { return X509_get_notBefore(x); }
 
-ASN1_TIME* OpenSSLLib::SSL_X509_get_notAfter(X509* x) noexcept { return X509_get_notAfter(x); }
+ASN1_TIME *OpenSSLLib::SSL_X509_get_notAfter(X509 *x) noexcept { return X509_get_notAfter(x); }
 
 /* ASN1 TIME */
-void OpenSSLLib::SSL_ASN1_TIME_free(ASN1_TIME* x) noexcept { ASN1_TIME_free(x); }
+void OpenSSLLib::SSL_ASN1_TIME_free(ASN1_TIME *x) noexcept { ASN1_TIME_free(x); }
 
-int OpenSSLLib::SSL_ASN1_TIME_diff(int* pday,
-                                   int* psec,
-                                   const ASN1_TIME* from,
-                                   const ASN1_TIME* to) noexcept
+int OpenSSLLib::SSL_ASN1_TIME_diff(int *pday,
+                                   int *psec,
+                                   const ASN1_TIME *from,
+                                   const ASN1_TIME *to) noexcept
 {
     return ASN1_TIME_diff(pday, psec, from, to);
 }
 
-ASN1_TIME* OpenSSLLib::SSL_ASN1_TIME_set(ASN1_TIME* s, time_t t) noexcept
+ASN1_TIME *OpenSSLLib::SSL_ASN1_TIME_set(ASN1_TIME *s, time_t t) noexcept
 {
     return ASN1_TIME_set(s, t);
 }
 
 /* X509 Certificate validation */
-X509_STORE* OpenSSLLib::SSL_X509_STORE_new() noexcept { return X509_STORE_new(); }
+X509_STORE *OpenSSLLib::SSL_X509_STORE_new() noexcept { return X509_STORE_new(); }
 
-void OpenSSLLib::SSL_X509_STORE_free(X509_STORE* v) noexcept { X509_STORE_free(v); }
+void OpenSSLLib::SSL_X509_STORE_free(X509_STORE *v) noexcept { X509_STORE_free(v); }
 
-int OpenSSLLib::SSL_X509_STORE_add_cert(X509_STORE* ctx, X509* x) noexcept
+int OpenSSLLib::SSL_X509_STORE_add_cert(X509_STORE *ctx, X509 *x) noexcept
 {
     return X509_STORE_add_cert(ctx, x);
 }
 
-X509_STORE_CTX* OpenSSLLib::SSL_X509_STORE_CTX_new() noexcept { return X509_STORE_CTX_new(); }
+X509_STORE_CTX *OpenSSLLib::SSL_X509_STORE_CTX_new() noexcept { return X509_STORE_CTX_new(); }
 
-void OpenSSLLib::SSL_X509_STORE_CTX_free(X509_STORE_CTX* ctx) noexcept { X509_STORE_CTX_free(ctx); }
+void OpenSSLLib::SSL_X509_STORE_CTX_free(X509_STORE_CTX *ctx) noexcept { X509_STORE_CTX_free(ctx); }
 
-int OpenSSLLib::SSL_X509_STORE_CTX_init(X509_STORE_CTX* ctx,
-                                        X509_STORE* store,
-                                        X509* x509,
+int OpenSSLLib::SSL_X509_STORE_CTX_init(X509_STORE_CTX *ctx,
+                                        X509_STORE *store,
+                                        X509 *x509,
                                         STACK_OF(X509) * chain) noexcept
 {
     return X509_STORE_CTX_init(ctx, store, x509, chain);
 }
 
-X509_VERIFY_PARAM* OpenSSLLib::SSL_X509_STORE_CTX_get0_param(X509_STORE_CTX* ctx) noexcept
+X509_VERIFY_PARAM *OpenSSLLib::SSL_X509_STORE_CTX_get0_param(X509_STORE_CTX *ctx) noexcept
 {
     return X509_STORE_CTX_get0_param(ctx);
 }
 
-int OpenSSLLib::SSL_X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM* param,
+int OpenSSLLib::SSL_X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param,
                                                 unsigned long flags) noexcept
 {
     return X509_VERIFY_PARAM_set_flags(param, flags);
 }
 
-int OpenSSLLib::SSL_X509_verify_cert(X509_STORE_CTX* ctx) noexcept { return X509_verify_cert(ctx); }
+int OpenSSLLib::SSL_X509_verify_cert(X509_STORE_CTX *ctx) noexcept { return X509_verify_cert(ctx); }
 
-const char* OpenSSLLib::SSL_X509_verify_cert_error_string(long n) noexcept
+const char *OpenSSLLib::SSL_X509_verify_cert_error_string(long n) noexcept
 {
     return X509_verify_cert_error_string(n);
 }
 
-int OpenSSLLib::SSL_X509_STORE_CTX_get_error(X509_STORE_CTX* ctx) noexcept
+int OpenSSLLib::SSL_X509_STORE_CTX_get_error(X509_STORE_CTX *ctx) noexcept
 {
     return X509_STORE_CTX_get_error(ctx);
 }
 
-int OpenSSLLib::SSL_X509_check_ca(X509* cert) noexcept { return X509_check_ca(cert); }
+int OpenSSLLib::SSL_X509_check_ca(X509 *cert) noexcept { return X509_check_ca(cert); }
 
 /* stack of X509 */
 STACK_OF(X509) * OpenSSLLib::SSL_sk_X509_new_null() noexcept { return sk_X509_new_null(); }
 
-int OpenSSLLib::SSL_sk_X509_push(STACK_OF(X509) * stack, const X509* crt) noexcept
+int OpenSSLLib::SSL_sk_X509_push(STACK_OF(X509) * stack, const X509 *crt) noexcept
 {
     /*
      * This const_cast was added to maintain API compatibility with OpenSSL, and const
      * correctness is reestablished inside the function call via a cast to const.
      */
-    return sk_X509_push(stack, const_cast<X509*>(crt));
+    return sk_X509_push(stack, const_cast<X509 *>(crt));
 }
 
 void OpenSSLLib::SSL_sk_X509_free(STACK_OF(X509) * stack) noexcept { sk_X509_free(stack); }
 
-BIO* OpenSSLLib::SSL_BIO_new_file(const char* filename, const char* mode) noexcept
+BIO *OpenSSLLib::SSL_BIO_new_file(const char *filename, const char *mode) noexcept
 {
     return BIO_new_file(filename, mode);
 }
 
-int OpenSSLLib::SSL_BIO_read(BIO* b, void* buf, int len) noexcept { return BIO_read(b, buf, len); }
+int OpenSSLLib::SSL_BIO_read(BIO *b, void *buf, int len) noexcept { return BIO_read(b, buf, len); }
 
-int OpenSSLLib::SSL_BIO_write(BIO* b, const void* buf, int len) noexcept
+int OpenSSLLib::SSL_BIO_write(BIO *b, const void *buf, int len) noexcept
 {
     return BIO_write(b, buf, len);
 }
 
-X509_EXTENSION* OpenSSLLib::SSL_X509V3_EXT_conf_nid(lhash_st_CONF_VALUE* conf,
-                                                    X509V3_CTX* ctx,
+X509_EXTENSION *OpenSSLLib::SSL_X509V3_EXT_conf_nid(lhash_st_CONF_VALUE *conf,
+                                                    X509V3_CTX *ctx,
                                                     int ext_nid,
-                                                    char* value) noexcept
+                                                    char *value) noexcept
 {
     return X509V3_EXT_conf_nid(conf, ctx, ext_nid, value);
 }
 
-int OpenSSLLib::SSL_X509_add_ext(X509* x, X509_EXTENSION* ex, int loc) noexcept
+int OpenSSLLib::SSL_X509_add_ext(X509 *x, X509_EXTENSION *ex, int loc) noexcept
 {
     return X509_add_ext(x, ex, loc);
 }
 
-void OpenSSLLib::SSL_X509_EXTENSION_free(X509_EXTENSION* a) noexcept { X509_EXTENSION_free(a); }
+void OpenSSLLib::SSL_X509_EXTENSION_free(X509_EXTENSION *a) noexcept { X509_EXTENSION_free(a); }
 
-void OpenSSLLib::SSL_X509V3_set_ctx_nodb(X509V3_CTX* ctx) noexcept { X509V3_set_ctx_nodb(ctx); }
+void OpenSSLLib::SSL_X509V3_set_ctx_nodb(X509V3_CTX *ctx) noexcept { X509V3_set_ctx_nodb(ctx); }
 
-void OpenSSLLib::SSL_X509V3_set_ctx(X509V3_CTX* ctx,
-                                    X509* issuer,
-                                    X509* subject,
-                                    X509_REQ* req,
-                                    X509_CRL* crl,
+void OpenSSLLib::SSL_X509V3_set_ctx(X509V3_CTX *ctx,
+                                    X509 *issuer,
+                                    X509 *subject,
+                                    X509_REQ *req,
+                                    X509_CRL *crl,
                                     int flags) noexcept
 {
     X509V3_set_ctx(ctx, issuer, subject, req, crl, flags);
 }
 
-int OpenSSLLib::SSL_X509_set_serialNumber(X509* x, ASN1_INTEGER* serial) noexcept
+int OpenSSLLib::SSL_X509_set_serialNumber(X509 *x, ASN1_INTEGER *serial) noexcept
 {
     return X509_set_serialNumber(x, serial);
 }
 
-ASN1_INTEGER* OpenSSLLib::SSL_X509_get_serialNumber(X509* x) noexcept
+ASN1_INTEGER *OpenSSLLib::SSL_X509_get_serialNumber(X509 *x) noexcept
 {
     return X509_get_serialNumber(x);
 }
 
-int OpenSSLLib::SSL_ASN1_INTEGER_set(ASN1_INTEGER* a, long value) noexcept
+int OpenSSLLib::SSL_ASN1_INTEGER_set(ASN1_INTEGER *a, long value) noexcept
 {
     return ASN1_INTEGER_set(a, value);
 }
 
-long OpenSSLLib::SSL_ASN1_INTEGER_get(const ASN1_INTEGER* a) noexcept
+long OpenSSLLib::SSL_ASN1_INTEGER_get(const ASN1_INTEGER *a) noexcept
 {
     return ASN1_INTEGER_get(a);
 }
 
-int OpenSSLLib::SSL_ASN1_INTEGER_cmp(const ASN1_INTEGER* x, const ASN1_INTEGER* y) noexcept
+int OpenSSLLib::SSL_ASN1_INTEGER_cmp(const ASN1_INTEGER *x, const ASN1_INTEGER *y) noexcept
 {
     return ASN1_INTEGER_cmp(x, y);
 }
 
-BIGNUM* OpenSSLLib::SSL_ASN1_INTEGER_to_BN(const ASN1_INTEGER* ai, BIGNUM* bn) noexcept
+BIGNUM *OpenSSLLib::SSL_ASN1_INTEGER_to_BN(const ASN1_INTEGER *ai, BIGNUM *bn) noexcept
 {
     return ASN1_INTEGER_to_BN(ai, bn);
 }
 
-void OpenSSLLib::SSL_BN_free(BIGNUM* a) noexcept { BN_free(a); }
+void OpenSSLLib::SSL_BN_free(BIGNUM *a) noexcept { BN_free(a); }
 
-char* OpenSSLLib::SSL_BN_bn2dec(const BIGNUM* a) noexcept { return BN_bn2dec(a); }
+char *OpenSSLLib::SSL_BN_bn2dec(const BIGNUM *a) noexcept { return BN_bn2dec(a); }
 
-void* OpenSSLLib::SSL_OPENSSL_malloc(int num) noexcept { return OPENSSL_malloc(num); }
+void *OpenSSLLib::SSL_OPENSSL_malloc(int num) noexcept { return OPENSSL_malloc(num); }
 
-void OpenSSLLib::SSL_OPENSSL_free(void* addr) noexcept { OPENSSL_free(addr); }
+void OpenSSLLib::SSL_OPENSSL_free(void *addr) noexcept { OPENSSL_free(addr); }
 
-void OpenSSLLib::SSL_ASN1_INTEGER_free(ASN1_INTEGER* a) noexcept { ASN1_INTEGER_free(a); }
+void OpenSSLLib::SSL_ASN1_INTEGER_free(ASN1_INTEGER *a) noexcept { ASN1_INTEGER_free(a); }
 
-ASN1_INTEGER* OpenSSLLib::SSL_ASN1_INTEGER_new() noexcept { return ASN1_INTEGER_new(); }
+ASN1_INTEGER *OpenSSLLib::SSL_ASN1_INTEGER_new() noexcept { return ASN1_INTEGER_new(); }
 
-int OpenSSLLib::SSL_BN_bn2bin(const BIGNUM* a, unsigned char* to) noexcept
+int OpenSSLLib::SSL_BN_bn2bin(const BIGNUM *a, unsigned char *to) noexcept
 {
     return BN_bn2bin(a, to);
 }
 
-int OpenSSLLib::SSL_BN_num_bytes(const BIGNUM* a) noexcept { return BN_num_bytes(a); }
+int OpenSSLLib::SSL_BN_num_bytes(const BIGNUM *a) noexcept { return BN_num_bytes(a); }
 
-int OpenSSLLib::SSL_ASN1_TIME_set_string(ASN1_TIME* s, const char* str) noexcept
+int OpenSSLLib::SSL_ASN1_TIME_set_string(ASN1_TIME *s, const char *str) noexcept
 {
     return ASN1_TIME_set_string(s, str);
 }
 
-ASN1_TIME* OpenSSLLib::SSL_ASN1_TIME_new() noexcept { return ASN1_TIME_new(); }
+ASN1_TIME *OpenSSLLib::SSL_ASN1_TIME_new() noexcept { return ASN1_TIME_new(); }
 
-ASN1_STRING* OpenSSLLib::SSL_ASN1_STRING_dup(const ASN1_STRING* str) noexcept
+ASN1_STRING *OpenSSLLib::SSL_ASN1_STRING_dup(const ASN1_STRING *str) noexcept
 {
     return ASN1_STRING_dup(str);
 }
 
-X509_NAME* OpenSSLLib::SSL_X509_CRL_get_issuer(const X509_CRL* crl) noexcept
+X509_NAME *OpenSSLLib::SSL_X509_CRL_get_issuer(const X509_CRL *crl) noexcept
 {
     return X509_CRL_get_issuer(crl);
 }
 
-int OpenSSLLib::SSL_X509_CRL_verify(X509_CRL* a, EVP_PKEY* r) noexcept
+int OpenSSLLib::SSL_X509_CRL_verify(X509_CRL *a, EVP_PKEY *r) noexcept
 {
     return X509_CRL_verify(a, r);
 }
 
-const ASN1_TIME* OpenSSLLib::SSL_X509_CRL_get_nextUpdate(const X509_CRL* x) noexcept
+const ASN1_TIME *OpenSSLLib::SSL_X509_CRL_get_nextUpdate(const X509_CRL *x) noexcept
 {
     return X509_CRL_get0_nextUpdate(x);
 }
 
-const ASN1_TIME* OpenSSLLib::SSL_X509_CRL_get_lastUpdate(const X509_CRL* x) noexcept
+const ASN1_TIME *OpenSSLLib::SSL_X509_CRL_get_lastUpdate(const X509_CRL *x) noexcept
 {
     return X509_CRL_get0_lastUpdate(x);
 }
 
-X509_CRL* OpenSSLLib::SSL_PEM_read_bio_X509_CRL(BIO* bp,
-                                                X509_CRL** x,
-                                                pem_password_cb* cb,
-                                                void* u) noexcept
+X509_CRL *OpenSSLLib::SSL_PEM_read_bio_X509_CRL(BIO *bp,
+                                                X509_CRL **x,
+                                                pem_password_cb *cb,
+                                                void *u) noexcept
 {
     return PEM_read_bio_X509_CRL(bp, x, cb, u);
 }
 
-int OpenSSLLib::SSL_PEM_write_bio_X509_CRL(BIO* bp, X509_CRL* x) noexcept
+int OpenSSLLib::SSL_PEM_write_bio_X509_CRL(BIO *bp, X509_CRL *x) noexcept
 {
     return PEM_write_bio_X509_CRL(bp, x);
 }
 
-X509_CRL* OpenSSLLib::SSL_d2i_X509_CRL_bio(BIO* bp, X509_CRL** crl) noexcept
+X509_CRL *OpenSSLLib::SSL_d2i_X509_CRL_bio(BIO *bp, X509_CRL **crl) noexcept
 {
     return d2i_X509_CRL_bio(bp, crl);
 }
 
-void OpenSSLLib::SSL_X509_CRL_free(X509_CRL* a) noexcept { X509_CRL_free(a); }
+void OpenSSLLib::SSL_X509_CRL_free(X509_CRL *a) noexcept { X509_CRL_free(a); }
 
-X509_CRL* OpenSSLLib::SSL_X509_CRL_new() noexcept { return X509_CRL_new(); }
+X509_CRL *OpenSSLLib::SSL_X509_CRL_new() noexcept { return X509_CRL_new(); }
 
-void OpenSSLLib::SSL_X509_STORE_CTX_set0_crls(X509_STORE_CTX* ctx,
+void OpenSSLLib::SSL_X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx,
                                               STACK_OF(X509_CRL) * crls) noexcept
 {
     X509_STORE_CTX_set0_crls(ctx, crls);
@@ -621,16 +621,16 @@ STACK_OF(X509_CRL) * OpenSSLLib::SSL_sk_X509_CRL_new_null() noexcept
     return sk_X509_CRL_new_null();
 }
 
-int OpenSSLLib::SSL_sk_X509_CRL_push(STACK_OF(X509_CRL) * stack, const X509_CRL* crl) noexcept
+int OpenSSLLib::SSL_sk_X509_CRL_push(STACK_OF(X509_CRL) * stack, const X509_CRL *crl) noexcept
 {
     /*
      * This const_cast was added to maintain API compatibility with OpenSSL, and const
      * correctness is reestablished inside the function call via a cast to const.
      */
-    return sk_X509_CRL_push(stack, const_cast<X509_CRL*>(crl));
+    return sk_X509_CRL_push(stack, const_cast<X509_CRL *>(crl));
 }
 
-ASN1_TIME* OpenSSLLib::SSL_ASN1_TIME_adj(ASN1_TIME* s,
+ASN1_TIME *OpenSSLLib::SSL_ASN1_TIME_adj(ASN1_TIME *s,
                                          time_t t,
                                          int offset_day,
                                          long offset_sec) noexcept
@@ -638,235 +638,235 @@ ASN1_TIME* OpenSSLLib::SSL_ASN1_TIME_adj(ASN1_TIME* s,
     return ASN1_TIME_adj(s, t, offset_day, offset_sec);
 }
 
-void OpenSSLLib::SSL_X509_STORE_CTX_set_time(X509_STORE_CTX* ctx,
+void OpenSSLLib::SSL_X509_STORE_CTX_set_time(X509_STORE_CTX *ctx,
                                              unsigned long flags,
                                              time_t t) noexcept
 {
     X509_STORE_CTX_set_time(ctx, flags, t);
 }
 
-void OpenSSLLib::SSL_EVP_MD_CTX_init(EVP_MD_CTX* ctx) noexcept { EVP_MD_CTX_init(ctx); }
+void OpenSSLLib::SSL_EVP_MD_CTX_init(EVP_MD_CTX *ctx) noexcept { EVP_MD_CTX_init(ctx); }
 
-int OpenSSLLib::SSL_EVP_DigestInit_ex(EVP_MD_CTX* ctx, const EVP_MD* type, ENGINE* impl) noexcept
+int OpenSSLLib::SSL_EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl) noexcept
 {
     return EVP_DigestInit_ex(ctx, type, impl);
 }
 
-int OpenSSLLib::SSL_EVP_DigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt) noexcept
+int OpenSSLLib::SSL_EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt) noexcept
 {
     return EVP_DigestUpdate(ctx, d, cnt);
 }
 
-int OpenSSLLib::SSL_EVP_DigestFinal_ex(EVP_MD_CTX* ctx, unsigned char* md, unsigned int* s) noexcept
+int OpenSSLLib::SSL_EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) noexcept
 {
     return EVP_DigestFinal_ex(ctx, md, s);
 }
 
-int OpenSSLLib::SSL_EVP_MD_CTX_reset(EVP_MD_CTX* ctx) noexcept { return EVP_MD_CTX_reset(ctx); }
+int OpenSSLLib::SSL_EVP_MD_CTX_reset(EVP_MD_CTX *ctx) noexcept { return EVP_MD_CTX_reset(ctx); }
 
-int OpenSSLLib::SSL_EVP_PKEY_encrypt_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return EVP_PKEY_encrypt_init(ctx);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_encrypt(EVP_PKEY_CTX* ctx,
-                                     unsigned char* out,
-                                     size_t* outlen,
-                                     const unsigned char* in,
+int OpenSSLLib::SSL_EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
+                                     unsigned char *out,
+                                     size_t *outlen,
+                                     const unsigned char *in,
                                      size_t inlen) noexcept
 {
     return EVP_PKEY_encrypt(ctx, out, outlen, in, inlen);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_decrypt_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return EVP_PKEY_decrypt_init(ctx);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_decrypt(EVP_PKEY_CTX* ctx,
-                                     unsigned char* out,
-                                     size_t* outlen,
-                                     const unsigned char* in,
+int OpenSSLLib::SSL_EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
+                                     unsigned char *out,
+                                     size_t *outlen,
+                                     const unsigned char *in,
                                      size_t inlen) noexcept
 {
     return EVP_PKEY_decrypt(ctx, out, outlen, in, inlen);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept
 {
     return EVP_PKEY_CTX_set_rsa_oaep_md(ctx, md);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX* ctx,
-                                                    unsigned char* l,
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx,
+                                                    unsigned char *l,
                                                     int llen) noexcept
 {
     return EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, l, llen);
 }
 
-int OpenSSLLib::SSL_RSA_size(const RSA* r) noexcept { return RSA_size(r); }
+int OpenSSLLib::SSL_RSA_size(const RSA *r) noexcept { return RSA_size(r); }
 
-int OpenSSLLib::SSL_EVP_MD_size(const EVP_MD* md) noexcept { return EVP_MD_size(md); }
+int OpenSSLLib::SSL_EVP_MD_size(const EVP_MD *md) noexcept { return EVP_MD_size(md); }
 
 /* Signatures */
-int OpenSSLLib::SSL_EVP_PKEY_sign(EVP_PKEY_CTX* ctx,
-                                  unsigned char* sig,
-                                  size_t* siglen,
-                                  const unsigned char* tbs,
+int OpenSSLLib::SSL_EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
+                                  unsigned char *sig,
+                                  size_t *siglen,
+                                  const unsigned char *tbs,
                                   size_t tbslen) noexcept
 {
     return EVP_PKEY_sign(ctx, sig, siglen, tbs, tbslen);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_sign_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return EVP_PKEY_sign_init(ctx);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_verify_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_verify_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return EVP_PKEY_verify_init(ctx);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_verify(EVP_PKEY_CTX* ctx,
-                                    const unsigned char* sig,
+int OpenSSLLib::SSL_EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
+                                    const unsigned char *sig,
                                     size_t siglen,
-                                    const unsigned char* tbs,
+                                    const unsigned char *tbs,
                                     size_t tbslen) noexcept
 {
     return EVP_PKEY_verify(ctx, sig, siglen, tbs, tbslen);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX* ctx, int pad) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad) noexcept
 {
     return EVP_PKEY_CTX_set_rsa_padding(ctx, pad);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept
 {
     return EVP_PKEY_CTX_set_signature_md(ctx, md);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX* ctx, int len) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int len) noexcept
 {
     return EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx, len);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept
 {
     return EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, md);
 }
 
-EC_KEY* OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY* pkey) noexcept
+EC_KEY *OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) noexcept
 {
     return EVP_PKEY_get0_EC_KEY(pkey);
 }
 
-int OpenSSLLib::SSL_EVP_DigestVerifyInit(EVP_MD_CTX* ctx,
-                                         EVP_PKEY_CTX** pctx,
-                                         const EVP_MD* type,
-                                         ENGINE* e,
-                                         EVP_PKEY* pkey) noexcept
+int OpenSSLLib::SSL_EVP_DigestVerifyInit(EVP_MD_CTX *ctx,
+                                         EVP_PKEY_CTX **pctx,
+                                         const EVP_MD *type,
+                                         ENGINE *e,
+                                         EVP_PKEY *pkey) noexcept
 {
     return EVP_DigestVerifyInit(ctx, pctx, type, e, pkey);
 }
 
-int OpenSSLLib::SSL_EVP_DigestVerify(EVP_MD_CTX* ctx,
-                                     const unsigned char* sigret,
+int OpenSSLLib::SSL_EVP_DigestVerify(EVP_MD_CTX *ctx,
+                                     const unsigned char *sigret,
                                      size_t siglen,
-                                     const unsigned char* tbs,
+                                     const unsigned char *tbs,
                                      size_t tbslen) noexcept
 {
     return EVP_DigestVerify(ctx, sigret, siglen, tbs, tbslen);
 }
 
-X509_REQ* OpenSSLLib::SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) noexcept
+X509_REQ *OpenSSLLib::SSL_d2i_X509_REQ_bio(BIO *bp, X509_REQ **req) noexcept
 {
     return d2i_X509_REQ_bio(bp, req);
 }
 
-int OpenSSLLib::SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) noexcept
+int OpenSSLLib::SSL_i2d_X509_REQ_bio(BIO *bp, X509_REQ *req) noexcept
 {
     return i2d_X509_REQ_bio(bp, req);
 }
 
-int OpenSSLLib::SSL_EVP_CIPHER_key_length(const EVP_CIPHER* cipher) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_key_length(const EVP_CIPHER *cipher) noexcept
 {
     return EVP_CIPHER_key_length(cipher);
 }
-const char* OpenSSLLib::SSL_EVP_CIPHER_name(const EVP_CIPHER* cipher) noexcept
+const char *OpenSSLLib::SSL_EVP_CIPHER_name(const EVP_CIPHER *cipher) noexcept
 {
     return EVP_CIPHER_name(cipher);
 }
 
-int OpenSSLLib::SSL_EVP_CipherUpdate(EVP_CIPHER_CTX* ctx,
-                                     unsigned char* out,
-                                     int* outl,
-                                     const unsigned char* in,
+int OpenSSLLib::SSL_EVP_CipherUpdate(EVP_CIPHER_CTX *ctx,
+                                     unsigned char *out,
+                                     int *outl,
+                                     const unsigned char *in,
                                      int inl) noexcept
 {
     return EVP_CipherUpdate(ctx, out, outl, in, inl);
 }
 
-int OpenSSLLib::SSL_EVP_CipherFinal_ex(EVP_CIPHER_CTX* ctx, unsigned char* outm, int* outl) noexcept
+int OpenSSLLib::SSL_EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl) noexcept
 {
     return EVP_CipherFinal_ex(ctx, outm, outl);
 }
 
-int OpenSSLLib::SSL_EVP_CipherInit_ex(EVP_CIPHER_CTX* ctx,
-                                      const EVP_CIPHER* cipher,
-                                      ENGINE* impl,
-                                      const unsigned char* key,
-                                      const unsigned char* iv,
+int OpenSSLLib::SSL_EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx,
+                                      const EVP_CIPHER *cipher,
+                                      ENGINE *impl,
+                                      const unsigned char *key,
+                                      const unsigned char *iv,
                                       int enc) noexcept
 {
     return EVP_CipherInit_ex(ctx, cipher, impl, key, iv, enc);
 }
-EVP_CIPHER_CTX* OpenSSLLib::SSL_EVP_CIPHER_CTX_new() noexcept { return EVP_CIPHER_CTX_new(); }
-void OpenSSLLib::SSL_EVP_CIPHER_CTX_free(EVP_CIPHER_CTX* c) noexcept { EVP_CIPHER_CTX_free(c); }
-int OpenSSLLib::SSL_EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX* ctx, int type, int arg, void* ptr) noexcept
+EVP_CIPHER_CTX *OpenSSLLib::SSL_EVP_CIPHER_CTX_new() noexcept { return EVP_CIPHER_CTX_new(); }
+void OpenSSLLib::SSL_EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *c) noexcept { EVP_CIPHER_CTX_free(c); }
+int OpenSSLLib::SSL_EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr) noexcept
 {
     return EVP_CIPHER_CTX_ctrl(ctx, type, arg, ptr);
 }
-int OpenSSLLib::SSL_EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX *ctx) noexcept
 {
     return EVP_CIPHER_CTX_key_length(ctx);
 }
-int OpenSSLLib::SSL_EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx) noexcept
 {
     return EVP_CIPHER_CTX_iv_length(ctx);
 }
-int OpenSSLLib::SSL_RAND_bytes(unsigned char* buf, int num) noexcept
+int OpenSSLLib::SSL_RAND_bytes(unsigned char *buf, int num) noexcept
 {
     return RAND_bytes(buf, num);
 }
-int OpenSSLLib::SSL_EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX* c) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *c) noexcept
 {
     return EVP_CIPHER_CTX_reset(c);
 }
-int OpenSSLLib::SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX* c, int pad) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *c, int pad) noexcept
 {
     return EVP_CIPHER_CTX_set_padding(c, pad);
 }
-int OpenSSLLib::SSL_PKCS5_PBKDF2_HMAC(const char* pass,
+int OpenSSLLib::SSL_PKCS5_PBKDF2_HMAC(const char *pass,
                                       int passlen,
-                                      const unsigned char* salt,
+                                      const unsigned char *salt,
                                       int saltlen,
                                       int iter,
-                                      const EVP_MD* digest,
+                                      const EVP_MD *digest,
                                       int keylen,
-                                      unsigned char* out) noexcept
+                                      unsigned char *out) noexcept
 {
     return PKCS5_PBKDF2_HMAC(pass, passlen, salt, saltlen, iter, digest, keylen, out);
 }
 
-int OpenSSLLib::SSL_ECDH_KDF_X9_63(unsigned char* out,
+int OpenSSLLib::SSL_ECDH_KDF_X9_63(unsigned char *out,
                                    size_t outlen,
-                                   const unsigned char* Z,
+                                   const unsigned char *Z,
                                    size_t Zlen,
-                                   const unsigned char* sinfo,
+                                   const unsigned char *sinfo,
                                    size_t sinfolen,
-                                   const EVP_MD* md) noexcept
+                                   const EVP_MD *md) noexcept
 {
     /*
      * The old name for ecdh_KDF_X9_63 (include/openssl/ec.h:1110)
@@ -884,143 +884,143 @@ int OpenSSLLib::SSL_ECDH_KDF_X9_63(unsigned char* out,
 }
 
 int OpenSSLLib::SSL_HMAC_Init_ex(
-        HMAC_CTX* ctx, const void* key, int key_len, const EVP_MD* md, ENGINE* impl) noexcept
+        HMAC_CTX *ctx, const void *key, int key_len, const EVP_MD *md, ENGINE *impl) noexcept
 {
     return HMAC_Init_ex(ctx, key, key_len, md, impl);
 }
-int OpenSSLLib::SSL_HMAC_Update(HMAC_CTX* ctx, const unsigned char* data, int len) noexcept
+int OpenSSLLib::SSL_HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, int len) noexcept
 {
     return HMAC_Update(ctx, data, len);
 }
-int OpenSSLLib::SSL_HMAC_Final(HMAC_CTX* ctx, unsigned char* md, unsigned int* len) noexcept
+int OpenSSLLib::SSL_HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len) noexcept
 {
     return HMAC_Final(ctx, md, len);
 }
-HMAC_CTX* OpenSSLLib::SSL_HMAC_CTX_new() noexcept { return HMAC_CTX_new(); }
+HMAC_CTX *OpenSSLLib::SSL_HMAC_CTX_new() noexcept { return HMAC_CTX_new(); }
 
-void OpenSSLLib::SSL_HMAC_CTX_free(HMAC_CTX* ctx) noexcept { HMAC_CTX_free(ctx); }
+void OpenSSLLib::SSL_HMAC_CTX_free(HMAC_CTX *ctx) noexcept { HMAC_CTX_free(ctx); }
 
-int OpenSSLLib::SSL_EC_KEY_oct2key(EC_KEY* eckey, const unsigned char* buf, size_t len) noexcept
+int OpenSSLLib::SSL_EC_KEY_oct2key(EC_KEY *eckey, const unsigned char *buf, size_t len) noexcept
 {
     return EC_KEY_oct2key(eckey, buf, len, NULL);
 }
-EC_KEY* OpenSSLLib::SSL_EC_KEY_new() noexcept { return EC_KEY_new(); }
-void OpenSSLLib::SSL_EC_KEY_free(EC_KEY* key) noexcept { EC_KEY_free(key); }
-EC_KEY* OpenSSLLib::SSL_EC_KEY_new_by_curve_name(int nid) noexcept
+EC_KEY *OpenSSLLib::SSL_EC_KEY_new() noexcept { return EC_KEY_new(); }
+void OpenSSLLib::SSL_EC_KEY_free(EC_KEY *key) noexcept { EC_KEY_free(key); }
+EC_KEY *OpenSSLLib::SSL_EC_KEY_new_by_curve_name(int nid) noexcept
 {
     return EC_KEY_new_by_curve_name(nid);
 }
-int OpenSSLLib::SSL_EVP_PKEY_set1_EC_KEY(EVP_PKEY* pkey, EC_KEY* key) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) noexcept
 {
     return EVP_PKEY_set1_EC_KEY(pkey, key);
 }
-size_t OpenSSLLib::SSL_EC_KEY_key2buf(const EC_KEY* eckey,
+size_t OpenSSLLib::SSL_EC_KEY_key2buf(const EC_KEY *eckey,
                                       point_conversion_form_t form,
-                                      unsigned char** pbuf,
-                                      BN_CTX* ctx) noexcept
+                                      unsigned char **pbuf,
+                                      BN_CTX *ctx) noexcept
 {
     return EC_KEY_key2buf(eckey, form, pbuf, ctx);
 }
-int OpenSSLLib::SSL_EVP_PKEY_derive_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return EVP_PKEY_derive_init(ctx);
 }
-int OpenSSLLib::SSL_EVP_PKEY_derive_set_peer(EVP_PKEY_CTX* ctx, EVP_PKEY* peer) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer) noexcept
 {
     return EVP_PKEY_derive_set_peer(ctx, peer);
 }
-int OpenSSLLib::SSL_EVP_PKEY_derive(EVP_PKEY_CTX* ctx, unsigned char* key, size_t* keylen) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen) noexcept
 {
     return EVP_PKEY_derive(ctx, key, keylen);
 }
-BIGNUM* OpenSSLLib::SSL_BN_bin2bn(const unsigned char* s, int len, BIGNUM* ret) noexcept
+BIGNUM *OpenSSLLib::SSL_BN_bin2bn(const unsigned char *s, int len, BIGNUM *ret) noexcept
 {
     return BN_bin2bn(s, len, ret);
 }
 
-ECDSA_SIG* OpenSSLLib::SSL_ECDSA_SIG_new() noexcept { return ECDSA_SIG_new(); }
-void OpenSSLLib::SSL_ECDSA_SIG_free(ECDSA_SIG* sig) noexcept { ECDSA_SIG_free(sig); }
-int OpenSSLLib::SSL_ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s) noexcept
+ECDSA_SIG *OpenSSLLib::SSL_ECDSA_SIG_new() noexcept { return ECDSA_SIG_new(); }
+void OpenSSLLib::SSL_ECDSA_SIG_free(ECDSA_SIG *sig) noexcept { ECDSA_SIG_free(sig); }
+int OpenSSLLib::SSL_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) noexcept
 {
     return ECDSA_SIG_set0(sig, r, s);
 }
-int OpenSSLLib::SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char** pp) noexcept
+int OpenSSLLib::SSL_i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp) noexcept
 {
     return i2d_ECDSA_SIG(sig, pp);
 }
-ECDSA_SIG* OpenSSLLib::SSL_d2i_ECDSA_SIG(ECDSA_SIG** sig,
-                                         const unsigned char** pp,
+ECDSA_SIG *OpenSSLLib::SSL_d2i_ECDSA_SIG(ECDSA_SIG **sig,
+                                         const unsigned char **pp,
                                          long len) noexcept
 {
     return d2i_ECDSA_SIG(sig, pp, len);
 }
-const BIGNUM* OpenSSLLib::SSL_ECDSA_SIG_get0_r(const ECDSA_SIG* sig) noexcept
+const BIGNUM *OpenSSLLib::SSL_ECDSA_SIG_get0_r(const ECDSA_SIG *sig) noexcept
 {
     return ECDSA_SIG_get0_r(sig);
 }
-const BIGNUM* OpenSSLLib::SSL_ECDSA_SIG_get0_s(const ECDSA_SIG* sig) noexcept
+const BIGNUM *OpenSSLLib::SSL_ECDSA_SIG_get0_s(const ECDSA_SIG *sig) noexcept
 {
     return ECDSA_SIG_get0_s(sig);
 }
-int OpenSSLLib::SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) noexcept
+int OpenSSLLib::SSL_BN_bn2binpad(const BIGNUM *a, unsigned char *to, int tolen) noexcept
 {
     return BN_bn2binpad(a, to, tolen);
 }
 
 /* CMAC */
-CMAC_CTX* OpenSSLLib::SSL_CMAC_CTX_new() noexcept { return CMAC_CTX_new(); }
-void OpenSSLLib::SSL_CMAC_CTX_cleanup(CMAC_CTX* ctx) noexcept { CMAC_CTX_cleanup(ctx); }
-void OpenSSLLib::SSL_CMAC_CTX_free(CMAC_CTX* ctx) noexcept { CMAC_CTX_free(ctx); }
-EVP_CIPHER_CTX* OpenSSLLib::SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX* ctx) noexcept
+CMAC_CTX *OpenSSLLib::SSL_CMAC_CTX_new() noexcept { return CMAC_CTX_new(); }
+void OpenSSLLib::SSL_CMAC_CTX_cleanup(CMAC_CTX *ctx) noexcept { CMAC_CTX_cleanup(ctx); }
+void OpenSSLLib::SSL_CMAC_CTX_free(CMAC_CTX *ctx) noexcept { CMAC_CTX_free(ctx); }
+EVP_CIPHER_CTX *OpenSSLLib::SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX *ctx) noexcept
 {
     return CMAC_CTX_get0_cipher_ctx(ctx);
 }
-int OpenSSLLib::SSL_CMAC_CTX_copy(CMAC_CTX* out, const CMAC_CTX* in) noexcept
+int OpenSSLLib::SSL_CMAC_CTX_copy(CMAC_CTX *out, const CMAC_CTX *in) noexcept
 {
     return CMAC_CTX_copy(out, in);
 }
-int OpenSSLLib::SSL_CMAC_Init(CMAC_CTX* ctx,
-                              const void* key,
+int OpenSSLLib::SSL_CMAC_Init(CMAC_CTX *ctx,
+                              const void *key,
                               size_t keylen,
-                              const EVP_CIPHER* cipher,
-                              ENGINE* impl) noexcept
+                              const EVP_CIPHER *cipher,
+                              ENGINE *impl) noexcept
 {
     return CMAC_Init(ctx, key, keylen, cipher, impl);
 }
-int OpenSSLLib::SSL_CMAC_Update(CMAC_CTX* ctx, const void* data, size_t dlen) noexcept
+int OpenSSLLib::SSL_CMAC_Update(CMAC_CTX *ctx, const void *data, size_t dlen) noexcept
 {
     return CMAC_Update(ctx, data, dlen);
 }
-int OpenSSLLib::SSL_CMAC_Final(CMAC_CTX* ctx, unsigned char* out, size_t* poutlen) noexcept
+int OpenSSLLib::SSL_CMAC_Final(CMAC_CTX *ctx, unsigned char *out, size_t *poutlen) noexcept
 {
     return CMAC_Final(ctx, out, poutlen);
 }
-int OpenSSLLib::SSL_CMAC_resume(CMAC_CTX* ctx) noexcept { return CMAC_resume(ctx); }
-EVP_PKEY* OpenSSLLib::SSL_ENGINE_load_private_key(ENGINE* e,
-                                                  const char* key_id,
-                                                  UI_METHOD* ui_method,
-                                                  void* callback_data) noexcept
+int OpenSSLLib::SSL_CMAC_resume(CMAC_CTX *ctx) noexcept { return CMAC_resume(ctx); }
+EVP_PKEY *OpenSSLLib::SSL_ENGINE_load_private_key(ENGINE *e,
+                                                  const char *key_id,
+                                                  UI_METHOD *ui_method,
+                                                  void *callback_data) noexcept
 {
     return ENGINE_load_private_key(e, key_id, ui_method, callback_data);
 }
-EVP_PKEY* OpenSSLLib::SSL_ENGINE_load_public_key(ENGINE* e,
-                                                 const char* key_id,
-                                                 UI_METHOD* ui_method,
-                                                 void* callback_data) noexcept
+EVP_PKEY *OpenSSLLib::SSL_ENGINE_load_public_key(ENGINE *e,
+                                                 const char *key_id,
+                                                 UI_METHOD *ui_method,
+                                                 void *callback_data) noexcept
 {
     return ENGINE_load_public_key(e, key_id, ui_method, callback_data);
 }
-int OpenSSLLib::SSL_ENGINE_ctrl_cmd_string(ENGINE* e,
-                                           const char* cmd_name,
-                                           const char* cmd_arg,
+int OpenSSLLib::SSL_ENGINE_ctrl_cmd_string(ENGINE *e,
+                                           const char *cmd_name,
+                                           const char *cmd_arg,
                                            int cmd_optional) noexcept
 {
     return ENGINE_ctrl_cmd_string(e, cmd_name, cmd_arg, cmd_optional);
 }
-int OpenSSLLib::SSL_ENGINE_init(ENGINE* e) noexcept { return ENGINE_init(e); }
-ENGINE* OpenSSLLib::SSL_ENGINE_by_id(const char* id) noexcept { return ENGINE_by_id(id); }
-int OpenSSLLib::SSL_ENGINE_finish(ENGINE* e) noexcept { return ENGINE_finish(e); }
-int OpenSSLLib::SSL_ENGINE_free(ENGINE* e) noexcept { return ENGINE_free(e); }
+int OpenSSLLib::SSL_ENGINE_init(ENGINE *e) noexcept { return ENGINE_init(e); }
+ENGINE *OpenSSLLib::SSL_ENGINE_by_id(const char *id) noexcept { return ENGINE_by_id(id); }
+int OpenSSLLib::SSL_ENGINE_finish(ENGINE *e) noexcept { return ENGINE_finish(e); }
+int OpenSSLLib::SSL_ENGINE_free(ENGINE *e) noexcept { return ENGINE_free(e); }
 }  // namespace lib
 }  // namespace openssl
 }  // namespace mococrw

--- a/src/padding_mode.cpp
+++ b/src/padding_mode.cpp
@@ -43,13 +43,13 @@ RSASignaturePadding::~RSASignaturePadding() = default;
  * NoPadding
  */
 
-bool NoPadding::checkMessageSize(const AsymmetricPublicKey& key, size_t messageSize) const
+bool NoPadding::checkMessageSize(const AsymmetricPublicKey &key, size_t messageSize) const
 {
     size_t keySizeInBit = key.getKeySize();
     return messageSize * 8 == keySizeInBit;
 }
 
-void NoPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const
+void NoPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx) const
 {
     openssl::_EVP_PKEY_CTX_set_rsa_padding(ctx.get(),
                                            static_cast<int>(openssl::RSAPaddingMode::NONE));
@@ -59,18 +59,18 @@ void NoPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const
  * PKCSPadding
  */
 
-bool PKCSPadding::checkMessageSize(const AsymmetricPublicKey& key, size_t messageSize) const
+bool PKCSPadding::checkMessageSize(const AsymmetricPublicKey &key, size_t messageSize) const
 {
     int remainingSize = key.getKeySize() - PKCS_MAX_SIZE_OVERHEAD * 8;
     return remainingSize > 0 && messageSize * 8 <= static_cast<size_t>(remainingSize);
 }
 
-void PKCSPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const
+void PKCSPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx) const
 {
     _EVP_PKEY_CTX_set_rsa_padding(ctx.get(), static_cast<int>(openssl::RSAPaddingMode::PKCS1));
 }
 
-void PKCSPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx,
+void PKCSPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx,
                                         openssl::DigestTypes hashFunction) const
 {
     _EVP_PKEY_CTX_set_rsa_padding(ctx.get(), static_cast<int>(openssl::RSAPaddingMode::PKCS1));
@@ -83,7 +83,7 @@ void PKCSPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx,
 
 MGF1::MGF1(openssl::DigestTypes hashFunction) : _hashFunction(hashFunction) {}
 
-void MGF1::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const
+void MGF1::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx) const
 {
     _EVP_PKEY_CTX_set_rsa_mgf1_md(ctx.get(), _getMDPtrFromDigestType(_hashFunction));
 }
@@ -104,7 +104,7 @@ public:
     {
     }
 
-    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx,
+    void prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx,
                                openssl::DigestTypes hashFunction) const
     {
         _EVP_PKEY_CTX_set_rsa_padding(ctx.get(), static_cast<int>(openssl::RSAPaddingMode::PSS));
@@ -136,12 +136,12 @@ PSSPadding::PSSPadding(std::shared_ptr<MaskGenerationFunction> maskGenerationFun
 {
 }
 
-PSSPadding::PSSPadding(const PSSPadding& other)
+PSSPadding::PSSPadding(const PSSPadding &other)
         : _impl(std::make_unique<PSSPadding::Impl>(*(other._impl)))
 {
 }
 
-PSSPadding& PSSPadding::operator=(const PSSPadding& other)
+PSSPadding &PSSPadding::operator=(const PSSPadding &other)
 {
     _impl = std::make_unique<PSSPadding::Impl>(*(other._impl));
     return *this;
@@ -149,7 +149,7 @@ PSSPadding& PSSPadding::operator=(const PSSPadding& other)
 
 PSSPadding::~PSSPadding() = default;
 
-void PSSPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx,
+void PSSPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx,
                                        openssl::DigestTypes hashFunction) const
 {
     _impl->prepareOpenSSLContext(ctx, hashFunction);
@@ -164,7 +164,7 @@ class OAEPPadding::Impl
 public:
     Impl(openssl::DigestTypes hashFunction,
          std::shared_ptr<MaskGenerationFunction> maskGenerationFunction,
-         const std::string& label)
+         const std::string &label)
             : hashFunction(hashFunction), label(label)
     {
         if (maskGenerationFunction != nullptr) {
@@ -181,17 +181,17 @@ public:
 
 OAEPPadding::OAEPPadding(openssl::DigestTypes hashFunction,
                          std::shared_ptr<MaskGenerationFunction> maskGenerationFunction,
-                         const std::string& label)
+                         const std::string &label)
         : _impl(std::make_unique<OAEPPadding::Impl>(hashFunction, maskGenerationFunction, label))
 {
 }
 
-OAEPPadding::OAEPPadding(const OAEPPadding& other)
+OAEPPadding::OAEPPadding(const OAEPPadding &other)
         : _impl(std::make_unique<OAEPPadding::Impl>(*(other._impl)))
 {
 }
 
-OAEPPadding& OAEPPadding::operator=(const OAEPPadding& other)
+OAEPPadding &OAEPPadding::operator=(const OAEPPadding &other)
 {
     _impl = std::make_unique<OAEPPadding::Impl>(*(other._impl));
     return *this;
@@ -199,7 +199,7 @@ OAEPPadding& OAEPPadding::operator=(const OAEPPadding& other)
 
 OAEPPadding::~OAEPPadding() = default;
 
-bool OAEPPadding::checkMessageSize(const AsymmetricPublicKey& key, size_t messageSize) const
+bool OAEPPadding::checkMessageSize(const AsymmetricPublicKey &key, size_t messageSize) const
 {
     int remainingSize =
             key.getKeySize() -
@@ -207,7 +207,7 @@ bool OAEPPadding::checkMessageSize(const AsymmetricPublicKey& key, size_t messag
     return remainingSize > 0 && messageSize * 8 <= static_cast<size_t>(remainingSize);
 }
 
-void OAEPPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) const
+void OAEPPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr &ctx) const
 {
     SSL_RSA_OAEP_LABEL_Ptr label_copy{nullptr};
 
@@ -221,18 +221,18 @@ void OAEPPadding::prepareOpenSSLContext(openssl::SSL_EVP_PKEY_CTX_Ptr& ctx) cons
         if (!_impl->label.empty()) {
             /* Make a copy of the label, since the context takes ownership of it when calling
              * '_EVP_PKEY_CTX_set_rsa_oaep_label()' function */
-            label_copy.reset(static_cast<uint8_t*>(_OPENSSL_malloc(_impl->label.size())));
+            label_copy.reset(static_cast<uint8_t *>(_OPENSSL_malloc(_impl->label.size())));
             memcpy(label_copy.get(), _impl->label.data(), _impl->label.size());
 
             _EVP_PKEY_CTX_set_rsa_oaep_label(ctx.get(),
-                                             static_cast<unsigned char*>(label_copy.get()),
+                                             static_cast<unsigned char *>(label_copy.get()),
                                              static_cast<int>(_impl->label.size()));
 
             /* Release ownership from the unique_ptr since the function above takes ownership of
              * the label pointer unless it throws an exception*/
             std::ignore = label_copy.release();
         }
-    } catch (const OpenSSLException& e) {
+    } catch (const OpenSSLException &e) {
         throw MoCOCrWException(e.what());
     }
 }

--- a/src/symmetric_memory.cpp
+++ b/src/symmetric_memory.cpp
@@ -106,7 +106,7 @@ std::vector<uint8_t> QueueOfVectorsMemoryStrategy::_readCompleteBlock()
 }
 
 void QueueOfVectorsMemoryStrategy::_readPartialBlock(size_t requestedSize,
-                                                     std::vector<uint8_t>& output)
+                                                     std::vector<uint8_t> &output)
 {
     assert((_queue.front().size() > requestedSize) && "Callers must not overread the block.");
 

--- a/tests/unit/ExecUtil.h
+++ b/tests/unit/ExecUtil.h
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <array>
 
-std::string exec(const char* cmd)
+std::string exec(const char *cmd)
 {
     std::array<char, 128> buffer;
     std::string result;

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -33,7 +33,7 @@ std::mutex OpenSSLLibMockManager::_mutex{};
 /*
  * If there is no mock yet, we create a new one.
  */
-testing::NiceMock<OpenSSLLibMock>& OpenSSLLibMockManager::getMockInterface()
+testing::NiceMock<OpenSSLLibMock> &OpenSSLLibMockManager::getMockInterface()
 {
     if (!_mock) {
         resetMock();
@@ -86,110 +86,110 @@ void OpenSSLLib::SSL_OpenSSL_add_all_algorithms() noexcept
     OpenSSLLibMockManager::getMockInterface().SSL_OpenSSL_add_all_algorithms();
 }
 
-X509_REQ* OpenSSLLib::SSL_X509_REQ_new() noexcept
+X509_REQ *OpenSSLLib::SSL_X509_REQ_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_new();
 }
 
-X509_NAME* OpenSSLLib::SSL_X509_REQ_get_subject_name(const X509_REQ* req) noexcept
+X509_NAME *OpenSSLLib::SSL_X509_REQ_get_subject_name(const X509_REQ *req) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_get_subject_name(req);
 }
 
-EVP_PKEY* OpenSSLLib::SSL_X509_REQ_get_pubkey(X509_REQ* req) noexcept
+EVP_PKEY *OpenSSLLib::SSL_X509_REQ_get_pubkey(X509_REQ *req) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_get_pubkey(req);
 }
 
-int OpenSSLLib::SSL_X509_REQ_verify(X509_REQ* a, EVP_PKEY* r) noexcept
+int OpenSSLLib::SSL_X509_REQ_verify(X509_REQ *a, EVP_PKEY *r) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_verify(a, r);
 }
 
-void OpenSSLLib::SSL_X509_REQ_free(X509_REQ* ptr) noexcept
+void OpenSSLLib::SSL_X509_REQ_free(X509_REQ *ptr) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_free(ptr);
 }
 
-EVP_PKEY* OpenSSLLib::SSL_EVP_PKEY_new() noexcept
+EVP_PKEY *OpenSSLLib::SSL_EVP_PKEY_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_new();
 }
 
-void OpenSSLLib::SSL_EVP_PKEY_free(EVP_PKEY* ptr) noexcept
+void OpenSSLLib::SSL_EVP_PKEY_free(EVP_PKEY *ptr) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_free(ptr);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_keygen(EVP_PKEY_CTX* ctx, EVP_PKEY** ppkey) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_keygen(ctx, ppkey);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_keygen_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_keygen_init(ctx);
 }
 
-EVP_PKEY_CTX* OpenSSLLib::SSL_EVP_PKEY_CTX_new(EVP_PKEY* pkey, ENGINE* engine) noexcept
+EVP_PKEY_CTX *OpenSSLLib::SSL_EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *engine) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_new(pkey, engine);
 }
 
-EVP_PKEY_CTX* OpenSSLLib::SSL_EVP_PKEY_CTX_new_id(int id, ENGINE* engine) noexcept
+EVP_PKEY_CTX *OpenSSLLib::SSL_EVP_PKEY_CTX_new_id(int id, ENGINE *engine) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_new_id(id, engine);
 }
 
-void OpenSSLLib::SSL_EVP_PKEY_CTX_free(EVP_PKEY_CTX* ptr) noexcept
+void OpenSSLLib::SSL_EVP_PKEY_CTX_free(EVP_PKEY_CTX *ptr) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_free(ptr);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX *ctx, int mbits) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(ctx,
                                                                                           mbits);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_cmp(const EVP_PKEY* a, const EVP_PKEY* b) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_cmp(a, b);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_paramgen_init(ctx);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX* ctx, EVP_PKEY** ppkey) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_paramgen(ctx, ppkey);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX* ctx, int nid) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
             ctx, nid);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX* ctx, int param_enc) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_ec_param_enc(ctx,
                                                                                        param_enc);
 }
 
-const EC_GROUP* OpenSSLLib::SSL_EC_KEY_get0_group(const EC_KEY* key) noexcept
+const EC_GROUP *OpenSSLLib::SSL_EC_KEY_get0_group(const EC_KEY *key) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EC_KEY_get0_group(key);
 }
 
-int OpenSSLLib::SSL_EC_GROUP_get_degree(const EC_GROUP* group) noexcept
+int OpenSSLLib::SSL_EC_GROUP_get_degree(const EC_GROUP *group) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EC_GROUP_get_degree(group);
 }
 
-int OpenSSLLib::SSL_EC_GROUP_get_curve_name(const EC_GROUP* group) noexcept
+int OpenSSLLib::SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EC_GROUP_get_curve_name(group);
 }
@@ -199,17 +199,17 @@ int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_type(type);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_id(const EVP_PKEY* pkey) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_id(const EVP_PKEY *pkey) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_id(pkey);
 }
 
-int OpenSSLLib::SSL_EVP_PKEY_size(EVP_PKEY* pkey) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_size(EVP_PKEY *pkey) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_size(pkey);
 }
 
-char* OpenSSLLib::SSL_ERR_error_string(unsigned long error, char* buf) noexcept
+char *OpenSSLLib::SSL_ERR_error_string(unsigned long error, char *buf) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ERR_error_string(error, buf);
 }
@@ -219,20 +219,20 @@ unsigned long OpenSSLLib::SSL_ERR_get_error() noexcept
     return OpenSSLLibMockManager::getMockInterface().SSL_ERR_get_error();
 }
 
-X509_NAME* OpenSSLLib::SSL_X509_NAME_new() noexcept
+X509_NAME *OpenSSLLib::SSL_X509_NAME_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_NAME_new();
 }
 
-void OpenSSLLib::SSL_X509_NAME_free(X509_NAME* ptr) noexcept
+void OpenSSLLib::SSL_X509_NAME_free(X509_NAME *ptr) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509_NAME_free(ptr);
 }
 
-int OpenSSLLib::SSL_X509_NAME_add_entry_by_NID(X509_NAME* name,
+int OpenSSLLib::SSL_X509_NAME_add_entry_by_NID(X509_NAME *name,
                                                int nid,
                                                int type,
-                                               unsigned char* bytes,
+                                               unsigned char *bytes,
                                                int len,
                                                int loc,
                                                int set) noexcept
@@ -241,316 +241,316 @@ int OpenSSLLib::SSL_X509_NAME_add_entry_by_NID(X509_NAME* name,
             name, nid, type, bytes, len, loc, set);
 }
 
-int OpenSSLLib::SSL_X509_REQ_set_subject_name(X509_REQ* req, X509_NAME* name) noexcept
+int OpenSSLLib::SSL_X509_REQ_set_subject_name(X509_REQ *req, X509_NAME *name) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_set_subject_name(req, name);
 }
 
-int OpenSSLLib::SSL_X509_REQ_set_pubkey(X509_REQ* req, EVP_PKEY* pkey) noexcept
+int OpenSSLLib::SSL_X509_REQ_set_pubkey(X509_REQ *req, EVP_PKEY *pkey) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_set_pubkey(req, pkey);
 }
 
-int OpenSSLLib::SSL_X509_REQ_set_version(X509_REQ* ctx, unsigned long version) noexcept
+int OpenSSLLib::SSL_X509_REQ_set_version(X509_REQ *ctx, unsigned long version) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_set_version(ctx, version);
 }
 
-int OpenSSLLib::SSL_PEM_write_bio_X509_REQ(BIO* bio, X509_REQ* req) noexcept
+int OpenSSLLib::SSL_PEM_write_bio_X509_REQ(BIO *bio, X509_REQ *req) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PEM_write_bio_X509_REQ(bio, req);
 }
 
-X509_REQ* OpenSSLLib::SSL_PEM_read_bio_X509_REQ(BIO* bp,
-                                                X509_REQ** x,
-                                                pem_password_cb* cb,
-                                                void* u) noexcept
+X509_REQ *OpenSSLLib::SSL_PEM_read_bio_X509_REQ(BIO *bp,
+                                                X509_REQ **x,
+                                                pem_password_cb *cb,
+                                                void *u) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PEM_read_bio_X509_REQ(bp, x, cb, u);
 }
 
-const BIO_METHOD* OpenSSLLib::SSL_BIO_s_mem() noexcept
+const BIO_METHOD *OpenSSLLib::SSL_BIO_s_mem() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BIO_s_mem();
 }
 
-void OpenSSLLib::SSL_BIO_free_all(BIO* ptr) noexcept
+void OpenSSLLib::SSL_BIO_free_all(BIO *ptr) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_BIO_free_all(ptr);
 }
 
-BIO* OpenSSLLib::SSL_BIO_new(const BIO_METHOD* method) noexcept
+BIO *OpenSSLLib::SSL_BIO_new(const BIO_METHOD *method) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BIO_new(method);
 }
 
-int OpenSSLLib::SSL_BIO_gets(BIO* bio, char* buf, int size) noexcept
+int OpenSSLLib::SSL_BIO_gets(BIO *bio, char *buf, int size) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BIO_gets(bio, buf, size);
 }
 
-int OpenSSLLib::SSL_BIO_puts(BIO* bio, char* buf) noexcept
+int OpenSSLLib::SSL_BIO_puts(BIO *bio, char *buf) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BIO_puts(bio, buf);
 }
 
-int OpenSSLLib::SSL_X509_REQ_sign_ctx(X509_REQ* req, EVP_MD_CTX* ctx) noexcept
+int OpenSSLLib::SSL_X509_REQ_sign_ctx(X509_REQ *req, EVP_MD_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_REQ_sign_ctx(req, ctx);
 }
 
-EVP_MD_CTX* OpenSSLLib::SSL_EVP_MD_CTX_create() noexcept
+EVP_MD_CTX *OpenSSLLib::SSL_EVP_MD_CTX_create() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_MD_CTX_create();
 }
 
-int OpenSSLLib::SSL_EVP_DigestSignInit(EVP_MD_CTX* ctx,
-                                       EVP_PKEY_CTX** pctx,
-                                       const EVP_MD* type,
-                                       ENGINE* e,
-                                       EVP_PKEY* pkey) noexcept
+int OpenSSLLib::SSL_EVP_DigestSignInit(EVP_MD_CTX *ctx,
+                                       EVP_PKEY_CTX **pctx,
+                                       const EVP_MD *type,
+                                       ENGINE *e,
+                                       EVP_PKEY *pkey) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_DigestSignInit(
             ctx, pctx, type, e, pkey);
 }
 
-void OpenSSLLib::SSL_EVP_MD_CTX_destroy(EVP_MD_CTX* ptr) noexcept
+void OpenSSLLib::SSL_EVP_MD_CTX_destroy(EVP_MD_CTX *ptr) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_EVP_MD_CTX_destroy(ptr);
 }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha1() noexcept
+const EVP_MD *OpenSSLLib::SSL_EVP_sha1() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha1();
 }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha256() noexcept
+const EVP_MD *OpenSSLLib::SSL_EVP_sha256() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha256();
 }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha384() noexcept
+const EVP_MD *OpenSSLLib::SSL_EVP_sha384() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha384();
 }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha512() noexcept
+const EVP_MD *OpenSSLLib::SSL_EVP_sha512() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha512();
 }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha3_256() noexcept
+const EVP_MD *OpenSSLLib::SSL_EVP_sha3_256() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha3_256();
 }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha3_384() noexcept
+const EVP_MD *OpenSSLLib::SSL_EVP_sha3_384() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha3_384();
 }
 
-const EVP_MD* OpenSSLLib::SSL_EVP_sha3_512() noexcept
+const EVP_MD *OpenSSLLib::SSL_EVP_sha3_512() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_sha3_512();
 }
 
-int OpenSSLLib::SSL_PEM_write_bio_PKCS8PrivateKey(BIO* bp,
-                                                  EVP_PKEY* x,
-                                                  const EVP_CIPHER* enc,
-                                                  char* kstr,
+int OpenSSLLib::SSL_PEM_write_bio_PKCS8PrivateKey(BIO *bp,
+                                                  EVP_PKEY *x,
+                                                  const EVP_CIPHER *enc,
+                                                  char *kstr,
                                                   int klen,
-                                                  pem_password_cb* cb,
-                                                  void* u) noexcept
+                                                  pem_password_cb *cb,
+                                                  void *u) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PEM_write_bio_PKCS8PrivateKey(
             bp, x, enc, kstr, klen, cb, u);
 }
 
-int OpenSSLLib::SSL_PEM_write_bio_PUBKEY(BIO* bp, EVP_PKEY* x) noexcept
+int OpenSSLLib::SSL_PEM_write_bio_PUBKEY(BIO *bp, EVP_PKEY *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PEM_write_bio_PUBKEY(bp, x);
 }
-EVP_PKEY* OpenSSLLib::SSL_PEM_read_bio_PUBKEY(BIO* bio,
-                                              EVP_PKEY** pkey,
-                                              pem_password_cb* cb,
-                                              void* u) noexcept
+EVP_PKEY *OpenSSLLib::SSL_PEM_read_bio_PUBKEY(BIO *bio,
+                                              EVP_PKEY **pkey,
+                                              pem_password_cb *cb,
+                                              void *u) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PEM_read_bio_PUBKEY(bio, pkey, cb, u);
 }
 
-EVP_PKEY* OpenSSLLib::SSL_PEM_read_bio_PrivateKey(BIO* bio,
-                                                  EVP_PKEY** pkey,
-                                                  pem_password_cb* cb,
-                                                  void* u) noexcept
+EVP_PKEY *OpenSSLLib::SSL_PEM_read_bio_PrivateKey(BIO *bio,
+                                                  EVP_PKEY **pkey,
+                                                  pem_password_cb *cb,
+                                                  void *u) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PEM_read_bio_PrivateKey(bio, pkey, cb, u);
 }
 
-X509* OpenSSLLib::SSL_d2i_X509_bio(BIO* bp, X509** x509) noexcept
+X509 *OpenSSLLib::SSL_d2i_X509_bio(BIO *bp, X509 **x509) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_d2i_X509_bio(bp, x509);
 }
 
-int OpenSSLLib::SSL_i2d_X509_bio(BIO* bp, X509* x) noexcept
+int OpenSSLLib::SSL_i2d_X509_bio(BIO *bp, X509 *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_i2d_X509_bio(bp, x);
 }
 
-X509* OpenSSLLib::SSL_X509_new() noexcept
+X509 *OpenSSLLib::SSL_X509_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_new();
 }
 
-int OpenSSLLib::SSL_X509_set_pubkey(X509* ptr, EVP_PKEY* pkey) noexcept
+int OpenSSLLib::SSL_X509_set_pubkey(X509 *ptr, EVP_PKEY *pkey) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_set_pubkey(ptr, pkey);
 }
 
-int OpenSSLLib::SSL_X509_set_issuer_name(X509* x, X509_NAME* name) noexcept
+int OpenSSLLib::SSL_X509_set_issuer_name(X509 *x, X509_NAME *name) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_set_issuer_name(x, name);
 }
 
-int OpenSSLLib::SSL_X509_set_subject_name(X509* x, X509_NAME* name) noexcept
+int OpenSSLLib::SSL_X509_set_subject_name(X509 *x, X509_NAME *name) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_set_subject_name(x, name);
 }
 
-int OpenSSLLib::SSL_X509_set_notBefore(X509* x, const ASN1_TIME* t) noexcept
+int OpenSSLLib::SSL_X509_set_notBefore(X509 *x, const ASN1_TIME *t) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_set_notBefore(x, t);
 }
 
-int OpenSSLLib::SSL_X509_set_notAfter(X509* x, const ASN1_TIME* t) noexcept
+int OpenSSLLib::SSL_X509_set_notAfter(X509 *x, const ASN1_TIME *t) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_set_notAfter(x, t);
 }
 
-int OpenSSLLib::SSL_X509_sign(X509* x, EVP_PKEY* pkey, const EVP_MD* md) noexcept
+int OpenSSLLib::SSL_X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_sign(x, pkey, md);
 }
 
-void OpenSSLLib::SSL_X509_free(X509* ptr) noexcept
+void OpenSSLLib::SSL_X509_free(X509 *ptr) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509_free(ptr);
 }
 
-X509* OpenSSLLib::SSL_PEM_read_bio_X509(BIO* bio, X509** x, pem_password_cb* cb, void* pwd) noexcept
+X509 *OpenSSLLib::SSL_PEM_read_bio_X509(BIO *bio, X509 **x, pem_password_cb *cb, void *pwd) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PEM_read_bio_X509(bio, x, cb, pwd);
 }
 
-int OpenSSLLib::SSL_PEM_write_bio_X509(BIO* bp, X509* x) noexcept
+int OpenSSLLib::SSL_PEM_write_bio_X509(BIO *bp, X509 *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PEM_write_bio_X509(bp, x);
 }
 
-void OpenSSLLib::SSL_ASN1_TIME_free(ASN1_TIME* x) noexcept
+void OpenSSLLib::SSL_ASN1_TIME_free(ASN1_TIME *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_TIME_free(x);
 }
 
-int OpenSSLLib::SSL_ASN1_TIME_diff(int* pday,
-                                   int* psec,
-                                   const ASN1_TIME* from,
-                                   const ASN1_TIME* to) noexcept
+int OpenSSLLib::SSL_ASN1_TIME_diff(int *pday,
+                                   int *psec,
+                                   const ASN1_TIME *from,
+                                   const ASN1_TIME *to) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_TIME_diff(pday, psec, from, to);
 }
 
-ASN1_TIME* OpenSSLLib::SSL_ASN1_TIME_set(ASN1_TIME* s, time_t t) noexcept
+ASN1_TIME *OpenSSLLib::SSL_ASN1_TIME_set(ASN1_TIME *s, time_t t) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_TIME_set(s, t);
 }
 
 /* X509 */
-X509_NAME* OpenSSLLib::SSL_X509_get_subject_name(X509* ptr) noexcept
+X509_NAME *OpenSSLLib::SSL_X509_get_subject_name(X509 *ptr) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_get_subject_name(ptr);
 }
 
-X509_NAME* OpenSSLLib::SSL_X509_get_issuer_name(X509* ptr) noexcept
+X509_NAME *OpenSSLLib::SSL_X509_get_issuer_name(X509 *ptr) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_get_issuer_name(ptr);
 }
 
-EVP_PKEY* OpenSSLLib::SSL_X509_get_pubkey(X509* x) noexcept
+EVP_PKEY *OpenSSLLib::SSL_X509_get_pubkey(X509 *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_get_pubkey(x);
 }
 
-ASN1_TIME* OpenSSLLib::SSL_X509_get_notBefore(X509* x) noexcept
+ASN1_TIME *OpenSSLLib::SSL_X509_get_notBefore(X509 *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_get_notBefore(x);
 }
 
-ASN1_TIME* OpenSSLLib::SSL_X509_get_notAfter(X509* x) noexcept
+ASN1_TIME *OpenSSLLib::SSL_X509_get_notAfter(X509 *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_get_notAfter(x);
 }
 
 /* X509 Certificate validation */
-X509_STORE* OpenSSLLib::SSL_X509_STORE_new() noexcept
+X509_STORE *OpenSSLLib::SSL_X509_STORE_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_STORE_new();
 }
 
-void OpenSSLLib::SSL_X509_STORE_free(X509_STORE* v) noexcept
+void OpenSSLLib::SSL_X509_STORE_free(X509_STORE *v) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509_STORE_free(v);
 }
 
-int OpenSSLLib::SSL_X509_STORE_add_cert(X509_STORE* ctx, X509* x) noexcept
+int OpenSSLLib::SSL_X509_STORE_add_cert(X509_STORE *ctx, X509 *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_STORE_add_cert(ctx, x);
 }
 
-X509_STORE_CTX* OpenSSLLib::SSL_X509_STORE_CTX_new() noexcept
+X509_STORE_CTX *OpenSSLLib::SSL_X509_STORE_CTX_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_STORE_CTX_new();
 }
 
-void OpenSSLLib::SSL_X509_STORE_CTX_free(X509_STORE_CTX* ctx) noexcept
+void OpenSSLLib::SSL_X509_STORE_CTX_free(X509_STORE_CTX *ctx) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509_STORE_CTX_free(ctx);
 }
-int OpenSSLLib::SSL_X509_STORE_CTX_init(X509_STORE_CTX* ctx,
-                                        X509_STORE* store,
-                                        X509* x509,
+int OpenSSLLib::SSL_X509_STORE_CTX_init(X509_STORE_CTX *ctx,
+                                        X509_STORE *store,
+                                        X509 *x509,
                                         STACK_OF(X509) * chain) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_STORE_CTX_init(
             ctx, store, x509, chain);
 }
 
-X509_VERIFY_PARAM* OpenSSLLib::SSL_X509_STORE_CTX_get0_param(X509_STORE_CTX* ctx) noexcept
+X509_VERIFY_PARAM *OpenSSLLib::SSL_X509_STORE_CTX_get0_param(X509_STORE_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_STORE_CTX_get0_param(ctx);
 }
 
-int OpenSSLLib::SSL_X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM* param,
+int OpenSSLLib::SSL_X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param,
                                                 unsigned long flags) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_VERIFY_PARAM_set_flags(param, flags);
 }
 
-int OpenSSLLib::SSL_X509_verify_cert(X509_STORE_CTX* ctx) noexcept
+int OpenSSLLib::SSL_X509_verify_cert(X509_STORE_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_verify_cert(ctx);
 }
 
-const char* OpenSSLLib::SSL_X509_verify_cert_error_string(long n) noexcept
+const char *OpenSSLLib::SSL_X509_verify_cert_error_string(long n) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_verify_cert_error_string(n);
 }
 
-int OpenSSLLib::SSL_X509_STORE_CTX_get_error(X509_STORE_CTX* ctx) noexcept
+int OpenSSLLib::SSL_X509_STORE_CTX_get_error(X509_STORE_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_STORE_CTX_get_error(ctx);
 }
 
-int OpenSSLLib::SSL_X509_check_ca(X509* cert) noexcept
+int OpenSSLLib::SSL_X509_check_ca(X509 *cert) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_check_ca(cert);
 }
@@ -561,7 +561,7 @@ STACK_OF(X509) * OpenSSLLib::SSL_sk_X509_new_null() noexcept
     return OpenSSLLibMockManager::getMockInterface().SSL_sk_X509_new_null();
 }
 
-int OpenSSLLib::SSL_sk_X509_push(STACK_OF(X509) * stack, const X509* crt) noexcept
+int OpenSSLLib::SSL_sk_X509_push(STACK_OF(X509) * stack, const X509 *crt) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_sk_X509_push(stack, crt);
 }
@@ -570,185 +570,185 @@ void OpenSSLLib::SSL_sk_X509_free(STACK_OF(X509) * stack) noexcept
     return OpenSSLLibMockManager::getMockInterface().SSL_sk_X509_free(stack);
 }
 
-int OpenSSLLib::SSL_X509_NAME_get_index_by_NID(X509_NAME* name, int nid, int lastpos) noexcept
+int OpenSSLLib::SSL_X509_NAME_get_index_by_NID(X509_NAME *name, int nid, int lastpos) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_NAME_get_index_by_NID(
             name, nid, lastpos);
 }
 
-X509_NAME_ENTRY* OpenSSLLib::SSL_X509_NAME_get_entry(X509_NAME* name, int loc) noexcept
+X509_NAME_ENTRY *OpenSSLLib::SSL_X509_NAME_get_entry(X509_NAME *name, int loc) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_NAME_get_entry(name, loc);
 }
 
-ASN1_STRING* OpenSSLLib::SSL_X509_NAME_ENTRY_get_data(X509_NAME_ENTRY* ne) noexcept
+ASN1_STRING *OpenSSLLib::SSL_X509_NAME_ENTRY_get_data(X509_NAME_ENTRY *ne) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_NAME_ENTRY_get_data(ne);
 }
 
-int OpenSSLLib::SSL_ASN1_STRING_print_ex(BIO* out, ASN1_STRING* str, unsigned long flags) noexcept
+int OpenSSLLib::SSL_ASN1_STRING_print_ex(BIO *out, ASN1_STRING *str, unsigned long flags) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_STRING_print_ex(out, str, flags);
 }
 
-BIO* OpenSSLLib::SSL_BIO_new_file(const char* filename, const char* mode) noexcept
+BIO *OpenSSLLib::SSL_BIO_new_file(const char *filename, const char *mode) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BIO_new_file(filename, mode);
 }
-int OpenSSLLib::SSL_BIO_read(BIO* b, void* buf, int len) noexcept
+int OpenSSLLib::SSL_BIO_read(BIO *b, void *buf, int len) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BIO_read(b, buf, len);
 }
-int OpenSSLLib::SSL_BIO_write(BIO* b, const void* buf, int len) noexcept
+int OpenSSLLib::SSL_BIO_write(BIO *b, const void *buf, int len) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BIO_write(b, buf, len);
 }
-const EVP_CIPHER* OpenSSLLib::SSL_EVP_aes_128_cbc() noexcept
+const EVP_CIPHER *OpenSSLLib::SSL_EVP_aes_128_cbc() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_aes_128_cbc();
 }
-const EVP_CIPHER* OpenSSLLib::SSL_EVP_aes_256_cbc() noexcept
+const EVP_CIPHER *OpenSSLLib::SSL_EVP_aes_256_cbc() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_aes_256_cbc();
 }
-X509_EXTENSION* OpenSSLLib::SSL_X509V3_EXT_conf_nid(lhash_st_CONF_VALUE* conf,
-                                                    X509V3_CTX* ctx,
+X509_EXTENSION *OpenSSLLib::SSL_X509V3_EXT_conf_nid(lhash_st_CONF_VALUE *conf,
+                                                    X509V3_CTX *ctx,
                                                     int ext_nid,
-                                                    char* value) noexcept
+                                                    char *value) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509V3_EXT_conf_nid(
             conf, ctx, ext_nid, value);
 }
-int OpenSSLLib::SSL_X509_add_ext(X509* x, X509_EXTENSION* ex, int loc) noexcept
+int OpenSSLLib::SSL_X509_add_ext(X509 *x, X509_EXTENSION *ex, int loc) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_add_ext(x, ex, loc);
 }
-void OpenSSLLib::SSL_X509_EXTENSION_free(X509_EXTENSION* a) noexcept
+void OpenSSLLib::SSL_X509_EXTENSION_free(X509_EXTENSION *a) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509_EXTENSION_free(a);
 }
-void OpenSSLLib::SSL_X509V3_set_ctx_nodb(X509V3_CTX* ctx) noexcept
+void OpenSSLLib::SSL_X509V3_set_ctx_nodb(X509V3_CTX *ctx) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509V3_set_ctx_nodb(ctx);
 }
-void OpenSSLLib::SSL_X509V3_set_ctx(X509V3_CTX* ctx,
-                                    X509* issuer,
-                                    X509* subject,
-                                    X509_REQ* req,
-                                    X509_CRL* crl,
+void OpenSSLLib::SSL_X509V3_set_ctx(X509V3_CTX *ctx,
+                                    X509 *issuer,
+                                    X509 *subject,
+                                    X509_REQ *req,
+                                    X509_CRL *crl,
                                     int flags) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509V3_set_ctx(
             ctx, issuer, subject, req, crl, flags);
 }
-int OpenSSLLib::SSL_X509_set_serialNumber(X509* x, ASN1_INTEGER* serial) noexcept
+int OpenSSLLib::SSL_X509_set_serialNumber(X509 *x, ASN1_INTEGER *serial) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_set_serialNumber(x, serial);
 }
-ASN1_INTEGER* OpenSSLLib::SSL_X509_get_serialNumber(X509* x) noexcept
+ASN1_INTEGER *OpenSSLLib::SSL_X509_get_serialNumber(X509 *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_get_serialNumber(x);
 }
-int OpenSSLLib::SSL_ASN1_INTEGER_set(ASN1_INTEGER* a, long value) noexcept
+int OpenSSLLib::SSL_ASN1_INTEGER_set(ASN1_INTEGER *a, long value) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_INTEGER_set(a, value);
 }
-long OpenSSLLib::SSL_ASN1_INTEGER_get(const ASN1_INTEGER* a) noexcept
+long OpenSSLLib::SSL_ASN1_INTEGER_get(const ASN1_INTEGER *a) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_INTEGER_get(a);
 }
-int OpenSSLLib::SSL_ASN1_INTEGER_cmp(const ASN1_INTEGER* x, const ASN1_INTEGER* y) noexcept
+int OpenSSLLib::SSL_ASN1_INTEGER_cmp(const ASN1_INTEGER *x, const ASN1_INTEGER *y) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_INTEGER_cmp(x, y);
 }
-BIGNUM* OpenSSLLib::SSL_ASN1_INTEGER_to_BN(const ASN1_INTEGER* ai, BIGNUM* bn) noexcept
+BIGNUM *OpenSSLLib::SSL_ASN1_INTEGER_to_BN(const ASN1_INTEGER *ai, BIGNUM *bn) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_INTEGER_to_BN(ai, bn);
 }
-void OpenSSLLib::SSL_BN_free(BIGNUM* a) noexcept
+void OpenSSLLib::SSL_BN_free(BIGNUM *a) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_BN_free(a);
 }
-char* OpenSSLLib::SSL_BN_bn2dec(const BIGNUM* a) noexcept
+char *OpenSSLLib::SSL_BN_bn2dec(const BIGNUM *a) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BN_bn2dec(a);
 }
-void* OpenSSLLib::SSL_OPENSSL_malloc(int num) noexcept
+void *OpenSSLLib::SSL_OPENSSL_malloc(int num) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_OPENSSL_malloc(num);
 }
-void OpenSSLLib::SSL_OPENSSL_free(void* addr) noexcept
+void OpenSSLLib::SSL_OPENSSL_free(void *addr) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_OPENSSL_free(addr);
 }
-void OpenSSLLib::SSL_ASN1_INTEGER_free(ASN1_INTEGER* a) noexcept
+void OpenSSLLib::SSL_ASN1_INTEGER_free(ASN1_INTEGER *a) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_ASN1_INTEGER_free(a);
 }
-ASN1_INTEGER* OpenSSLLib::SSL_ASN1_INTEGER_new() noexcept
+ASN1_INTEGER *OpenSSLLib::SSL_ASN1_INTEGER_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_INTEGER_new();
 }
-int OpenSSLLib::SSL_BN_bn2bin(const BIGNUM* a, unsigned char* to) noexcept
+int OpenSSLLib::SSL_BN_bn2bin(const BIGNUM *a, unsigned char *to) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BN_bn2bin(a, to);
 }
-int OpenSSLLib::SSL_BN_num_bytes(const BIGNUM* a) noexcept
+int OpenSSLLib::SSL_BN_num_bytes(const BIGNUM *a) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BN_num_bytes(a);
 }
-int OpenSSLLib::SSL_ASN1_TIME_set_string(ASN1_TIME* s, const char* str) noexcept
+int OpenSSLLib::SSL_ASN1_TIME_set_string(ASN1_TIME *s, const char *str) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_TIME_set_string(s, str);
 }
-ASN1_TIME* OpenSSLLib::SSL_ASN1_TIME_new() noexcept
+ASN1_TIME *OpenSSLLib::SSL_ASN1_TIME_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_TIME_new();
 }
-ASN1_STRING* OpenSSLLib::SSL_ASN1_STRING_dup(const ASN1_STRING* str) noexcept
+ASN1_STRING *OpenSSLLib::SSL_ASN1_STRING_dup(const ASN1_STRING *str) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_STRING_dup(str);
 }
-X509_NAME* OpenSSLLib::SSL_X509_CRL_get_issuer(const X509_CRL* crl) noexcept
+X509_NAME *OpenSSLLib::SSL_X509_CRL_get_issuer(const X509_CRL *crl) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_CRL_get_issuer(crl);
 }
-int OpenSSLLib::SSL_X509_CRL_verify(X509_CRL* a, EVP_PKEY* r) noexcept
+int OpenSSLLib::SSL_X509_CRL_verify(X509_CRL *a, EVP_PKEY *r) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_CRL_verify(a, r);
 }
-const ASN1_TIME* OpenSSLLib::SSL_X509_CRL_get_nextUpdate(const X509_CRL* x) noexcept
+const ASN1_TIME *OpenSSLLib::SSL_X509_CRL_get_nextUpdate(const X509_CRL *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_CRL_get_nextUpdate(x);
 }
-const ASN1_TIME* OpenSSLLib::SSL_X509_CRL_get_lastUpdate(const X509_CRL* x) noexcept
+const ASN1_TIME *OpenSSLLib::SSL_X509_CRL_get_lastUpdate(const X509_CRL *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_CRL_get_lastUpdate(x);
 }
-X509_CRL* OpenSSLLib::SSL_PEM_read_bio_X509_CRL(BIO* bp,
-                                                X509_CRL** x,
-                                                pem_password_cb* cb,
-                                                void* u) noexcept
+X509_CRL *OpenSSLLib::SSL_PEM_read_bio_X509_CRL(BIO *bp,
+                                                X509_CRL **x,
+                                                pem_password_cb *cb,
+                                                void *u) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PEM_read_bio_X509_CRL(bp, x, cb, u);
 }
-int OpenSSLLib::SSL_PEM_write_bio_X509_CRL(BIO* bp, X509_CRL* x) noexcept
+int OpenSSLLib::SSL_PEM_write_bio_X509_CRL(BIO *bp, X509_CRL *x) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PEM_write_bio_X509_CRL(bp, x);
 }
-X509_CRL* OpenSSLLib::SSL_d2i_X509_CRL_bio(BIO* bp, X509_CRL** crl) noexcept
+X509_CRL *OpenSSLLib::SSL_d2i_X509_CRL_bio(BIO *bp, X509_CRL **crl) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_d2i_X509_CRL_bio(bp, crl);
 }
-void OpenSSLLib::SSL_X509_CRL_free(X509_CRL* a) noexcept
+void OpenSSLLib::SSL_X509_CRL_free(X509_CRL *a) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509_CRL_free(a);
 }
-X509_CRL* OpenSSLLib::SSL_X509_CRL_new() noexcept
+X509_CRL *OpenSSLLib::SSL_X509_CRL_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_CRL_new();
 }
-void OpenSSLLib::SSL_X509_STORE_CTX_set0_crls(X509_STORE_CTX* ctx,
+void OpenSSLLib::SSL_X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx,
                                               STACK_OF(X509_CRL) * crls) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509_STORE_CTX_set0_crls(ctx, crls);
@@ -761,11 +761,11 @@ STACK_OF(X509_CRL) * OpenSSLLib::SSL_sk_X509_CRL_new_null() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_sk_X509_CRL_new_null();
 }
-int OpenSSLLib::SSL_sk_X509_CRL_push(STACK_OF(X509_CRL) * stack, const X509_CRL* crl) noexcept
+int OpenSSLLib::SSL_sk_X509_CRL_push(STACK_OF(X509_CRL) * stack, const X509_CRL *crl) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_sk_X509_CRL_push(stack, crl);
 }
-ASN1_TIME* OpenSSLLib::SSL_ASN1_TIME_adj(ASN1_TIME* s,
+ASN1_TIME *OpenSSLLib::SSL_ASN1_TIME_adj(ASN1_TIME *s,
                                          time_t t,
                                          int offset_day,
                                          long offset_sec) noexcept
@@ -773,423 +773,423 @@ ASN1_TIME* OpenSSLLib::SSL_ASN1_TIME_adj(ASN1_TIME* s,
     return OpenSSLLibMockManager::getMockInterface().SSL_ASN1_TIME_adj(
             s, t, offset_day, offset_sec);
 }
-void OpenSSLLib::SSL_X509_STORE_CTX_set_time(X509_STORE_CTX* ctx,
+void OpenSSLLib::SSL_X509_STORE_CTX_set_time(X509_STORE_CTX *ctx,
                                              unsigned long flags,
                                              time_t t) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_X509_STORE_CTX_set_time(ctx, flags, t);
 }
-void OpenSSLLib::SSL_EVP_MD_CTX_init(EVP_MD_CTX* ctx) noexcept
+void OpenSSLLib::SSL_EVP_MD_CTX_init(EVP_MD_CTX *ctx) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_EVP_MD_CTX_init(ctx);
 }
-int OpenSSLLib::SSL_EVP_DigestInit_ex(EVP_MD_CTX* ctx, const EVP_MD* type, ENGINE* impl) noexcept
+int OpenSSLLib::SSL_EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_DigestInit_ex(ctx, type, impl);
 }
-int OpenSSLLib::SSL_EVP_DigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt) noexcept
+int OpenSSLLib::SSL_EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_DigestUpdate(ctx, d, cnt);
 }
-int OpenSSLLib::SSL_EVP_DigestFinal_ex(EVP_MD_CTX* ctx, unsigned char* md, unsigned int* s) noexcept
+int OpenSSLLib::SSL_EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_DigestFinal_ex(ctx, md, s);
 }
-int OpenSSLLib::SSL_EVP_MD_CTX_reset(EVP_MD_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_MD_CTX_reset(EVP_MD_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_MD_CTX_reset(ctx);
 }
-int OpenSSLLib::SSL_EVP_PKEY_sign(EVP_PKEY_CTX* ctx,
-                                  unsigned char* sig,
-                                  size_t* siglen,
-                                  const unsigned char* tbs,
+int OpenSSLLib::SSL_EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
+                                  unsigned char *sig,
+                                  size_t *siglen,
+                                  const unsigned char *tbs,
                                   size_t tbslen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_sign(
             ctx, sig, siglen, tbs, tbslen);
 }
-int OpenSSLLib::SSL_EVP_PKEY_sign_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_sign_init(ctx);
 }
-int OpenSSLLib::SSL_EVP_PKEY_verify_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_verify_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_verify_init(ctx);
 }
-int OpenSSLLib::SSL_EVP_PKEY_verify(EVP_PKEY_CTX* ctx,
-                                    const unsigned char* sig,
+int OpenSSLLib::SSL_EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
+                                    const unsigned char *sig,
                                     size_t siglen,
-                                    const unsigned char* tbs,
+                                    const unsigned char *tbs,
                                     size_t tbslen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_verify(
             ctx, sig, siglen, tbs, tbslen);
 }
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX* ctx, int pad) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_rsa_padding(ctx, pad);
 }
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_signature_md(ctx, md);
 }
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX* ctx, int len) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int len) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx, len);
 }
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, md);
 }
-int OpenSSLLib::SSL_EVP_PKEY_encrypt_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_encrypt_init(ctx);
 }
-int OpenSSLLib::SSL_EVP_PKEY_encrypt(EVP_PKEY_CTX* ctx,
-                                     unsigned char* out,
-                                     size_t* outlen,
-                                     const unsigned char* in,
+int OpenSSLLib::SSL_EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
+                                     unsigned char *out,
+                                     size_t *outlen,
+                                     const unsigned char *in,
                                      size_t inlen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_encrypt(
             ctx, out, outlen, in, inlen);
 }
-int OpenSSLLib::SSL_EVP_PKEY_decrypt_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_decrypt_init(ctx);
 }
-int OpenSSLLib::SSL_EVP_PKEY_decrypt(EVP_PKEY_CTX* ctx,
-                                     unsigned char* out,
-                                     size_t* outlen,
-                                     const unsigned char* in,
+int OpenSSLLib::SSL_EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
+                                     unsigned char *out,
+                                     size_t *outlen,
+                                     const unsigned char *in,
                                      size_t inlen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_decrypt(
             ctx, out, outlen, in, inlen);
 }
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_rsa_oaep_md(ctx, md);
 }
-int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX* ctx,
-                                                    unsigned char* l,
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx,
+                                                    unsigned char *l,
                                                     int llen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_rsa_oaep_label(
             ctx, l, llen);
 }
-int OpenSSLLib::SSL_RSA_size(const RSA* r) noexcept
+int OpenSSLLib::SSL_RSA_size(const RSA *r) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_RSA_size(r);
 }
-int OpenSSLLib::SSL_EVP_MD_size(const EVP_MD* md) noexcept
+int OpenSSLLib::SSL_EVP_MD_size(const EVP_MD *md) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_MD_size(md);
 }
-EC_KEY* OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY* pkey) noexcept
+EC_KEY *OpenSSLLib::SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_get0_EC_KEY(pkey);
 }
-int OpenSSLLib::SSL_EVP_DigestSign(EVP_MD_CTX* ctx,
-                                   unsigned char* sigret,
-                                   size_t* siglen,
-                                   const unsigned char* tbs,
+int OpenSSLLib::SSL_EVP_DigestSign(EVP_MD_CTX *ctx,
+                                   unsigned char *sigret,
+                                   size_t *siglen,
+                                   const unsigned char *tbs,
                                    size_t tbslen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_DigestSign(
             ctx, sigret, siglen, tbs, tbslen);
 }
-int OpenSSLLib::SSL_EVP_DigestVerifyInit(EVP_MD_CTX* ctx,
-                                         EVP_PKEY_CTX** pctx,
-                                         const EVP_MD* type,
-                                         ENGINE* e,
-                                         EVP_PKEY* pkey) noexcept
+int OpenSSLLib::SSL_EVP_DigestVerifyInit(EVP_MD_CTX *ctx,
+                                         EVP_PKEY_CTX **pctx,
+                                         const EVP_MD *type,
+                                         ENGINE *e,
+                                         EVP_PKEY *pkey) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_DigestVerifyInit(
             ctx, pctx, type, e, pkey);
 }
-int OpenSSLLib::SSL_EVP_DigestVerify(EVP_MD_CTX* ctx,
-                                     const unsigned char* sigret,
+int OpenSSLLib::SSL_EVP_DigestVerify(EVP_MD_CTX *ctx,
+                                     const unsigned char *sigret,
                                      size_t siglen,
-                                     const unsigned char* tbs,
+                                     const unsigned char *tbs,
                                      size_t tbslen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_DigestVerify(
             ctx, sigret, siglen, tbs, tbslen);
 }
-X509_REQ* OpenSSLLib::SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) noexcept
+X509_REQ *OpenSSLLib::SSL_d2i_X509_REQ_bio(BIO *bp, X509_REQ **req) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_d2i_X509_REQ_bio(bp, req);
 }
-int OpenSSLLib::SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) noexcept
+int OpenSSLLib::SSL_i2d_X509_REQ_bio(BIO *bp, X509_REQ *req) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_i2d_X509_REQ_bio(bp, req);
 }
-int OpenSSLLib::SSL_EVP_CipherUpdate(EVP_CIPHER_CTX* ctx,
-                                     unsigned char* out,
-                                     int* outl,
-                                     const unsigned char* in,
+int OpenSSLLib::SSL_EVP_CipherUpdate(EVP_CIPHER_CTX *ctx,
+                                     unsigned char *out,
+                                     int *outl,
+                                     const unsigned char *in,
                                      int inl) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CipherUpdate(ctx, out, outl, in, inl);
 }
-int OpenSSLLib::SSL_EVP_CipherFinal_ex(EVP_CIPHER_CTX* ctx, unsigned char* outm, int* outl) noexcept
+int OpenSSLLib::SSL_EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CipherFinal_ex(ctx, outm, outl);
 }
-int OpenSSLLib::SSL_EVP_CipherInit_ex(EVP_CIPHER_CTX* ctx,
-                                      const EVP_CIPHER* cipher,
-                                      ENGINE* impl,
-                                      const unsigned char* key,
-                                      const unsigned char* iv,
+int OpenSSLLib::SSL_EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx,
+                                      const EVP_CIPHER *cipher,
+                                      ENGINE *impl,
+                                      const unsigned char *key,
+                                      const unsigned char *iv,
                                       int enc) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CipherInit_ex(
             ctx, cipher, impl, key, iv, enc);
 }
-EVP_CIPHER_CTX* OpenSSLLib::SSL_EVP_CIPHER_CTX_new() noexcept
+EVP_CIPHER_CTX *OpenSSLLib::SSL_EVP_CIPHER_CTX_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_CTX_new();
 }
-void OpenSSLLib::SSL_EVP_CIPHER_CTX_free(EVP_CIPHER_CTX* c) noexcept
+void OpenSSLLib::SSL_EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *c) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_CTX_free(c);
 }
-int OpenSSLLib::SSL_EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX* ctx, int type, int arg, void* ptr) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_CTX_ctrl(ctx, type, arg, ptr);
 }
-int OpenSSLLib::SSL_EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_CTX_key_length(ctx);
 }
-int OpenSSLLib::SSL_EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_CTX_iv_length(ctx);
 }
-int OpenSSLLib::SSL_RAND_bytes(unsigned char* buf, int num) noexcept
+int OpenSSLLib::SSL_RAND_bytes(unsigned char *buf, int num) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_RAND_bytes(buf, num);
 }
-int OpenSSLLib::SSL_EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX* c) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *c) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_CTX_reset(c);
 }
-int OpenSSLLib::SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX* c, int pad) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *c, int pad) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_CTX_set_padding(c, pad);
 }
 
-int OpenSSLLib::SSL_PKCS5_PBKDF2_HMAC(const char* pass,
+int OpenSSLLib::SSL_PKCS5_PBKDF2_HMAC(const char *pass,
                                       int passlen,
-                                      const unsigned char* salt,
+                                      const unsigned char *salt,
                                       int saltlen,
                                       int iter,
-                                      const EVP_MD* digest,
+                                      const EVP_MD *digest,
                                       int keylen,
-                                      unsigned char* out) noexcept
+                                      unsigned char *out) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_PKCS5_PBKDF2_HMAC(
             pass, passlen, salt, saltlen, iter, digest, keylen, out);
 }
 
-int OpenSSLLib::SSL_ECDH_KDF_X9_63(unsigned char* out,
+int OpenSSLLib::SSL_ECDH_KDF_X9_63(unsigned char *out,
                                    size_t outlen,
-                                   const unsigned char* Z,
+                                   const unsigned char *Z,
                                    size_t Zlen,
-                                   const unsigned char* sinfo,
+                                   const unsigned char *sinfo,
                                    size_t sinfolen,
-                                   const EVP_MD* md) noexcept
+                                   const EVP_MD *md) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ECDH_KDF_X9_63(
             out, outlen, Z, Zlen, sinfo, sinfolen, md);
 }
 int OpenSSLLib::SSL_HMAC_Init_ex(
-        HMAC_CTX* ctx, const void* key, int key_len, const EVP_MD* md, ENGINE* impl) noexcept
+        HMAC_CTX *ctx, const void *key, int key_len, const EVP_MD *md, ENGINE *impl) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_HMAC_Init_ex(ctx, key, key_len, md, impl);
 }
-int OpenSSLLib::SSL_HMAC_Update(HMAC_CTX* ctx, const unsigned char* data, int len) noexcept
+int OpenSSLLib::SSL_HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, int len) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_HMAC_Update(ctx, data, len);
 }
-int OpenSSLLib::SSL_HMAC_Final(HMAC_CTX* ctx, unsigned char* md, unsigned int* len) noexcept
+int OpenSSLLib::SSL_HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_HMAC_Final(ctx, md, len);
 }
-HMAC_CTX* OpenSSLLib::SSL_HMAC_CTX_new() noexcept
+HMAC_CTX *OpenSSLLib::SSL_HMAC_CTX_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_HMAC_CTX_new();
 }
-void OpenSSLLib::SSL_HMAC_CTX_free(HMAC_CTX* ctx) noexcept
+void OpenSSLLib::SSL_HMAC_CTX_free(HMAC_CTX *ctx) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_HMAC_CTX_free(ctx);
 }
-int OpenSSLLib::SSL_EC_KEY_oct2key(EC_KEY* eckey, const unsigned char* buf, size_t len) noexcept
+int OpenSSLLib::SSL_EC_KEY_oct2key(EC_KEY *eckey, const unsigned char *buf, size_t len) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EC_KEY_oct2key(eckey, buf, len);
 }
-EC_KEY* OpenSSLLib::SSL_EC_KEY_new() noexcept
+EC_KEY *OpenSSLLib::SSL_EC_KEY_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EC_KEY_new();
 }
-void OpenSSLLib::SSL_EC_KEY_free(EC_KEY* key) noexcept
+void OpenSSLLib::SSL_EC_KEY_free(EC_KEY *key) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_EC_KEY_free(key);
 }
-EC_KEY* OpenSSLLib::SSL_EC_KEY_new_by_curve_name(int nid) noexcept
+EC_KEY *OpenSSLLib::SSL_EC_KEY_new_by_curve_name(int nid) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EC_KEY_new_by_curve_name(nid);
 }
-int OpenSSLLib::SSL_EVP_PKEY_set1_EC_KEY(EVP_PKEY* pkey, EC_KEY* key) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_set1_EC_KEY(pkey, key);
 }
-size_t OpenSSLLib::SSL_EC_KEY_key2buf(const EC_KEY* eckey,
+size_t OpenSSLLib::SSL_EC_KEY_key2buf(const EC_KEY *eckey,
                                       point_conversion_form_t form,
-                                      unsigned char** pbuf,
-                                      BN_CTX* ctx) noexcept
+                                      unsigned char **pbuf,
+                                      BN_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EC_KEY_key2buf(eckey, form, pbuf, ctx);
 }
-int OpenSSLLib::SSL_EVP_PKEY_derive_init(EVP_PKEY_CTX* ctx) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_derive_init(ctx);
 }
-int OpenSSLLib::SSL_EVP_PKEY_derive_set_peer(EVP_PKEY_CTX* ctx, EVP_PKEY* peer) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_derive_set_peer(ctx, peer);
 }
-int OpenSSLLib::SSL_EVP_PKEY_derive(EVP_PKEY_CTX* ctx, unsigned char* key, size_t* keylen) noexcept
+int OpenSSLLib::SSL_EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_derive(ctx, key, keylen);
 }
-BIGNUM* OpenSSLLib::SSL_BN_bin2bn(const unsigned char* s, int len, BIGNUM* ret) noexcept
+BIGNUM *OpenSSLLib::SSL_BN_bin2bn(const unsigned char *s, int len, BIGNUM *ret) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BN_bin2bn(s, len, ret);
 }
-ECDSA_SIG* OpenSSLLib::SSL_ECDSA_SIG_new() noexcept
+ECDSA_SIG *OpenSSLLib::SSL_ECDSA_SIG_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ECDSA_SIG_new();
 }
-void OpenSSLLib::SSL_ECDSA_SIG_free(ECDSA_SIG* sig) noexcept
+void OpenSSLLib::SSL_ECDSA_SIG_free(ECDSA_SIG *sig) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_ECDSA_SIG_free(sig);
 }
-int OpenSSLLib::SSL_ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s) noexcept
+int OpenSSLLib::SSL_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ECDSA_SIG_set0(sig, r, s);
 }
-int OpenSSLLib::SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char** pp) noexcept
+int OpenSSLLib::SSL_i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_i2d_ECDSA_SIG(sig, pp);
 }
-ECDSA_SIG* OpenSSLLib::SSL_d2i_ECDSA_SIG(ECDSA_SIG** sig,
-                                         const unsigned char** pp,
+ECDSA_SIG *OpenSSLLib::SSL_d2i_ECDSA_SIG(ECDSA_SIG **sig,
+                                         const unsigned char **pp,
                                          long len) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_d2i_ECDSA_SIG(sig, pp, len);
 }
-const BIGNUM* OpenSSLLib::SSL_ECDSA_SIG_get0_r(const ECDSA_SIG* sig) noexcept
+const BIGNUM *OpenSSLLib::SSL_ECDSA_SIG_get0_r(const ECDSA_SIG *sig) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ECDSA_SIG_get0_r(sig);
 }
-const BIGNUM* OpenSSLLib::SSL_ECDSA_SIG_get0_s(const ECDSA_SIG* sig) noexcept
+const BIGNUM *OpenSSLLib::SSL_ECDSA_SIG_get0_s(const ECDSA_SIG *sig) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ECDSA_SIG_get0_s(sig);
 }
-int OpenSSLLib::SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) noexcept
+int OpenSSLLib::SSL_BN_bn2binpad(const BIGNUM *a, unsigned char *to, int tolen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_BN_bn2binpad(a, to, tolen);
 }
 
 /* CMAC */
-CMAC_CTX* OpenSSLLib::SSL_CMAC_CTX_new() noexcept
+CMAC_CTX *OpenSSLLib::SSL_CMAC_CTX_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_CTX_new();
 }
-void OpenSSLLib::SSL_CMAC_CTX_cleanup(CMAC_CTX* ctx) noexcept
+void OpenSSLLib::SSL_CMAC_CTX_cleanup(CMAC_CTX *ctx) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_CMAC_CTX_cleanup(ctx);
 }
-void OpenSSLLib::SSL_CMAC_CTX_free(CMAC_CTX* ctx) noexcept
+void OpenSSLLib::SSL_CMAC_CTX_free(CMAC_CTX *ctx) noexcept
 {
     OpenSSLLibMockManager::getMockInterface().SSL_CMAC_CTX_free(ctx);
 }
-EVP_CIPHER_CTX* OpenSSLLib::SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX* ctx) noexcept
+EVP_CIPHER_CTX *OpenSSLLib::SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_CTX_get0_cipher_ctx(ctx);
 }
-int OpenSSLLib::SSL_CMAC_CTX_copy(CMAC_CTX* out, const CMAC_CTX* in) noexcept
+int OpenSSLLib::SSL_CMAC_CTX_copy(CMAC_CTX *out, const CMAC_CTX *in) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_CTX_copy(out, in);
 }
-int OpenSSLLib::SSL_CMAC_Init(CMAC_CTX* ctx,
-                              const void* key,
+int OpenSSLLib::SSL_CMAC_Init(CMAC_CTX *ctx,
+                              const void *key,
                               size_t keylen,
-                              const EVP_CIPHER* cipher,
-                              ENGINE* impl) noexcept
+                              const EVP_CIPHER *cipher,
+                              ENGINE *impl) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_Init(ctx, key, keylen, cipher, impl);
 }
-int OpenSSLLib::SSL_CMAC_Update(CMAC_CTX* ctx, const void* data, size_t dlen) noexcept
+int OpenSSLLib::SSL_CMAC_Update(CMAC_CTX *ctx, const void *data, size_t dlen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_Update(ctx, data, dlen);
 }
-int OpenSSLLib::SSL_CMAC_Final(CMAC_CTX* ctx, unsigned char* out, size_t* poutlen) noexcept
+int OpenSSLLib::SSL_CMAC_Final(CMAC_CTX *ctx, unsigned char *out, size_t *poutlen) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_Final(ctx, out, poutlen);
 }
-int OpenSSLLib::SSL_CMAC_resume(CMAC_CTX* ctx) noexcept
+int OpenSSLLib::SSL_CMAC_resume(CMAC_CTX *ctx) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_CMAC_resume(ctx);
 }
 
-int OpenSSLLib::SSL_EVP_CIPHER_key_length(const EVP_CIPHER* cipher) noexcept
+int OpenSSLLib::SSL_EVP_CIPHER_key_length(const EVP_CIPHER *cipher) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_key_length(cipher);
 }
-const char* OpenSSLLib::SSL_EVP_CIPHER_name(const EVP_CIPHER* cipher) noexcept
+const char *OpenSSLLib::SSL_EVP_CIPHER_name(const EVP_CIPHER *cipher) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_CIPHER_name(cipher);
 }
-EVP_PKEY* OpenSSLLib::SSL_ENGINE_load_private_key(ENGINE* e,
-                                                  const char* key_id,
-                                                  UI_METHOD* ui_method,
-                                                  void* callback_data) noexcept
+EVP_PKEY *OpenSSLLib::SSL_ENGINE_load_private_key(ENGINE *e,
+                                                  const char *key_id,
+                                                  UI_METHOD *ui_method,
+                                                  void *callback_data) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_load_private_key(
             e, key_id, ui_method, callback_data);
 }
-EVP_PKEY* OpenSSLLib::SSL_ENGINE_load_public_key(ENGINE* e,
-                                                 const char* key_id,
-                                                 UI_METHOD* ui_method,
-                                                 void* callback_data) noexcept
+EVP_PKEY *OpenSSLLib::SSL_ENGINE_load_public_key(ENGINE *e,
+                                                 const char *key_id,
+                                                 UI_METHOD *ui_method,
+                                                 void *callback_data) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_load_public_key(
             e, key_id, ui_method, callback_data);
 }
-int OpenSSLLib::SSL_ENGINE_ctrl_cmd_string(ENGINE* e,
-                                           const char* cmd_name,
-                                           const char* cmd_arg,
+int OpenSSLLib::SSL_ENGINE_ctrl_cmd_string(ENGINE *e,
+                                           const char *cmd_name,
+                                           const char *cmd_arg,
                                            int cmd_optional) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_ctrl_cmd_string(
             e, cmd_name, cmd_arg, cmd_optional);
 }
-int OpenSSLLib::SSL_ENGINE_init(ENGINE* e) noexcept
+int OpenSSLLib::SSL_ENGINE_init(ENGINE *e) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_init(e);
 }
-ENGINE* OpenSSLLib::SSL_ENGINE_by_id(const char* id) noexcept
+ENGINE *OpenSSLLib::SSL_ENGINE_by_id(const char *id) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_by_id(id);
 }
-int OpenSSLLib::SSL_ENGINE_finish(ENGINE* e) noexcept
+int OpenSSLLib::SSL_ENGINE_finish(ENGINE *e) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_finish(e);
 }
-int OpenSSLLib::SSL_ENGINE_free(ENGINE* e) noexcept
+int OpenSSLLib::SSL_ENGINE_free(ENGINE *e) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_free(e);
 }

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -35,136 +35,136 @@ namespace openssl
 class OpenSSLLibMockInterface
 {
 public:
-    virtual int SSL_ENGINE_free(ENGINE* e) = 0;
-    virtual int SSL_ENGINE_finish(ENGINE* e) = 0;
-    virtual ENGINE* SSL_ENGINE_by_id(const char* id) = 0;
-    virtual int SSL_ENGINE_init(ENGINE* e) = 0;
-    virtual int SSL_ENGINE_ctrl_cmd_string(ENGINE* e,
-                                           const char* cmd_name,
-                                           const char* cmd_arg,
+    virtual int SSL_ENGINE_free(ENGINE *e) = 0;
+    virtual int SSL_ENGINE_finish(ENGINE *e) = 0;
+    virtual ENGINE *SSL_ENGINE_by_id(const char *id) = 0;
+    virtual int SSL_ENGINE_init(ENGINE *e) = 0;
+    virtual int SSL_ENGINE_ctrl_cmd_string(ENGINE *e,
+                                           const char *cmd_name,
+                                           const char *cmd_arg,
                                            int cmd_optional) = 0;
-    virtual EVP_PKEY* SSL_ENGINE_load_public_key(ENGINE* e,
-                                                 const char* key_id,
-                                                 UI_METHOD* ui_method,
-                                                 void* callback_data) = 0;
-    virtual EVP_PKEY* SSL_ENGINE_load_private_key(ENGINE* e,
-                                                  const char* key_id,
-                                                  UI_METHOD* ui_method,
-                                                  void* callback_data) = 0;
-    virtual const char* SSL_EVP_CIPHER_name(const EVP_CIPHER* cipher) = 0;
-    virtual int SSL_EVP_CIPHER_key_length(const EVP_CIPHER* cipher) = 0;
-    virtual int SSL_BN_bn2binpad(const BIGNUM* a, unsigned char* to, int tolen) = 0;
-    virtual const BIGNUM* SSL_ECDSA_SIG_get0_s(const ECDSA_SIG* sig) = 0;
-    virtual const BIGNUM* SSL_ECDSA_SIG_get0_r(const ECDSA_SIG* sig) = 0;
-    virtual ECDSA_SIG* SSL_d2i_ECDSA_SIG(ECDSA_SIG** sig, const unsigned char** pp, long len) = 0;
-    virtual int SSL_EVP_PKEY_derive(EVP_PKEY_CTX* ctx, unsigned char* key, size_t* keylen) = 0;
-    virtual int SSL_EVP_PKEY_derive_set_peer(EVP_PKEY_CTX* ctx, EVP_PKEY* peer) = 0;
-    virtual int SSL_EVP_PKEY_derive_init(EVP_PKEY_CTX* ctx) = 0;
-    virtual size_t SSL_EC_KEY_key2buf(const EC_KEY* eckey,
+    virtual EVP_PKEY *SSL_ENGINE_load_public_key(ENGINE *e,
+                                                 const char *key_id,
+                                                 UI_METHOD *ui_method,
+                                                 void *callback_data) = 0;
+    virtual EVP_PKEY *SSL_ENGINE_load_private_key(ENGINE *e,
+                                                  const char *key_id,
+                                                  UI_METHOD *ui_method,
+                                                  void *callback_data) = 0;
+    virtual const char *SSL_EVP_CIPHER_name(const EVP_CIPHER *cipher) = 0;
+    virtual int SSL_EVP_CIPHER_key_length(const EVP_CIPHER *cipher) = 0;
+    virtual int SSL_BN_bn2binpad(const BIGNUM *a, unsigned char *to, int tolen) = 0;
+    virtual const BIGNUM *SSL_ECDSA_SIG_get0_s(const ECDSA_SIG *sig) = 0;
+    virtual const BIGNUM *SSL_ECDSA_SIG_get0_r(const ECDSA_SIG *sig) = 0;
+    virtual ECDSA_SIG *SSL_d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp, long len) = 0;
+    virtual int SSL_EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen) = 0;
+    virtual int SSL_EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer) = 0;
+    virtual int SSL_EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx) = 0;
+    virtual size_t SSL_EC_KEY_key2buf(const EC_KEY *eckey,
                                       point_conversion_form_t form,
-                                      unsigned char** pbuf,
-                                      BN_CTX* ctx) = 0;
-    virtual int SSL_EVP_PKEY_set1_EC_KEY(EVP_PKEY* pkey, EC_KEY* key) = 0;
-    virtual EC_KEY* SSL_EC_KEY_new_by_curve_name(int nid) = 0;
-    virtual void SSL_EC_KEY_free(EC_KEY* key) = 0;
-    virtual EC_KEY* SSL_EC_KEY_new() = 0;
-    virtual int SSL_EC_KEY_oct2key(EC_KEY* eckey, const unsigned char* buf, size_t len) = 0;
-    virtual int SSL_i2d_ECDSA_SIG(const ECDSA_SIG* sig, unsigned char** pp) = 0;
-    virtual int SSL_ECDSA_SIG_set0(ECDSA_SIG* sig, BIGNUM* r, BIGNUM* s) = 0;
-    virtual void SSL_ECDSA_SIG_free(ECDSA_SIG* sig) = 0;
-    virtual ECDSA_SIG* SSL_ECDSA_SIG_new() = 0;
-    virtual BIGNUM* SSL_BN_bin2bn(const unsigned char* s, int len, BIGNUM* ret) = 0;
-    virtual void SSL_HMAC_CTX_free(HMAC_CTX* ctx) = 0;
-    virtual HMAC_CTX* SSL_HMAC_CTX_new() = 0;
-    virtual int SSL_HMAC_Final(HMAC_CTX* ctx, unsigned char* md, unsigned int* len) = 0;
-    virtual int SSL_HMAC_Update(HMAC_CTX* ctx, const unsigned char* data, int len) = 0;
+                                      unsigned char **pbuf,
+                                      BN_CTX *ctx) = 0;
+    virtual int SSL_EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) = 0;
+    virtual EC_KEY *SSL_EC_KEY_new_by_curve_name(int nid) = 0;
+    virtual void SSL_EC_KEY_free(EC_KEY *key) = 0;
+    virtual EC_KEY *SSL_EC_KEY_new() = 0;
+    virtual int SSL_EC_KEY_oct2key(EC_KEY *eckey, const unsigned char *buf, size_t len) = 0;
+    virtual int SSL_i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp) = 0;
+    virtual int SSL_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) = 0;
+    virtual void SSL_ECDSA_SIG_free(ECDSA_SIG *sig) = 0;
+    virtual ECDSA_SIG *SSL_ECDSA_SIG_new() = 0;
+    virtual BIGNUM *SSL_BN_bin2bn(const unsigned char *s, int len, BIGNUM *ret) = 0;
+    virtual void SSL_HMAC_CTX_free(HMAC_CTX *ctx) = 0;
+    virtual HMAC_CTX *SSL_HMAC_CTX_new() = 0;
+    virtual int SSL_HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len) = 0;
+    virtual int SSL_HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, int len) = 0;
     virtual int SSL_HMAC_Init_ex(
-            HMAC_CTX* ctx, const void* key, int key_len, const EVP_MD* md, ENGINE* impl) = 0;
-    virtual int SSL_i2d_X509_REQ_bio(BIO* bp, X509_REQ* req) = 0;
-    virtual X509_REQ* SSL_d2i_X509_REQ_bio(BIO* bp, X509_REQ** req) = 0;
-    virtual int SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX* c, int pad) = 0;
-    virtual int SSL_EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX* c) = 0;
-    virtual int SSL_RAND_bytes(unsigned char* buf, int num) = 0;
-    virtual int SSL_EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX* ctx) = 0;
-    virtual int SSL_EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX* ctx) = 0;
-    virtual int SSL_EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX* ctx, int type, int arg, void* ptr) = 0;
-    virtual void SSL_EVP_CIPHER_CTX_free(EVP_CIPHER_CTX* c) = 0;
-    virtual EVP_CIPHER_CTX* SSL_EVP_CIPHER_CTX_new() = 0;
-    virtual int SSL_EVP_CipherInit_ex(EVP_CIPHER_CTX* ctx,
-                                      const EVP_CIPHER* cipher,
-                                      ENGINE* impl,
-                                      const unsigned char* key,
-                                      const unsigned char* iv,
+            HMAC_CTX *ctx, const void *key, int key_len, const EVP_MD *md, ENGINE *impl) = 0;
+    virtual int SSL_i2d_X509_REQ_bio(BIO *bp, X509_REQ *req) = 0;
+    virtual X509_REQ *SSL_d2i_X509_REQ_bio(BIO *bp, X509_REQ **req) = 0;
+    virtual int SSL_EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *c, int pad) = 0;
+    virtual int SSL_EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *c) = 0;
+    virtual int SSL_RAND_bytes(unsigned char *buf, int num) = 0;
+    virtual int SSL_EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx) = 0;
+    virtual int SSL_EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX *ctx) = 0;
+    virtual int SSL_EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr) = 0;
+    virtual void SSL_EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *c) = 0;
+    virtual EVP_CIPHER_CTX *SSL_EVP_CIPHER_CTX_new() = 0;
+    virtual int SSL_EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx,
+                                      const EVP_CIPHER *cipher,
+                                      ENGINE *impl,
+                                      const unsigned char *key,
+                                      const unsigned char *iv,
                                       int enc) = 0;
-    virtual int SSL_EVP_CipherFinal_ex(EVP_CIPHER_CTX* ctx, unsigned char* outm, int* outl) = 0;
-    virtual int SSL_EVP_CipherUpdate(EVP_CIPHER_CTX* ctx,
-                                     unsigned char* out,
-                                     int* outl,
-                                     const unsigned char* in,
+    virtual int SSL_EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl) = 0;
+    virtual int SSL_EVP_CipherUpdate(EVP_CIPHER_CTX *ctx,
+                                     unsigned char *out,
+                                     int *outl,
+                                     const unsigned char *in,
                                      int inl) = 0;
-    virtual int SSL_EVP_MD_CTX_reset(EVP_MD_CTX* ctx) = 0;
-    virtual int SSL_EVP_DigestFinal_ex(EVP_MD_CTX* ctx, unsigned char* md, unsigned int* s) = 0;
-    virtual int SSL_EVP_DigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt) = 0;
-    virtual int SSL_EVP_DigestInit_ex(EVP_MD_CTX* ctx, const EVP_MD* type, ENGINE* impl) = 0;
-    virtual void SSL_EVP_MD_CTX_init(EVP_MD_CTX* ctx) = 0;
-    virtual void SSL_X509_STORE_CTX_set_time(X509_STORE_CTX* ctx,
+    virtual int SSL_EVP_MD_CTX_reset(EVP_MD_CTX *ctx) = 0;
+    virtual int SSL_EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) = 0;
+    virtual int SSL_EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt) = 0;
+    virtual int SSL_EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl) = 0;
+    virtual void SSL_EVP_MD_CTX_init(EVP_MD_CTX *ctx) = 0;
+    virtual void SSL_X509_STORE_CTX_set_time(X509_STORE_CTX *ctx,
                                              unsigned long flags,
                                              time_t t) = 0;
-    virtual ASN1_TIME* SSL_ASN1_TIME_adj(ASN1_TIME* s,
+    virtual ASN1_TIME *SSL_ASN1_TIME_adj(ASN1_TIME *s,
                                          time_t t,
                                          int offset_day,
                                          long offset_sec) = 0;
-    virtual int SSL_sk_X509_CRL_push(STACK_OF(X509_CRL) * stack, const X509_CRL* crl) = 0;
+    virtual int SSL_sk_X509_CRL_push(STACK_OF(X509_CRL) * stack, const X509_CRL *crl) = 0;
     virtual STACK_OF(X509_CRL) * SSL_sk_X509_CRL_new_null() = 0;
     virtual void SSL_sk_X509_CRL_free(STACK_OF(X509_CRL) * stack) = 0;
-    virtual void SSL_X509_STORE_CTX_set0_crls(X509_STORE_CTX* ctx, STACK_OF(X509_CRL) * crls) = 0;
-    virtual X509_CRL* SSL_X509_CRL_new() = 0;
-    virtual void SSL_X509_CRL_free(X509_CRL* a) = 0;
-    virtual X509_CRL* SSL_d2i_X509_CRL_bio(BIO* bp, X509_CRL** crl) = 0;
-    virtual int SSL_PEM_write_bio_X509_CRL(BIO* bp, X509_CRL* x) = 0;
-    virtual X509_CRL* SSL_PEM_read_bio_X509_CRL(BIO* bp,
-                                                X509_CRL** x,
-                                                pem_password_cb* cb,
-                                                void* u) = 0;
-    virtual const ASN1_TIME* SSL_X509_CRL_get_lastUpdate(const X509_CRL* x) = 0;
-    virtual const ASN1_TIME* SSL_X509_CRL_get_nextUpdate(const X509_CRL* x) = 0;
-    virtual int SSL_X509_CRL_verify(X509_CRL* a, EVP_PKEY* r) = 0;
-    virtual X509_NAME* SSL_X509_CRL_get_issuer(const X509_CRL* crl) = 0;
-    virtual ASN1_STRING* SSL_ASN1_STRING_dup(const ASN1_STRING* str) = 0;
-    virtual ASN1_TIME* SSL_ASN1_TIME_new() = 0;
-    virtual int SSL_ASN1_TIME_set_string(ASN1_TIME* s, const char* str) = 0;
-    virtual int SSL_BN_num_bytes(const BIGNUM* a) = 0;
-    virtual int SSL_BN_bn2bin(const BIGNUM* a, unsigned char* to) = 0;
-    virtual ASN1_INTEGER* SSL_ASN1_INTEGER_new() = 0;
-    virtual void SSL_ASN1_INTEGER_free(ASN1_INTEGER* a) = 0;
-    virtual void* SSL_OPENSSL_malloc(int num) = 0;
-    virtual void SSL_OPENSSL_free(void* addr) = 0;
-    virtual char* SSL_BN_bn2dec(const BIGNUM* a) = 0;
-    virtual void SSL_BN_free(BIGNUM* a) = 0;
-    virtual BIGNUM* SSL_ASN1_INTEGER_to_BN(const ASN1_INTEGER* ai, BIGNUM* bn) = 0;
-    virtual int SSL_ASN1_INTEGER_cmp(const ASN1_INTEGER* x, const ASN1_INTEGER* y) = 0;
-    virtual long SSL_ASN1_INTEGER_get(const ASN1_INTEGER* a) = 0;
-    virtual int SSL_ASN1_INTEGER_set(ASN1_INTEGER* a, long value) = 0;
-    virtual ASN1_INTEGER* SSL_X509_get_serialNumber(X509* x) = 0;
-    virtual int SSL_X509_set_serialNumber(X509* x, ASN1_INTEGER* serial) = 0;
-    virtual void SSL_X509V3_set_ctx(X509V3_CTX* ctx,
-                                    X509* issuer,
-                                    X509* subject,
-                                    X509_REQ* req,
-                                    X509_CRL* crl,
+    virtual void SSL_X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx, STACK_OF(X509_CRL) * crls) = 0;
+    virtual X509_CRL *SSL_X509_CRL_new() = 0;
+    virtual void SSL_X509_CRL_free(X509_CRL *a) = 0;
+    virtual X509_CRL *SSL_d2i_X509_CRL_bio(BIO *bp, X509_CRL **crl) = 0;
+    virtual int SSL_PEM_write_bio_X509_CRL(BIO *bp, X509_CRL *x) = 0;
+    virtual X509_CRL *SSL_PEM_read_bio_X509_CRL(BIO *bp,
+                                                X509_CRL **x,
+                                                pem_password_cb *cb,
+                                                void *u) = 0;
+    virtual const ASN1_TIME *SSL_X509_CRL_get_lastUpdate(const X509_CRL *x) = 0;
+    virtual const ASN1_TIME *SSL_X509_CRL_get_nextUpdate(const X509_CRL *x) = 0;
+    virtual int SSL_X509_CRL_verify(X509_CRL *a, EVP_PKEY *r) = 0;
+    virtual X509_NAME *SSL_X509_CRL_get_issuer(const X509_CRL *crl) = 0;
+    virtual ASN1_STRING *SSL_ASN1_STRING_dup(const ASN1_STRING *str) = 0;
+    virtual ASN1_TIME *SSL_ASN1_TIME_new() = 0;
+    virtual int SSL_ASN1_TIME_set_string(ASN1_TIME *s, const char *str) = 0;
+    virtual int SSL_BN_num_bytes(const BIGNUM *a) = 0;
+    virtual int SSL_BN_bn2bin(const BIGNUM *a, unsigned char *to) = 0;
+    virtual ASN1_INTEGER *SSL_ASN1_INTEGER_new() = 0;
+    virtual void SSL_ASN1_INTEGER_free(ASN1_INTEGER *a) = 0;
+    virtual void *SSL_OPENSSL_malloc(int num) = 0;
+    virtual void SSL_OPENSSL_free(void *addr) = 0;
+    virtual char *SSL_BN_bn2dec(const BIGNUM *a) = 0;
+    virtual void SSL_BN_free(BIGNUM *a) = 0;
+    virtual BIGNUM *SSL_ASN1_INTEGER_to_BN(const ASN1_INTEGER *ai, BIGNUM *bn) = 0;
+    virtual int SSL_ASN1_INTEGER_cmp(const ASN1_INTEGER *x, const ASN1_INTEGER *y) = 0;
+    virtual long SSL_ASN1_INTEGER_get(const ASN1_INTEGER *a) = 0;
+    virtual int SSL_ASN1_INTEGER_set(ASN1_INTEGER *a, long value) = 0;
+    virtual ASN1_INTEGER *SSL_X509_get_serialNumber(X509 *x) = 0;
+    virtual int SSL_X509_set_serialNumber(X509 *x, ASN1_INTEGER *serial) = 0;
+    virtual void SSL_X509V3_set_ctx(X509V3_CTX *ctx,
+                                    X509 *issuer,
+                                    X509 *subject,
+                                    X509_REQ *req,
+                                    X509_CRL *crl,
                                     int flags) = 0;
-    virtual void SSL_X509V3_set_ctx_nodb(X509V3_CTX* ctx) = 0;
-    virtual void SSL_X509_EXTENSION_free(X509_EXTENSION* a) = 0;
-    virtual int SSL_X509_add_ext(X509* x, X509_EXTENSION* ex, int loc) = 0;
-    virtual X509_EXTENSION* SSL_X509V3_EXT_conf_nid(lhash_st_CONF_VALUE* conf,
-                                                    X509V3_CTX* ctx,
+    virtual void SSL_X509V3_set_ctx_nodb(X509V3_CTX *ctx) = 0;
+    virtual void SSL_X509_EXTENSION_free(X509_EXTENSION *a) = 0;
+    virtual int SSL_X509_add_ext(X509 *x, X509_EXTENSION *ex, int loc) = 0;
+    virtual X509_EXTENSION *SSL_X509V3_EXT_conf_nid(lhash_st_CONF_VALUE *conf,
+                                                    X509V3_CTX *ctx,
                                                     int ext_nid,
-                                                    char* value) = 0;
-    virtual const EVP_CIPHER* SSL_EVP_aes_128_cbc() = 0;
-    virtual const EVP_CIPHER* SSL_EVP_aes_256_cbc() = 0;
-    virtual int SSL_BIO_write(BIO* b, const void* buf, int len) = 0;
-    virtual int SSL_BIO_read(BIO* b, void* buf, int len) = 0;
-    virtual BIO* SSL_BIO_new_file(const char* filename, const char* mode) = 0;
+                                                    char *value) = 0;
+    virtual const EVP_CIPHER *SSL_EVP_aes_128_cbc() = 0;
+    virtual const EVP_CIPHER *SSL_EVP_aes_256_cbc() = 0;
+    virtual int SSL_BIO_write(BIO *b, const void *buf, int len) = 0;
+    virtual int SSL_BIO_read(BIO *b, void *buf, int len) = 0;
+    virtual BIO *SSL_BIO_new_file(const char *filename, const char *mode) = 0;
     virtual ~OpenSSLLibMockInterface() = default;
 
     /* Initialization */
@@ -174,236 +174,236 @@ public:
     virtual void SSL_CRYPTO_malloc_init() = 0;
 
     /* Key Generation */
-    virtual EVP_PKEY* SSL_EVP_PKEY_new() = 0;
-    virtual void SSL_EVP_PKEY_free(EVP_PKEY* ptr) = 0;
-    virtual int SSL_EVP_PKEY_keygen(EVP_PKEY_CTX* ctx, EVP_PKEY** ppkey) = 0;
-    virtual int SSL_EVP_PKEY_keygen_init(EVP_PKEY_CTX* ctx) = 0;
+    virtual EVP_PKEY *SSL_EVP_PKEY_new() = 0;
+    virtual void SSL_EVP_PKEY_free(EVP_PKEY *ptr) = 0;
+    virtual int SSL_EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) = 0;
+    virtual int SSL_EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx) = 0;
 
-    virtual EVP_PKEY_CTX* SSL_EVP_PKEY_CTX_new(EVP_PKEY* pkey, ENGINE* engine) = 0;
-    virtual EVP_PKEY_CTX* SSL_EVP_PKEY_CTX_new_id(int id, ENGINE* engine) = 0;
-    virtual void SSL_EVP_PKEY_CTX_free(EVP_PKEY_CTX* ptr) = 0;
-    virtual int SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits) = 0;
+    virtual EVP_PKEY_CTX *SSL_EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *engine) = 0;
+    virtual EVP_PKEY_CTX *SSL_EVP_PKEY_CTX_new_id(int id, ENGINE *engine) = 0;
+    virtual void SSL_EVP_PKEY_CTX_free(EVP_PKEY_CTX *ptr) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX *ctx, int mbits) = 0;
 
-    virtual int SSL_EVP_PKEY_cmp(const EVP_PKEY* a, const EVP_PKEY* b) = 0;
+    virtual int SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) = 0;
 
-    virtual int SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX* ctx) = 0;
-    virtual int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX* ctx, EVP_PKEY** ppkey) = 0;
-    virtual int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX* ctx, int nid) = 0;
-    virtual int SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX* ctx, int param_enc) = 0;
-    virtual const EC_GROUP* SSL_EC_KEY_get0_group(const EC_KEY* key) = 0;
-    virtual int SSL_EC_GROUP_get_degree(const EC_GROUP* group) = 0;
-    virtual int SSL_EC_GROUP_get_curve_name(const EC_GROUP* group) = 0;
+    virtual int SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) = 0;
+    virtual int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) = 0;
+    virtual const EC_GROUP *SSL_EC_KEY_get0_group(const EC_KEY *key) = 0;
+    virtual int SSL_EC_GROUP_get_degree(const EC_GROUP *group) = 0;
+    virtual int SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) = 0;
     virtual int SSL_EVP_PKEY_type(int type) = 0;
-    virtual int SSL_EVP_PKEY_id(const EVP_PKEY* pkey) = 0;
-    virtual int SSL_EVP_PKEY_size(EVP_PKEY* pkey) = 0;
+    virtual int SSL_EVP_PKEY_id(const EVP_PKEY *pkey) = 0;
+    virtual int SSL_EVP_PKEY_size(EVP_PKEY *pkey) = 0;
 
     /* Error handling */
-    virtual char* SSL_ERR_error_string(unsigned long error, char* buf) = 0;
+    virtual char *SSL_ERR_error_string(unsigned long error, char *buf) = 0;
     virtual unsigned long SSL_ERR_get_error() = 0;
 
     /* X509_NAME related things */
-    virtual X509_NAME* SSL_X509_NAME_new() = 0;
-    virtual void SSL_X509_NAME_free(X509_NAME*) = 0;
-    virtual int SSL_X509_NAME_add_entry_by_NID(X509_NAME* name,
+    virtual X509_NAME *SSL_X509_NAME_new() = 0;
+    virtual void SSL_X509_NAME_free(X509_NAME *) = 0;
+    virtual int SSL_X509_NAME_add_entry_by_NID(X509_NAME *name,
                                                int nid,
                                                int type,
-                                               unsigned char* bytes,
+                                               unsigned char *bytes,
                                                int len,
                                                int loc,
                                                int set) = 0;
-    virtual int SSL_X509_NAME_get_index_by_NID(X509_NAME* name, int nid, int lastpos) = 0;
-    virtual X509_NAME_ENTRY* SSL_X509_NAME_get_entry(X509_NAME* name, int loc) = 0;
+    virtual int SSL_X509_NAME_get_index_by_NID(X509_NAME *name, int nid, int lastpos) = 0;
+    virtual X509_NAME_ENTRY *SSL_X509_NAME_get_entry(X509_NAME *name, int loc) = 0;
 
     /* X509_NAME_ENTRY */
-    virtual ASN1_STRING* SSL_X509_NAME_ENTRY_get_data(X509_NAME_ENTRY* ne) = 0;
+    virtual ASN1_STRING *SSL_X509_NAME_ENTRY_get_data(X509_NAME_ENTRY *ne) = 0;
 
     /* ASN1_STRING */
-    virtual int SSL_ASN1_STRING_print_ex(BIO* out, ASN1_STRING* str, unsigned long flags) = 0;
+    virtual int SSL_ASN1_STRING_print_ex(BIO *out, ASN1_STRING *str, unsigned long flags) = 0;
 
     /* X509_REQ */
-    virtual void SSL_X509_REQ_free(X509_REQ* ptr) = 0;
-    virtual X509_REQ* SSL_X509_REQ_new() = 0;
-    virtual int SSL_X509_REQ_set_subject_name(X509_REQ* req, X509_NAME* name) = 0;
-    virtual int SSL_X509_REQ_set_pubkey(X509_REQ* x, EVP_PKEY* pkey) = 0;
-    virtual int SSL_X509_REQ_set_version(X509_REQ* req, unsigned long version) = 0;
-    virtual int SSL_X509_REQ_sign_ctx(X509_REQ*, EVP_MD_CTX*) = 0;
-    virtual X509_NAME* SSL_X509_REQ_get_subject_name(const X509_REQ* req) = 0;
-    virtual EVP_PKEY* SSL_X509_REQ_get_pubkey(X509_REQ* req) = 0;
-    virtual int SSL_X509_REQ_verify(X509_REQ* a, EVP_PKEY* r) = 0;
+    virtual void SSL_X509_REQ_free(X509_REQ *ptr) = 0;
+    virtual X509_REQ *SSL_X509_REQ_new() = 0;
+    virtual int SSL_X509_REQ_set_subject_name(X509_REQ *req, X509_NAME *name) = 0;
+    virtual int SSL_X509_REQ_set_pubkey(X509_REQ *x, EVP_PKEY *pkey) = 0;
+    virtual int SSL_X509_REQ_set_version(X509_REQ *req, unsigned long version) = 0;
+    virtual int SSL_X509_REQ_sign_ctx(X509_REQ *, EVP_MD_CTX *) = 0;
+    virtual X509_NAME *SSL_X509_REQ_get_subject_name(const X509_REQ *req) = 0;
+    virtual EVP_PKEY *SSL_X509_REQ_get_pubkey(X509_REQ *req) = 0;
+    virtual int SSL_X509_REQ_verify(X509_REQ *a, EVP_PKEY *r) = 0;
 
     /* X509 */
-    virtual X509* SSL_X509_new() = 0;
-    virtual int SSL_X509_set_pubkey(X509* ptr, EVP_PKEY* pkey) = 0;
-    virtual int SSL_X509_set_issuer_name(X509* x, X509_NAME* name) = 0;
-    virtual int SSL_X509_set_subject_name(X509* x, X509_NAME* name) = 0;
-    virtual int SSL_X509_set_notBefore(X509* x, const ASN1_TIME* t) = 0;
-    virtual int SSL_X509_set_notAfter(X509* x, const ASN1_TIME* t) = 0;
-    virtual int SSL_X509_sign(X509* x, EVP_PKEY* pkey, const EVP_MD* md) = 0;
-    virtual void SSL_X509_free(X509* ptr) = 0;
-    virtual X509_NAME* SSL_X509_get_subject_name(X509* ptr) = 0;
-    virtual X509_NAME* SSL_X509_get_issuer_name(X509* ptr) = 0;
-    virtual EVP_PKEY* SSL_X509_get_pubkey(X509* x) = 0;
-    virtual ASN1_TIME* SSL_X509_get_notBefore(X509* x) = 0;
-    virtual ASN1_TIME* SSL_X509_get_notAfter(X509* x) = 0;
+    virtual X509 *SSL_X509_new() = 0;
+    virtual int SSL_X509_set_pubkey(X509 *ptr, EVP_PKEY *pkey) = 0;
+    virtual int SSL_X509_set_issuer_name(X509 *x, X509_NAME *name) = 0;
+    virtual int SSL_X509_set_subject_name(X509 *x, X509_NAME *name) = 0;
+    virtual int SSL_X509_set_notBefore(X509 *x, const ASN1_TIME *t) = 0;
+    virtual int SSL_X509_set_notAfter(X509 *x, const ASN1_TIME *t) = 0;
+    virtual int SSL_X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md) = 0;
+    virtual void SSL_X509_free(X509 *ptr) = 0;
+    virtual X509_NAME *SSL_X509_get_subject_name(X509 *ptr) = 0;
+    virtual X509_NAME *SSL_X509_get_issuer_name(X509 *ptr) = 0;
+    virtual EVP_PKEY *SSL_X509_get_pubkey(X509 *x) = 0;
+    virtual ASN1_TIME *SSL_X509_get_notBefore(X509 *x) = 0;
+    virtual ASN1_TIME *SSL_X509_get_notAfter(X509 *x) = 0;
 
     /* ASN1_TIME */
-    virtual void SSL_ASN1_TIME_free(ASN1_TIME* x) = 0;
-    virtual int SSL_ASN1_TIME_diff(int* pday,
-                                   int* psec,
-                                   const ASN1_TIME* from,
-                                   const ASN1_TIME* to) = 0;
-    virtual ASN1_TIME* SSL_ASN1_TIME_set(ASN1_TIME* s, time_t t) = 0;
+    virtual void SSL_ASN1_TIME_free(ASN1_TIME *x) = 0;
+    virtual int SSL_ASN1_TIME_diff(int *pday,
+                                   int *psec,
+                                   const ASN1_TIME *from,
+                                   const ASN1_TIME *to) = 0;
+    virtual ASN1_TIME *SSL_ASN1_TIME_set(ASN1_TIME *s, time_t t) = 0;
 
     /* BIO Stuff */
-    virtual const BIO_METHOD* SSL_BIO_s_mem() = 0;
-    virtual void SSL_BIO_free_all(BIO* ptr) = 0;
-    virtual BIO* SSL_BIO_new(const BIO_METHOD* method) = 0;
-    virtual int SSL_BIO_gets(BIO* bio, char* bug, int size) = 0;
-    virtual int SSL_BIO_puts(BIO* bio, char* buf) = 0;
-    virtual int SSL_PEM_write_bio_X509_REQ(BIO* bio, X509_REQ* req) = 0;
-    virtual X509_REQ* SSL_PEM_read_bio_X509_REQ(BIO* bp,
-                                                X509_REQ** x,
-                                                pem_password_cb* cb,
-                                                void* u) = 0;
-    virtual int SSL_PEM_write_bio_PKCS8PrivateKey(BIO* bp,
-                                                  EVP_PKEY* x,
-                                                  const EVP_CIPHER* enc,
-                                                  char* kstr,
+    virtual const BIO_METHOD *SSL_BIO_s_mem() = 0;
+    virtual void SSL_BIO_free_all(BIO *ptr) = 0;
+    virtual BIO *SSL_BIO_new(const BIO_METHOD *method) = 0;
+    virtual int SSL_BIO_gets(BIO *bio, char *bug, int size) = 0;
+    virtual int SSL_BIO_puts(BIO *bio, char *buf) = 0;
+    virtual int SSL_PEM_write_bio_X509_REQ(BIO *bio, X509_REQ *req) = 0;
+    virtual X509_REQ *SSL_PEM_read_bio_X509_REQ(BIO *bp,
+                                                X509_REQ **x,
+                                                pem_password_cb *cb,
+                                                void *u) = 0;
+    virtual int SSL_PEM_write_bio_PKCS8PrivateKey(BIO *bp,
+                                                  EVP_PKEY *x,
+                                                  const EVP_CIPHER *enc,
+                                                  char *kstr,
                                                   int klen,
-                                                  pem_password_cb* cb,
-                                                  void* u) = 0;
-    virtual int SSL_PEM_write_bio_PUBKEY(BIO* bp, EVP_PKEY* x) = 0;
-    virtual EVP_PKEY* SSL_PEM_read_bio_PUBKEY(BIO* bio,
-                                              EVP_PKEY** pkey,
-                                              pem_password_cb* cb,
-                                              void* u) = 0;
+                                                  pem_password_cb *cb,
+                                                  void *u) = 0;
+    virtual int SSL_PEM_write_bio_PUBKEY(BIO *bp, EVP_PKEY *x) = 0;
+    virtual EVP_PKEY *SSL_PEM_read_bio_PUBKEY(BIO *bio,
+                                              EVP_PKEY **pkey,
+                                              pem_password_cb *cb,
+                                              void *u) = 0;
 
-    virtual EVP_PKEY* SSL_PEM_read_bio_PrivateKey(BIO* bio,
-                                                  EVP_PKEY** pkey,
-                                                  pem_password_cb* cb,
-                                                  void* u) = 0;
-    virtual X509* SSL_PEM_read_bio_X509(BIO* bio, X509**, pem_password_cb*, void*) = 0;
-    virtual int SSL_PEM_write_bio_X509(BIO* bp, X509* x) = 0;
-    virtual X509* SSL_d2i_X509_bio(BIO* bp, X509** x509) = 0;
-    virtual int SSL_i2d_X509_bio(BIO* bp, X509* x) = 0;
+    virtual EVP_PKEY *SSL_PEM_read_bio_PrivateKey(BIO *bio,
+                                                  EVP_PKEY **pkey,
+                                                  pem_password_cb *cb,
+                                                  void *u) = 0;
+    virtual X509 *SSL_PEM_read_bio_X509(BIO *bio, X509 **, pem_password_cb *, void *) = 0;
+    virtual int SSL_PEM_write_bio_X509(BIO *bp, X509 *x) = 0;
+    virtual X509 *SSL_d2i_X509_bio(BIO *bp, X509 **x509) = 0;
+    virtual int SSL_i2d_X509_bio(BIO *bp, X509 *x) = 0;
 
     /* EVP_MD */
-    virtual EVP_MD_CTX* SSL_EVP_MD_CTX_create() = 0;
-    virtual void SSL_EVP_MD_CTX_destroy(EVP_MD_CTX* ptr) = 0;
+    virtual EVP_MD_CTX *SSL_EVP_MD_CTX_create() = 0;
+    virtual void SSL_EVP_MD_CTX_destroy(EVP_MD_CTX *ptr) = 0;
     virtual int SSL_EVP_DigestSignInit(
-            EVP_MD_CTX* ctx, EVP_PKEY_CTX**, const EVP_MD*, ENGINE*, EVP_PKEY*) = 0;
-    virtual int SSL_EVP_DigestSign(EVP_MD_CTX* ctx,
-                                   unsigned char* sigret,
-                                   size_t* siglen,
-                                   const unsigned char* tbs,
+            EVP_MD_CTX *ctx, EVP_PKEY_CTX **, const EVP_MD *, ENGINE *, EVP_PKEY *) = 0;
+    virtual int SSL_EVP_DigestSign(EVP_MD_CTX *ctx,
+                                   unsigned char *sigret,
+                                   size_t *siglen,
+                                   const unsigned char *tbs,
                                    size_t tbslen) = 0;
-    virtual int SSL_EVP_DigestVerifyInit(EVP_MD_CTX* ctx,
-                                         EVP_PKEY_CTX** pctx,
-                                         const EVP_MD* type,
-                                         ENGINE* e,
-                                         EVP_PKEY* pkey) = 0;
-    virtual int SSL_EVP_DigestVerify(EVP_MD_CTX* ctx,
-                                     const unsigned char* sigret,
+    virtual int SSL_EVP_DigestVerifyInit(EVP_MD_CTX *ctx,
+                                         EVP_PKEY_CTX **pctx,
+                                         const EVP_MD *type,
+                                         ENGINE *e,
+                                         EVP_PKEY *pkey) = 0;
+    virtual int SSL_EVP_DigestVerify(EVP_MD_CTX *ctx,
+                                     const unsigned char *sigret,
                                      size_t siglen,
-                                     const unsigned char* tbs,
+                                     const unsigned char *tbs,
                                      size_t tbslen) = 0;
-    virtual const EVP_MD* SSL_EVP_sha1() = 0;
-    virtual const EVP_MD* SSL_EVP_sha256() = 0;
-    virtual const EVP_MD* SSL_EVP_sha384() = 0;
-    virtual const EVP_MD* SSL_EVP_sha512() = 0;
-    virtual const EVP_MD* SSL_EVP_sha3_256() = 0;
-    virtual const EVP_MD* SSL_EVP_sha3_384() = 0;
-    virtual const EVP_MD* SSL_EVP_sha3_512() = 0;
+    virtual const EVP_MD *SSL_EVP_sha1() = 0;
+    virtual const EVP_MD *SSL_EVP_sha256() = 0;
+    virtual const EVP_MD *SSL_EVP_sha384() = 0;
+    virtual const EVP_MD *SSL_EVP_sha512() = 0;
+    virtual const EVP_MD *SSL_EVP_sha3_256() = 0;
+    virtual const EVP_MD *SSL_EVP_sha3_384() = 0;
+    virtual const EVP_MD *SSL_EVP_sha3_512() = 0;
 
     /* X509 Certificate validation */
-    virtual X509_STORE* SSL_X509_STORE_new() = 0;
-    virtual void SSL_X509_STORE_free(X509_STORE* v) = 0;
-    virtual int SSL_X509_STORE_add_cert(X509_STORE* ctx, X509* x) = 0;
+    virtual X509_STORE *SSL_X509_STORE_new() = 0;
+    virtual void SSL_X509_STORE_free(X509_STORE *v) = 0;
+    virtual int SSL_X509_STORE_add_cert(X509_STORE *ctx, X509 *x) = 0;
 
-    virtual X509_STORE_CTX* SSL_X509_STORE_CTX_new() = 0;
-    virtual void SSL_X509_STORE_CTX_free(X509_STORE_CTX* ctx) = 0;
-    virtual int SSL_X509_STORE_CTX_init(X509_STORE_CTX* ctx,
-                                        X509_STORE* store,
-                                        X509* x509,
+    virtual X509_STORE_CTX *SSL_X509_STORE_CTX_new() = 0;
+    virtual void SSL_X509_STORE_CTX_free(X509_STORE_CTX *ctx) = 0;
+    virtual int SSL_X509_STORE_CTX_init(X509_STORE_CTX *ctx,
+                                        X509_STORE *store,
+                                        X509 *x509,
                                         STACK_OF(X509) * chain) = 0;
 
-    virtual X509_VERIFY_PARAM* SSL_X509_STORE_CTX_get0_param(X509_STORE_CTX* ctx) = 0;
-    virtual int SSL_X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM* param, unsigned long flags) = 0;
+    virtual X509_VERIFY_PARAM *SSL_X509_STORE_CTX_get0_param(X509_STORE_CTX *ctx) = 0;
+    virtual int SSL_X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param, unsigned long flags) = 0;
 
-    virtual int SSL_X509_verify_cert(X509_STORE_CTX* ctx) = 0;
-    virtual const char* SSL_X509_verify_cert_error_string(long n) = 0;
-    virtual int SSL_X509_STORE_CTX_get_error(X509_STORE_CTX* ctx) = 0;
+    virtual int SSL_X509_verify_cert(X509_STORE_CTX *ctx) = 0;
+    virtual const char *SSL_X509_verify_cert_error_string(long n) = 0;
+    virtual int SSL_X509_STORE_CTX_get_error(X509_STORE_CTX *ctx) = 0;
 
-    virtual int SSL_X509_check_ca(X509* cert) = 0;
+    virtual int SSL_X509_check_ca(X509 *cert) = 0;
 
     /* stack of X509 */
     virtual STACK_OF(X509) * SSL_sk_X509_new_null() = 0;
-    virtual int SSL_sk_X509_push(STACK_OF(X509) * stack, const X509* crt) = 0;
+    virtual int SSL_sk_X509_push(STACK_OF(X509) * stack, const X509 *crt) = 0;
     virtual void SSL_sk_X509_free(STACK_OF(X509) * stack) = 0;
 
     /* Signatures */
-    virtual int SSL_EVP_PKEY_sign(EVP_PKEY_CTX* ctx,
-                                  unsigned char* sig,
-                                  size_t* siglen,
-                                  const unsigned char* tbs,
+    virtual int SSL_EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
+                                  unsigned char *sig,
+                                  size_t *siglen,
+                                  const unsigned char *tbs,
                                   size_t tbslen) = 0;
-    virtual int SSL_EVP_PKEY_sign_init(EVP_PKEY_CTX* ctx) = 0;
-    virtual int SSL_EVP_PKEY_verify_init(EVP_PKEY_CTX* ctx) = 0;
-    virtual int SSL_EVP_PKEY_verify(EVP_PKEY_CTX* ctx,
-                                    const unsigned char* sig,
+    virtual int SSL_EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx) = 0;
+    virtual int SSL_EVP_PKEY_verify_init(EVP_PKEY_CTX *ctx) = 0;
+    virtual int SSL_EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
+                                    const unsigned char *sig,
                                     size_t siglen,
-                                    const unsigned char* tbs,
+                                    const unsigned char *tbs,
                                     size_t tbslen) = 0;
-    virtual int SSL_EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX* ctx, int pad) = 0;
-    virtual int SSL_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) = 0;
-    virtual int SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX* ctx, int len) = 0;
-    virtual int SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) = 0;
-    virtual EC_KEY* SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY* pkey) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen(EVP_PKEY_CTX *ctx, int len) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) = 0;
+    virtual EC_KEY *SSL_EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) = 0;
 
     /* Encryption */
-    virtual int SSL_EVP_PKEY_encrypt_init(EVP_PKEY_CTX* ctx) = 0;
-    virtual int SSL_EVP_PKEY_encrypt(EVP_PKEY_CTX* ctx,
-                                     unsigned char* out,
-                                     size_t* outlen,
-                                     const unsigned char* in,
+    virtual int SSL_EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx) = 0;
+    virtual int SSL_EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
+                                     unsigned char *out,
+                                     size_t *outlen,
+                                     const unsigned char *in,
                                      size_t inlen) = 0;
-    virtual int SSL_EVP_PKEY_decrypt_init(EVP_PKEY_CTX* ctx) = 0;
-    virtual int SSL_EVP_PKEY_decrypt(EVP_PKEY_CTX* ctx,
-                                     unsigned char* out,
-                                     size_t* outlen,
-                                     const unsigned char* in,
+    virtual int SSL_EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx) = 0;
+    virtual int SSL_EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
+                                     unsigned char *out,
+                                     size_t *outlen,
+                                     const unsigned char *in,
                                      size_t inlen) = 0;
-    virtual int SSL_EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX* ctx, const EVP_MD* md) = 0;
-    virtual int SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX* ctx,
-                                                    unsigned char* l,
+    virtual int SSL_EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_rsa_oaep_label(EVP_PKEY_CTX *ctx,
+                                                    unsigned char *l,
                                                     int llen) = 0;
-    virtual int SSL_RSA_size(const RSA* r) = 0;
-    virtual int SSL_EVP_MD_size(const EVP_MD* md) = 0;
+    virtual int SSL_RSA_size(const RSA *r) = 0;
+    virtual int SSL_EVP_MD_size(const EVP_MD *md) = 0;
 
     /* KDF */
-    virtual int SSL_PKCS5_PBKDF2_HMAC(const char* pass,
+    virtual int SSL_PKCS5_PBKDF2_HMAC(const char *pass,
                                       int passlen,
-                                      const unsigned char* salt,
+                                      const unsigned char *salt,
                                       int saltlen,
                                       int iter,
-                                      const EVP_MD* digest,
+                                      const EVP_MD *digest,
                                       int keylen,
-                                      unsigned char* out) = 0;
+                                      unsigned char *out) = 0;
 
     /* CMAC */
-    virtual CMAC_CTX* SSL_CMAC_CTX_new() = 0;
-    virtual void SSL_CMAC_CTX_cleanup(CMAC_CTX* ctx) = 0;
-    virtual void SSL_CMAC_CTX_free(CMAC_CTX* ctx) = 0;
-    virtual EVP_CIPHER_CTX* SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX* ctx) = 0;
-    virtual int SSL_CMAC_CTX_copy(CMAC_CTX* out, const CMAC_CTX* in) = 0;
-    virtual int SSL_CMAC_Init(CMAC_CTX* ctx,
-                              const void* key,
+    virtual CMAC_CTX *SSL_CMAC_CTX_new() = 0;
+    virtual void SSL_CMAC_CTX_cleanup(CMAC_CTX *ctx) = 0;
+    virtual void SSL_CMAC_CTX_free(CMAC_CTX *ctx) = 0;
+    virtual EVP_CIPHER_CTX *SSL_CMAC_CTX_get0_cipher_ctx(CMAC_CTX *ctx) = 0;
+    virtual int SSL_CMAC_CTX_copy(CMAC_CTX *out, const CMAC_CTX *in) = 0;
+    virtual int SSL_CMAC_Init(CMAC_CTX *ctx,
+                              const void *key,
                               size_t keylen,
-                              const EVP_CIPHER* cipher,
-                              ENGINE* impl) = 0;
-    virtual int SSL_CMAC_Update(CMAC_CTX* ctx, const void* data, size_t dlen) = 0;
-    virtual int SSL_CMAC_Final(CMAC_CTX* ctx, unsigned char* out, size_t* poutlen) = 0;
-    virtual int SSL_CMAC_resume(CMAC_CTX* ctx) = 0;
+                              const EVP_CIPHER *cipher,
+                              ENGINE *impl) = 0;
+    virtual int SSL_CMAC_Update(CMAC_CTX *ctx, const void *data, size_t dlen) = 0;
+    virtual int SSL_CMAC_Final(CMAC_CTX *ctx, unsigned char *out, size_t *poutlen) = 0;
+    virtual int SSL_CMAC_resume(CMAC_CTX *ctx) = 0;
 };
 
 /**
@@ -413,305 +413,313 @@ public:
 class OpenSSLLibMock : public OpenSSLLibMockInterface
 {
 public:
-    MOCK_METHOD1(SSL_ENGINE_free, int(ENGINE*));
-    MOCK_METHOD1(SSL_ENGINE_finish, int(ENGINE*));
-    MOCK_METHOD1(SSL_ENGINE_by_id, ENGINE*(const char*));
-    MOCK_METHOD1(SSL_ENGINE_init, int(ENGINE*));
-    MOCK_METHOD4(SSL_ENGINE_ctrl_cmd_string, int(ENGINE*, const char*, const char*, int));
-    MOCK_METHOD4(SSL_ENGINE_load_public_key, EVP_PKEY*(ENGINE*, const char*, UI_METHOD*, void*));
-    MOCK_METHOD4(SSL_ENGINE_load_private_key, EVP_PKEY*(ENGINE*, const char*, UI_METHOD*, void*));
-    MOCK_METHOD1(SSL_EVP_CIPHER_name, const char*(const EVP_CIPHER*));
-    MOCK_METHOD1(SSL_EVP_CIPHER_key_length, int(const EVP_CIPHER*));
-    MOCK_METHOD3(SSL_BN_bn2binpad, int(const BIGNUM*, unsigned char*, int));
-    MOCK_METHOD1(SSL_ECDSA_SIG_get0_s, const BIGNUM*(const ECDSA_SIG*));
-    MOCK_METHOD1(SSL_ECDSA_SIG_get0_r, const BIGNUM*(const ECDSA_SIG*));
-    MOCK_METHOD3(SSL_d2i_ECDSA_SIG, ECDSA_SIG*(ECDSA_SIG**, const unsigned char**, long));
-    MOCK_METHOD3(SSL_EVP_PKEY_derive, int(EVP_PKEY_CTX*, unsigned char*, size_t*));
-    MOCK_METHOD2(SSL_EVP_PKEY_derive_set_peer, int(EVP_PKEY_CTX*, EVP_PKEY*));
-    MOCK_METHOD1(SSL_EVP_PKEY_derive_init, int(EVP_PKEY_CTX*));
+    MOCK_METHOD1(SSL_ENGINE_free, int(ENGINE *));
+    MOCK_METHOD1(SSL_ENGINE_finish, int(ENGINE *));
+    MOCK_METHOD1(SSL_ENGINE_by_id, ENGINE *(const char *));
+    MOCK_METHOD1(SSL_ENGINE_init, int(ENGINE *));
+    MOCK_METHOD4(SSL_ENGINE_ctrl_cmd_string, int(ENGINE *, const char *, const char *, int));
+    MOCK_METHOD4(SSL_ENGINE_load_public_key,
+                 EVP_PKEY *(ENGINE *, const char *, UI_METHOD *, void *));
+    MOCK_METHOD4(SSL_ENGINE_load_private_key,
+                 EVP_PKEY *(ENGINE *, const char *, UI_METHOD *, void *));
+    MOCK_METHOD1(SSL_EVP_CIPHER_name, const char *(const EVP_CIPHER *));
+    MOCK_METHOD1(SSL_EVP_CIPHER_key_length, int(const EVP_CIPHER *));
+    MOCK_METHOD3(SSL_BN_bn2binpad, int(const BIGNUM *, unsigned char *, int));
+    MOCK_METHOD1(SSL_ECDSA_SIG_get0_s, const BIGNUM *(const ECDSA_SIG *));
+    MOCK_METHOD1(SSL_ECDSA_SIG_get0_r, const BIGNUM *(const ECDSA_SIG *));
+    MOCK_METHOD3(SSL_d2i_ECDSA_SIG, ECDSA_SIG *(ECDSA_SIG **, const unsigned char **, long));
+    MOCK_METHOD3(SSL_EVP_PKEY_derive, int(EVP_PKEY_CTX *, unsigned char *, size_t *));
+    MOCK_METHOD2(SSL_EVP_PKEY_derive_set_peer, int(EVP_PKEY_CTX *, EVP_PKEY *));
+    MOCK_METHOD1(SSL_EVP_PKEY_derive_init, int(EVP_PKEY_CTX *));
     MOCK_METHOD4(SSL_EC_KEY_key2buf,
-                 size_t(const EC_KEY*, point_conversion_form_t, unsigned char**, BN_CTX*));
-    MOCK_METHOD2(SSL_EVP_PKEY_set1_EC_KEY, int(EVP_PKEY*, EC_KEY*));
-    MOCK_METHOD1(SSL_EC_KEY_new_by_curve_name, EC_KEY*(int));
-    MOCK_METHOD1(SSL_EC_KEY_free, void(EC_KEY*));
-    MOCK_METHOD0(SSL_EC_KEY_new, EC_KEY*());
-    MOCK_METHOD3(SSL_EC_KEY_oct2key, int(EC_KEY*, const unsigned char*, size_t));
-    MOCK_METHOD2(SSL_i2d_ECDSA_SIG, int(const ECDSA_SIG*, unsigned char**));
-    MOCK_METHOD3(SSL_ECDSA_SIG_set0, int(ECDSA_SIG*, BIGNUM*, BIGNUM*));
-    MOCK_METHOD1(SSL_ECDSA_SIG_set0, int(ECDSA_SIG*));
-    MOCK_METHOD1(SSL_ECDSA_SIG_free, void(ECDSA_SIG*));
-    MOCK_METHOD0(SSL_ECDSA_SIG_new, ECDSA_SIG*());
-    MOCK_METHOD3(SSL_BN_bin2bn, BIGNUM*(const unsigned char*, int, BIGNUM*));
-    MOCK_METHOD1(SSL_HMAC_CTX_free, void(HMAC_CTX*));
-    MOCK_METHOD0(SSL_HMAC_CTX_new, HMAC_CTX*());
-    MOCK_METHOD3(SSL_HMAC_Final, int(HMAC_CTX*, unsigned char*, unsigned int*));
-    MOCK_METHOD3(SSL_HMAC_Update, int(HMAC_CTX*, const unsigned char*, int));
-    MOCK_METHOD5(SSL_HMAC_Init_ex, int(HMAC_CTX*, const void*, int, const EVP_MD*, ENGINE*));
-    MOCK_METHOD2(SSL_i2d_X509_REQ_bio, int(BIO*, X509_REQ*));
-    MOCK_METHOD2(SSL_d2i_X509_REQ_bio, X509_REQ*(BIO*, X509_REQ**));
-    MOCK_METHOD2(SSL_EVP_CIPHER_CTX_set_padding, int(EVP_CIPHER_CTX*, int));
-    MOCK_METHOD1(SSL_EVP_CIPHER_CTX_reset, int(EVP_CIPHER_CTX*));
-    MOCK_METHOD2(SSL_RAND_bytes, int(unsigned char*, int));
-    MOCK_METHOD1(SSL_EVP_CIPHER_CTX_iv_length, int(const EVP_CIPHER_CTX*));
-    MOCK_METHOD1(SSL_EVP_CIPHER_CTX_key_length, int(const EVP_CIPHER_CTX*));
-    MOCK_METHOD4(SSL_EVP_CIPHER_CTX_ctrl, int(EVP_CIPHER_CTX*, int, int, void*));
-    MOCK_METHOD1(SSL_EVP_CIPHER_CTX_free, void(EVP_CIPHER_CTX*));
-    MOCK_METHOD0(SSL_EVP_CIPHER_CTX_new, EVP_CIPHER_CTX*());
+                 size_t(const EC_KEY *, point_conversion_form_t, unsigned char **, BN_CTX *));
+    MOCK_METHOD2(SSL_EVP_PKEY_set1_EC_KEY, int(EVP_PKEY *, EC_KEY *));
+    MOCK_METHOD1(SSL_EC_KEY_new_by_curve_name, EC_KEY *(int));
+    MOCK_METHOD1(SSL_EC_KEY_free, void(EC_KEY *));
+    MOCK_METHOD0(SSL_EC_KEY_new, EC_KEY *());
+    MOCK_METHOD3(SSL_EC_KEY_oct2key, int(EC_KEY *, const unsigned char *, size_t));
+    MOCK_METHOD2(SSL_i2d_ECDSA_SIG, int(const ECDSA_SIG *, unsigned char **));
+    MOCK_METHOD3(SSL_ECDSA_SIG_set0, int(ECDSA_SIG *, BIGNUM *, BIGNUM *));
+    MOCK_METHOD1(SSL_ECDSA_SIG_set0, int(ECDSA_SIG *));
+    MOCK_METHOD1(SSL_ECDSA_SIG_free, void(ECDSA_SIG *));
+    MOCK_METHOD0(SSL_ECDSA_SIG_new, ECDSA_SIG *());
+    MOCK_METHOD3(SSL_BN_bin2bn, BIGNUM *(const unsigned char *, int, BIGNUM *));
+    MOCK_METHOD1(SSL_HMAC_CTX_free, void(HMAC_CTX *));
+    MOCK_METHOD0(SSL_HMAC_CTX_new, HMAC_CTX *());
+    MOCK_METHOD3(SSL_HMAC_Final, int(HMAC_CTX *, unsigned char *, unsigned int *));
+    MOCK_METHOD3(SSL_HMAC_Update, int(HMAC_CTX *, const unsigned char *, int));
+    MOCK_METHOD5(SSL_HMAC_Init_ex, int(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *));
+    MOCK_METHOD2(SSL_i2d_X509_REQ_bio, int(BIO *, X509_REQ *));
+    MOCK_METHOD2(SSL_d2i_X509_REQ_bio, X509_REQ *(BIO *, X509_REQ **));
+    MOCK_METHOD2(SSL_EVP_CIPHER_CTX_set_padding, int(EVP_CIPHER_CTX *, int));
+    MOCK_METHOD1(SSL_EVP_CIPHER_CTX_reset, int(EVP_CIPHER_CTX *));
+    MOCK_METHOD2(SSL_RAND_bytes, int(unsigned char *, int));
+    MOCK_METHOD1(SSL_EVP_CIPHER_CTX_iv_length, int(const EVP_CIPHER_CTX *));
+    MOCK_METHOD1(SSL_EVP_CIPHER_CTX_key_length, int(const EVP_CIPHER_CTX *));
+    MOCK_METHOD4(SSL_EVP_CIPHER_CTX_ctrl, int(EVP_CIPHER_CTX *, int, int, void *));
+    MOCK_METHOD1(SSL_EVP_CIPHER_CTX_free, void(EVP_CIPHER_CTX *));
+    MOCK_METHOD0(SSL_EVP_CIPHER_CTX_new, EVP_CIPHER_CTX *());
     MOCK_METHOD6(SSL_EVP_CipherInit_ex,
-                 int(EVP_CIPHER_CTX*,
-                     const EVP_CIPHER*,
-                     ENGINE*,
-                     const unsigned char*,
-                     const unsigned char*,
+                 int(EVP_CIPHER_CTX *,
+                     const EVP_CIPHER *,
+                     ENGINE *,
+                     const unsigned char *,
+                     const unsigned char *,
                      int));
-    MOCK_METHOD3(SSL_EVP_CipherFinal_ex, int(EVP_CIPHER_CTX*, unsigned char*, int*));
+    MOCK_METHOD3(SSL_EVP_CipherFinal_ex, int(EVP_CIPHER_CTX *, unsigned char *, int *));
     MOCK_METHOD5(SSL_EVP_CipherUpdate,
-                 int(EVP_CIPHER_CTX*, unsigned char*, int*, const unsigned char*, int));
-    MOCK_METHOD1(SSL_EVP_MD_CTX_reset, int(EVP_MD_CTX*));
-    MOCK_METHOD3(SSL_EVP_DigestFinal_ex, int(EVP_MD_CTX*, unsigned char*, unsigned int*));
-    MOCK_METHOD3(SSL_EVP_DigestUpdate, int(EVP_MD_CTX*, const void*, size_t));
-    MOCK_METHOD3(SSL_EVP_DigestInit_ex, int(EVP_MD_CTX*, const EVP_MD*, ENGINE*));
-    MOCK_METHOD1(SSL_EVP_MD_CTX_init, void(EVP_MD_CTX*));
-    MOCK_METHOD3(SSL_X509_STORE_CTX_set_time, void(X509_STORE_CTX*, unsigned long, time_t));
-    MOCK_METHOD4(SSL_ASN1_TIME_adj, ASN1_TIME*(ASN1_TIME*, time_t, int, long));
-    MOCK_METHOD2(SSL_sk_X509_CRL_push, int(STACK_OF(X509_CRL) *, const X509_CRL*));
+                 int(EVP_CIPHER_CTX *, unsigned char *, int *, const unsigned char *, int));
+    MOCK_METHOD1(SSL_EVP_MD_CTX_reset, int(EVP_MD_CTX *));
+    MOCK_METHOD3(SSL_EVP_DigestFinal_ex, int(EVP_MD_CTX *, unsigned char *, unsigned int *));
+    MOCK_METHOD3(SSL_EVP_DigestUpdate, int(EVP_MD_CTX *, const void *, size_t));
+    MOCK_METHOD3(SSL_EVP_DigestInit_ex, int(EVP_MD_CTX *, const EVP_MD *, ENGINE *));
+    MOCK_METHOD1(SSL_EVP_MD_CTX_init, void(EVP_MD_CTX *));
+    MOCK_METHOD3(SSL_X509_STORE_CTX_set_time, void(X509_STORE_CTX *, unsigned long, time_t));
+    MOCK_METHOD4(SSL_ASN1_TIME_adj, ASN1_TIME *(ASN1_TIME *, time_t, int, long));
+    MOCK_METHOD2(SSL_sk_X509_CRL_push, int(STACK_OF(X509_CRL) *, const X509_CRL *));
     MOCK_METHOD0(SSL_sk_X509_CRL_new_null, STACK_OF(X509_CRL) * ());
     MOCK_METHOD1(SSL_sk_X509_CRL_free, void(STACK_OF(X509_CRL) *));
-    MOCK_METHOD2(SSL_X509_STORE_CTX_set0_crls, void(X509_STORE_CTX*, STACK_OF(X509_CRL) *));
+    MOCK_METHOD2(SSL_X509_STORE_CTX_set0_crls, void(X509_STORE_CTX *, STACK_OF(X509_CRL) *));
     MOCK_METHOD1(SSL_sk_X509_REVOKED_num, int(STACK_OF(X509_REVOKED) *));
-    MOCK_METHOD2(SSL_sk_X509_REVOKED_value, X509_REVOKED*(STACK_OF(X509_REVOKED) *, int));
-    MOCK_METHOD0(SSL_X509_CRL_new, X509_CRL*());
-    MOCK_METHOD1(SSL_X509_CRL_free, void(X509_CRL*));
-    MOCK_METHOD2(SSL_d2i_X509_CRL_bio, X509_CRL*(BIO*, X509_CRL**));
-    MOCK_METHOD2(SSL_PEM_write_bio_X509_CRL, int(BIO*, X509_CRL*));
-    MOCK_METHOD4(SSL_PEM_read_bio_X509_CRL, X509_CRL*(BIO*, X509_CRL**, pem_password_cb*, void*));
-    MOCK_METHOD1(SSL_X509_CRL_get_REVOKED, STACK_OF(X509_REVOKED) * (X509_CRL*));
-    MOCK_METHOD1(SSL_X509_CRL_get_lastUpdate, const ASN1_TIME*(const X509_CRL*));
-    MOCK_METHOD1(SSL_X509_CRL_get_nextUpdate, const ASN1_TIME*(const X509_CRL*));
-    MOCK_METHOD2(SSL_X509_CRL_verify, int(X509_CRL*, EVP_PKEY*));
-    MOCK_METHOD1(SSL_X509_CRL_get_issuer, X509_NAME*(const X509_CRL*));
-    MOCK_METHOD1(SSL_ASN1_STRING_dup, ASN1_STRING*(const ASN1_STRING*));
-    MOCK_METHOD0(SSL_ASN1_TIME_new, ASN1_TIME*());
-    MOCK_METHOD2(SSL_ASN1_TIME_set_string, int(ASN1_TIME*, const char*));
-    MOCK_METHOD1(SSL_BN_num_bytes, int(const BIGNUM*));
-    MOCK_METHOD2(SSL_BN_bn2bin, int(const BIGNUM*, unsigned char*));
-    MOCK_METHOD0(SSL_ASN1_INTEGER_new, ASN1_INTEGER*());
-    MOCK_METHOD1(SSL_ASN1_INTEGER_free, void(ASN1_INTEGER*));
-    MOCK_METHOD1(SSL_OPENSSL_malloc, void*(int));
-    MOCK_METHOD1(SSL_OPENSSL_free, void(void*));
-    MOCK_METHOD1(SSL_BN_bn2dec, char*(const BIGNUM*));
-    MOCK_METHOD1(SSL_BN_free, void(BIGNUM*));
-    MOCK_METHOD2(SSL_ASN1_INTEGER_to_BN, BIGNUM*(const ASN1_INTEGER*, BIGNUM*));
-    MOCK_METHOD2(SSL_ASN1_INTEGER_cmp, int(const ASN1_INTEGER*, const ASN1_INTEGER*));
-    MOCK_METHOD1(SSL_ASN1_INTEGER_get, long(const ASN1_INTEGER*));
-    MOCK_METHOD2(SSL_ASN1_INTEGER_set, int(ASN1_INTEGER*, long));
-    MOCK_METHOD1(SSL_X509_get_serialNumber, ASN1_INTEGER*(X509*));
-    MOCK_METHOD2(SSL_X509_set_serialNumber, int(X509*, ASN1_INTEGER*));
-    MOCK_METHOD6(SSL_X509V3_set_ctx, void(X509V3_CTX*, X509*, X509*, X509_REQ*, X509_CRL*, int));
-    MOCK_METHOD1(SSL_X509V3_set_ctx_nodb, void(X509V3_CTX*));
-    MOCK_METHOD1(SSL_X509_EXTENSION_free, void(X509_EXTENSION*));
-    MOCK_METHOD3(SSL_X509_add_ext, int(X509*, X509_EXTENSION*, int));
+    MOCK_METHOD2(SSL_sk_X509_REVOKED_value, X509_REVOKED *(STACK_OF(X509_REVOKED) *, int));
+    MOCK_METHOD0(SSL_X509_CRL_new, X509_CRL *());
+    MOCK_METHOD1(SSL_X509_CRL_free, void(X509_CRL *));
+    MOCK_METHOD2(SSL_d2i_X509_CRL_bio, X509_CRL *(BIO *, X509_CRL **));
+    MOCK_METHOD2(SSL_PEM_write_bio_X509_CRL, int(BIO *, X509_CRL *));
+    MOCK_METHOD4(SSL_PEM_read_bio_X509_CRL,
+                 X509_CRL *(BIO *, X509_CRL **, pem_password_cb *, void *));
+    MOCK_METHOD1(SSL_X509_CRL_get_REVOKED, STACK_OF(X509_REVOKED) * (X509_CRL *));
+    MOCK_METHOD1(SSL_X509_CRL_get_lastUpdate, const ASN1_TIME *(const X509_CRL *));
+    MOCK_METHOD1(SSL_X509_CRL_get_nextUpdate, const ASN1_TIME *(const X509_CRL *));
+    MOCK_METHOD2(SSL_X509_CRL_verify, int(X509_CRL *, EVP_PKEY *));
+    MOCK_METHOD1(SSL_X509_CRL_get_issuer, X509_NAME *(const X509_CRL *));
+    MOCK_METHOD1(SSL_ASN1_STRING_dup, ASN1_STRING *(const ASN1_STRING *));
+    MOCK_METHOD0(SSL_ASN1_TIME_new, ASN1_TIME *());
+    MOCK_METHOD2(SSL_ASN1_TIME_set_string, int(ASN1_TIME *, const char *));
+    MOCK_METHOD1(SSL_BN_num_bytes, int(const BIGNUM *));
+    MOCK_METHOD2(SSL_BN_bn2bin, int(const BIGNUM *, unsigned char *));
+    MOCK_METHOD0(SSL_ASN1_INTEGER_new, ASN1_INTEGER *());
+    MOCK_METHOD1(SSL_ASN1_INTEGER_free, void(ASN1_INTEGER *));
+    MOCK_METHOD1(SSL_OPENSSL_malloc, void *(int));
+    MOCK_METHOD1(SSL_OPENSSL_free, void(void *));
+    MOCK_METHOD1(SSL_BN_bn2dec, char *(const BIGNUM *));
+    MOCK_METHOD1(SSL_BN_free, void(BIGNUM *));
+    MOCK_METHOD2(SSL_ASN1_INTEGER_to_BN, BIGNUM *(const ASN1_INTEGER *, BIGNUM *));
+    MOCK_METHOD2(SSL_ASN1_INTEGER_cmp, int(const ASN1_INTEGER *, const ASN1_INTEGER *));
+    MOCK_METHOD1(SSL_ASN1_INTEGER_get, long(const ASN1_INTEGER *));
+    MOCK_METHOD2(SSL_ASN1_INTEGER_set, int(ASN1_INTEGER *, long));
+    MOCK_METHOD1(SSL_X509_get_serialNumber, ASN1_INTEGER *(X509 *));
+    MOCK_METHOD2(SSL_X509_set_serialNumber, int(X509 *, ASN1_INTEGER *));
+    MOCK_METHOD6(SSL_X509V3_set_ctx,
+                 void(X509V3_CTX *, X509 *, X509 *, X509_REQ *, X509_CRL *, int));
+    MOCK_METHOD1(SSL_X509V3_set_ctx_nodb, void(X509V3_CTX *));
+    MOCK_METHOD1(SSL_X509_EXTENSION_free, void(X509_EXTENSION *));
+    MOCK_METHOD3(SSL_X509_add_ext, int(X509 *, X509_EXTENSION *, int));
     MOCK_METHOD4(SSL_X509V3_EXT_conf_nid,
-                 X509_EXTENSION*(lhash_st_CONF_VALUE*, X509V3_CTX*, int, char*));
-    MOCK_METHOD0(SSL_EVP_aes_128_cbc, const EVP_CIPHER*());
-    MOCK_METHOD0(SSL_EVP_aes_256_cbc, const EVP_CIPHER*());
-    MOCK_METHOD3(SSL_BIO_write, int(BIO*, const void*, int));
-    MOCK_METHOD3(SSL_BIO_read, int(BIO*, void*, int));
-    MOCK_METHOD2(SSL_BIO_new_file, BIO*(const char*, const char*));
+                 X509_EXTENSION *(lhash_st_CONF_VALUE *, X509V3_CTX *, int, char *));
+    MOCK_METHOD0(SSL_EVP_aes_128_cbc, const EVP_CIPHER *());
+    MOCK_METHOD0(SSL_EVP_aes_256_cbc, const EVP_CIPHER *());
+    MOCK_METHOD3(SSL_BIO_write, int(BIO *, const void *, int));
+    MOCK_METHOD3(SSL_BIO_read, int(BIO *, void *, int));
+    MOCK_METHOD2(SSL_BIO_new_file, BIO *(const char *, const char *));
     MOCK_METHOD0(SSL_ERR_load_crypto_strings, void());
     MOCK_METHOD0(SSL_SSL_load_error_strings, void());
     MOCK_METHOD0(SSL_OpenSSL_add_all_algorithms, void());
     MOCK_METHOD0(SSL_CRYPTO_malloc_init, void());
 
-    MOCK_METHOD1(SSL_X509_REQ_free, void(X509_REQ*));
-    MOCK_METHOD0(SSL_X509_REQ_new, X509_REQ*());
-    MOCK_METHOD1(SSL_X509_REQ_get_subject_name, X509_NAME*(const X509_REQ* req));
-    MOCK_METHOD1(SSL_X509_REQ_get_pubkey, EVP_PKEY*(X509_REQ* req));
-    MOCK_METHOD2(SSL_X509_REQ_verify, int(X509_REQ* a, EVP_PKEY* r));
+    MOCK_METHOD1(SSL_X509_REQ_free, void(X509_REQ *));
+    MOCK_METHOD0(SSL_X509_REQ_new, X509_REQ *());
+    MOCK_METHOD1(SSL_X509_REQ_get_subject_name, X509_NAME *(const X509_REQ *req));
+    MOCK_METHOD1(SSL_X509_REQ_get_pubkey, EVP_PKEY *(X509_REQ *req));
+    MOCK_METHOD2(SSL_X509_REQ_verify, int(X509_REQ *a, EVP_PKEY *r));
 
-    MOCK_METHOD0(SSL_EVP_PKEY_new, EVP_PKEY*());
-    MOCK_METHOD1(SSL_EVP_PKEY_free, void(EVP_PKEY*));
-    MOCK_METHOD2(SSL_EVP_PKEY_keygen, int(EVP_PKEY_CTX*, EVP_PKEY**));
-    MOCK_METHOD1(SSL_EVP_PKEY_keygen_init, int(EVP_PKEY_CTX* ctx));
+    MOCK_METHOD0(SSL_EVP_PKEY_new, EVP_PKEY *());
+    MOCK_METHOD1(SSL_EVP_PKEY_free, void(EVP_PKEY *));
+    MOCK_METHOD2(SSL_EVP_PKEY_keygen, int(EVP_PKEY_CTX *, EVP_PKEY **));
+    MOCK_METHOD1(SSL_EVP_PKEY_keygen_init, int(EVP_PKEY_CTX *ctx));
 
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_new, EVP_PKEY_CTX*(EVP_PKEY*, ENGINE*));
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_new_id, EVP_PKEY_CTX*(int, ENGINE*));
-    MOCK_METHOD1(SSL_EVP_PKEY_CTX_free, void(EVP_PKEY_CTX*));
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_keygen_bits, int(EVP_PKEY_CTX*, int));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_new, EVP_PKEY_CTX *(EVP_PKEY *, ENGINE *));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_new_id, EVP_PKEY_CTX *(int, ENGINE *));
+    MOCK_METHOD1(SSL_EVP_PKEY_CTX_free, void(EVP_PKEY_CTX *));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_keygen_bits, int(EVP_PKEY_CTX *, int));
 
-    MOCK_METHOD2(SSL_EVP_PKEY_cmp, int(const EVP_PKEY*, const EVP_PKEY*));
+    MOCK_METHOD2(SSL_EVP_PKEY_cmp, int(const EVP_PKEY *, const EVP_PKEY *));
 
-    MOCK_METHOD1(SSL_EVP_PKEY_paramgen_init, int(EVP_PKEY_CTX*));
-    MOCK_METHOD2(SSL_EVP_PKEY_paramgen, int(EVP_PKEY_CTX* ctx, EVP_PKEY** ppkey));
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid, int(EVP_PKEY_CTX* ctx, int nid));
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_ec_param_enc, int(EVP_PKEY_CTX* ctx, int param_enc));
-    MOCK_METHOD1(SSL_EC_KEY_get0_group, EC_GROUP*(const EC_KEY* key));
-    MOCK_METHOD1(SSL_EC_GROUP_get_degree, int(const EC_GROUP* group));
-    MOCK_METHOD1(SSL_EC_GROUP_get_curve_name, int(const EC_GROUP* group));
+    MOCK_METHOD1(SSL_EVP_PKEY_paramgen_init, int(EVP_PKEY_CTX *));
+    MOCK_METHOD2(SSL_EVP_PKEY_paramgen, int(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid, int(EVP_PKEY_CTX *ctx, int nid));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_ec_param_enc, int(EVP_PKEY_CTX *ctx, int param_enc));
+    MOCK_METHOD1(SSL_EC_KEY_get0_group, EC_GROUP *(const EC_KEY *key));
+    MOCK_METHOD1(SSL_EC_GROUP_get_degree, int(const EC_GROUP *group));
+    MOCK_METHOD1(SSL_EC_GROUP_get_curve_name, int(const EC_GROUP *group));
 
     MOCK_METHOD1(SSL_EVP_PKEY_type, int(int type));
-    MOCK_METHOD1(SSL_EVP_PKEY_id, int(const EVP_PKEY* pkey));
+    MOCK_METHOD1(SSL_EVP_PKEY_id, int(const EVP_PKEY *pkey));
 
-    MOCK_METHOD1(SSL_EVP_PKEY_size, int(EVP_PKEY* pkey));
+    MOCK_METHOD1(SSL_EVP_PKEY_size, int(EVP_PKEY *pkey));
 
     MOCK_METHOD0(SSL_ERR_get_error, unsigned long());
-    MOCK_METHOD2(SSL_ERR_error_string, char*(unsigned long, char*));
+    MOCK_METHOD2(SSL_ERR_error_string, char *(unsigned long, char *));
 
-    MOCK_METHOD0(SSL_X509_NAME_new, X509_NAME*());
-    MOCK_METHOD1(SSL_X509_NAME_free, void(X509_NAME*));
+    MOCK_METHOD0(SSL_X509_NAME_new, X509_NAME *());
+    MOCK_METHOD1(SSL_X509_NAME_free, void(X509_NAME *));
     MOCK_METHOD7(SSL_X509_NAME_add_entry_by_NID,
-                 int(X509_NAME* name,
+                 int(X509_NAME *name,
                      int nid,
                      int type,
-                     unsigned char* bytes,
+                     unsigned char *bytes,
                      int len,
                      int loc,
                      int set));
-    MOCK_METHOD2(SSL_X509_REQ_set_subject_name, int(X509_REQ* req, X509_NAME* name));
-    MOCK_METHOD2(SSL_X509_REQ_set_pubkey, int(X509_REQ* x, EVP_PKEY* pkey));
-    MOCK_METHOD2(SSL_X509_REQ_set_version, int(X509_REQ*, unsigned long));
+    MOCK_METHOD2(SSL_X509_REQ_set_subject_name, int(X509_REQ *req, X509_NAME *name));
+    MOCK_METHOD2(SSL_X509_REQ_set_pubkey, int(X509_REQ *x, EVP_PKEY *pkey));
+    MOCK_METHOD2(SSL_X509_REQ_set_version, int(X509_REQ *, unsigned long));
 
-    MOCK_METHOD0(SSL_BIO_s_mem, const BIO_METHOD*());
-    MOCK_METHOD1(SSL_BIO_free_all, void(BIO*));
-    MOCK_METHOD1(SSL_BIO_new, BIO*(const BIO_METHOD*));
-    MOCK_METHOD2(SSL_PEM_write_bio_X509_REQ, int(BIO*, X509_REQ*));
-    MOCK_METHOD3(SSL_BIO_gets, int(BIO*, char*, int));
-    MOCK_METHOD2(SSL_X509_REQ_sign_ctx, int(X509_REQ*, EVP_MD_CTX*));
-    MOCK_METHOD0(SSL_EVP_MD_CTX_create, EVP_MD_CTX*());
+    MOCK_METHOD0(SSL_BIO_s_mem, const BIO_METHOD *());
+    MOCK_METHOD1(SSL_BIO_free_all, void(BIO *));
+    MOCK_METHOD1(SSL_BIO_new, BIO *(const BIO_METHOD *));
+    MOCK_METHOD2(SSL_PEM_write_bio_X509_REQ, int(BIO *, X509_REQ *));
+    MOCK_METHOD3(SSL_BIO_gets, int(BIO *, char *, int));
+    MOCK_METHOD2(SSL_X509_REQ_sign_ctx, int(X509_REQ *, EVP_MD_CTX *));
+    MOCK_METHOD0(SSL_EVP_MD_CTX_create, EVP_MD_CTX *());
     MOCK_METHOD5(SSL_EVP_DigestSignInit,
-                 int(EVP_MD_CTX* ctx, EVP_PKEY_CTX**, const EVP_MD*, ENGINE*, EVP_PKEY*));
+                 int(EVP_MD_CTX *ctx, EVP_PKEY_CTX **, const EVP_MD *, ENGINE *, EVP_PKEY *));
     MOCK_METHOD5(SSL_EVP_DigestSign,
-                 int(EVP_MD_CTX*, unsigned char*, size_t*, const unsigned char*, size_t));
+                 int(EVP_MD_CTX *, unsigned char *, size_t *, const unsigned char *, size_t));
     MOCK_METHOD5(SSL_EVP_DigestVerifyInit,
-                 int(EVP_MD_CTX*, EVP_PKEY_CTX**, const EVP_MD*, ENGINE*, EVP_PKEY*));
+                 int(EVP_MD_CTX *, EVP_PKEY_CTX **, const EVP_MD *, ENGINE *, EVP_PKEY *));
     MOCK_METHOD5(SSL_EVP_DigestVerify,
-                 int(EVP_MD_CTX*, const unsigned char*, size_t, const unsigned char*, size_t));
-    MOCK_METHOD1(SSL_EVP_MD_CTX_destroy, void(EVP_MD_CTX*));
-    MOCK_METHOD0(SSL_EVP_sha1, const EVP_MD*());
-    MOCK_METHOD0(SSL_EVP_sha256, const EVP_MD*());
-    MOCK_METHOD0(SSL_EVP_sha384, const EVP_MD*());
-    MOCK_METHOD0(SSL_EVP_sha512, const EVP_MD*());
-    MOCK_METHOD0(SSL_EVP_sha3_256, const EVP_MD*());
-    MOCK_METHOD0(SSL_EVP_sha3_384, const EVP_MD*());
-    MOCK_METHOD0(SSL_EVP_sha3_512, const EVP_MD*());
-    MOCK_METHOD7(SSL_PEM_write_bio_PKCS8PrivateKey,
-                 int(BIO*, EVP_PKEY*, const EVP_CIPHER*, char*, int, pem_password_cb*, void*));
-    MOCK_METHOD2(SSL_PEM_write_bio_PUBKEY, int(BIO*, EVP_PKEY*));
-    MOCK_METHOD4(SSL_PEM_read_bio_PUBKEY, EVP_PKEY*(BIO*, EVP_PKEY**, pem_password_cb*, void*));
-    MOCK_METHOD4(SSL_PEM_read_bio_PrivateKey, EVP_PKEY*(BIO*, EVP_PKEY**, pem_password_cb*, void*));
-    MOCK_METHOD2(SSL_BIO_puts, int(BIO*, char*));
+                 int(EVP_MD_CTX *, const unsigned char *, size_t, const unsigned char *, size_t));
+    MOCK_METHOD1(SSL_EVP_MD_CTX_destroy, void(EVP_MD_CTX *));
+    MOCK_METHOD0(SSL_EVP_sha1, const EVP_MD *());
+    MOCK_METHOD0(SSL_EVP_sha256, const EVP_MD *());
+    MOCK_METHOD0(SSL_EVP_sha384, const EVP_MD *());
+    MOCK_METHOD0(SSL_EVP_sha512, const EVP_MD *());
+    MOCK_METHOD0(SSL_EVP_sha3_256, const EVP_MD *());
+    MOCK_METHOD0(SSL_EVP_sha3_384, const EVP_MD *());
+    MOCK_METHOD0(SSL_EVP_sha3_512, const EVP_MD *());
+    MOCK_METHOD7(
+            SSL_PEM_write_bio_PKCS8PrivateKey,
+            int(BIO *, EVP_PKEY *, const EVP_CIPHER *, char *, int, pem_password_cb *, void *));
+    MOCK_METHOD2(SSL_PEM_write_bio_PUBKEY, int(BIO *, EVP_PKEY *));
+    MOCK_METHOD4(SSL_PEM_read_bio_PUBKEY,
+                 EVP_PKEY *(BIO *, EVP_PKEY **, pem_password_cb *, void *));
+    MOCK_METHOD4(SSL_PEM_read_bio_PrivateKey,
+                 EVP_PKEY *(BIO *, EVP_PKEY **, pem_password_cb *, void *));
+    MOCK_METHOD2(SSL_BIO_puts, int(BIO *, char *));
     MOCK_METHOD4(SSL_PEM_read_bio_X509_REQ,
-                 X509_REQ*(BIO* bp, X509_REQ** x, pem_password_cb* cb, void* u));
+                 X509_REQ *(BIO *bp, X509_REQ **x, pem_password_cb *cb, void *u));
 
-    MOCK_METHOD2(SSL_PEM_write_bio_X509, int(BIO* bp, X509* x));
-    MOCK_METHOD2(SSL_d2i_X509_bio, X509*(BIO*, X509**));
-    MOCK_METHOD2(SSL_i2d_X509_bio, int(BIO*, X509*));
+    MOCK_METHOD2(SSL_PEM_write_bio_X509, int(BIO *bp, X509 *x));
+    MOCK_METHOD2(SSL_d2i_X509_bio, X509 *(BIO *, X509 **));
+    MOCK_METHOD2(SSL_i2d_X509_bio, int(BIO *, X509 *));
 
-    MOCK_METHOD0(SSL_X509_new, X509*());
-    MOCK_METHOD2(SSL_X509_set_pubkey, int(X509* ptr, EVP_PKEY* pkey));
-    MOCK_METHOD2(SSL_X509_set_issuer_name, int(X509* x, X509_NAME* name));
-    MOCK_METHOD2(SSL_X509_set_subject_name, int(X509* x, X509_NAME* name));
-    MOCK_METHOD2(SSL_X509_set_notBefore, int(X509* x, const ASN1_TIME* t));
-    MOCK_METHOD2(SSL_X509_set_notAfter, int(X509* x, const ASN1_TIME* t));
-    MOCK_METHOD3(SSL_X509_sign, int(X509* x, EVP_PKEY* pkey, const EVP_MD* md));
-    MOCK_METHOD1(SSL_X509_free, void(X509*));
-    MOCK_METHOD4(SSL_PEM_read_bio_X509, X509*(BIO* bio, X509**, pem_password_cb*, void*));
+    MOCK_METHOD0(SSL_X509_new, X509 *());
+    MOCK_METHOD2(SSL_X509_set_pubkey, int(X509 *ptr, EVP_PKEY *pkey));
+    MOCK_METHOD2(SSL_X509_set_issuer_name, int(X509 *x, X509_NAME *name));
+    MOCK_METHOD2(SSL_X509_set_subject_name, int(X509 *x, X509_NAME *name));
+    MOCK_METHOD2(SSL_X509_set_notBefore, int(X509 *x, const ASN1_TIME *t));
+    MOCK_METHOD2(SSL_X509_set_notAfter, int(X509 *x, const ASN1_TIME *t));
+    MOCK_METHOD3(SSL_X509_sign, int(X509 *x, EVP_PKEY *pkey, const EVP_MD *md));
+    MOCK_METHOD1(SSL_X509_free, void(X509 *));
+    MOCK_METHOD4(SSL_PEM_read_bio_X509, X509 *(BIO *bio, X509 **, pem_password_cb *, void *));
 
-    MOCK_METHOD1(SSL_X509_get_subject_name, X509_NAME*(X509*));
-    MOCK_METHOD1(SSL_X509_get_issuer_name, X509_NAME*(X509*));
-    MOCK_METHOD1(SSL_X509_get_pubkey, EVP_PKEY*(X509*));
-    MOCK_METHOD1(SSL_X509_get_notBefore, ASN1_TIME*(X509*));
-    MOCK_METHOD1(SSL_X509_get_notAfter, ASN1_TIME*(X509*));
+    MOCK_METHOD1(SSL_X509_get_subject_name, X509_NAME *(X509 *));
+    MOCK_METHOD1(SSL_X509_get_issuer_name, X509_NAME *(X509 *));
+    MOCK_METHOD1(SSL_X509_get_pubkey, EVP_PKEY *(X509 *));
+    MOCK_METHOD1(SSL_X509_get_notBefore, ASN1_TIME *(X509 *));
+    MOCK_METHOD1(SSL_X509_get_notAfter, ASN1_TIME *(X509 *));
 
-    MOCK_METHOD1(SSL_ASN1_TIME_free, void(ASN1_TIME*));
-    MOCK_METHOD4(SSL_ASN1_TIME_diff, int(int*, int*, const ASN1_TIME*, const ASN1_TIME*));
-    MOCK_METHOD2(SSL_ASN1_TIME_set, ASN1_TIME*(ASN1_TIME*, time_t));
+    MOCK_METHOD1(SSL_ASN1_TIME_free, void(ASN1_TIME *));
+    MOCK_METHOD4(SSL_ASN1_TIME_diff, int(int *, int *, const ASN1_TIME *, const ASN1_TIME *));
+    MOCK_METHOD2(SSL_ASN1_TIME_set, ASN1_TIME *(ASN1_TIME *, time_t));
 
-    MOCK_METHOD0(SSL_X509_STORE_new, X509_STORE*());
-    MOCK_METHOD1(SSL_X509_STORE_free, void(X509_STORE*));
-    MOCK_METHOD2(SSL_X509_STORE_add_cert, int(X509_STORE*, X509*));
+    MOCK_METHOD0(SSL_X509_STORE_new, X509_STORE *());
+    MOCK_METHOD1(SSL_X509_STORE_free, void(X509_STORE *));
+    MOCK_METHOD2(SSL_X509_STORE_add_cert, int(X509_STORE *, X509 *));
 
-    MOCK_METHOD0(SSL_X509_STORE_CTX_new, X509_STORE_CTX*());
-    MOCK_METHOD1(SSL_X509_STORE_CTX_free, void(X509_STORE_CTX*));
+    MOCK_METHOD0(SSL_X509_STORE_CTX_new, X509_STORE_CTX *());
+    MOCK_METHOD1(SSL_X509_STORE_CTX_free, void(X509_STORE_CTX *));
     MOCK_METHOD4(SSL_X509_STORE_CTX_init,
-                 int(X509_STORE_CTX*, X509_STORE*, X509*, STACK_OF(X509) *));
+                 int(X509_STORE_CTX *, X509_STORE *, X509 *, STACK_OF(X509) *));
 
-    MOCK_METHOD1(SSL_X509_STORE_CTX_get0_param, X509_VERIFY_PARAM*(X509_STORE_CTX*));
-    MOCK_METHOD2(SSL_X509_VERIFY_PARAM_set_flags, int(X509_VERIFY_PARAM*, unsigned long));
+    MOCK_METHOD1(SSL_X509_STORE_CTX_get0_param, X509_VERIFY_PARAM *(X509_STORE_CTX *));
+    MOCK_METHOD2(SSL_X509_VERIFY_PARAM_set_flags, int(X509_VERIFY_PARAM *, unsigned long));
 
-    MOCK_METHOD1(SSL_X509_verify_cert, int(X509_STORE_CTX*));
-    MOCK_METHOD1(SSL_X509_verify_cert_error_string, const char*(long));
-    MOCK_METHOD1(SSL_X509_STORE_CTX_get_error, int(X509_STORE_CTX*));
+    MOCK_METHOD1(SSL_X509_verify_cert, int(X509_STORE_CTX *));
+    MOCK_METHOD1(SSL_X509_verify_cert_error_string, const char *(long));
+    MOCK_METHOD1(SSL_X509_STORE_CTX_get_error, int(X509_STORE_CTX *));
 
-    MOCK_METHOD1(SSL_X509_check_ca, int(X509*));
+    MOCK_METHOD1(SSL_X509_check_ca, int(X509 *));
 
     MOCK_METHOD0(SSL_sk_X509_new_null, STACK_OF(X509) * ());
-    MOCK_METHOD2(SSL_sk_X509_push, int(STACK_OF(X509) *, const X509*));
+    MOCK_METHOD2(SSL_sk_X509_push, int(STACK_OF(X509) *, const X509 *));
     MOCK_METHOD1(SSL_sk_X509_free, void(STACK_OF(X509) *));
 
-    MOCK_METHOD3(SSL_X509_NAME_get_index_by_NID, int(X509_NAME*, int, int));
-    MOCK_METHOD2(SSL_X509_NAME_get_entry, X509_NAME_ENTRY*(X509_NAME*, int));
-    MOCK_METHOD1(SSL_X509_NAME_ENTRY_get_data, ASN1_STRING*(X509_NAME_ENTRY*));
-    MOCK_METHOD3(SSL_ASN1_STRING_print_ex, int(BIO*, ASN1_STRING*, unsigned long));
+    MOCK_METHOD3(SSL_X509_NAME_get_index_by_NID, int(X509_NAME *, int, int));
+    MOCK_METHOD2(SSL_X509_NAME_get_entry, X509_NAME_ENTRY *(X509_NAME *, int));
+    MOCK_METHOD1(SSL_X509_NAME_ENTRY_get_data, ASN1_STRING *(X509_NAME_ENTRY *));
+    MOCK_METHOD3(SSL_ASN1_STRING_print_ex, int(BIO *, ASN1_STRING *, unsigned long));
 
     MOCK_METHOD5(SSL_EVP_PKEY_sign,
-                 int(EVP_PKEY_CTX*, unsigned char*, size_t*, const unsigned char*, size_t));
-    MOCK_METHOD1(SSL_EVP_PKEY_sign_init, int(EVP_PKEY_CTX*));
-    MOCK_METHOD1(SSL_EVP_PKEY_verify_init, int(EVP_PKEY_CTX*));
+                 int(EVP_PKEY_CTX *, unsigned char *, size_t *, const unsigned char *, size_t));
+    MOCK_METHOD1(SSL_EVP_PKEY_sign_init, int(EVP_PKEY_CTX *));
+    MOCK_METHOD1(SSL_EVP_PKEY_verify_init, int(EVP_PKEY_CTX *));
     MOCK_METHOD5(SSL_EVP_PKEY_verify,
-                 int(EVP_PKEY_CTX*, const unsigned char*, size_t, const unsigned char*, size_t));
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_padding, int(EVP_PKEY_CTX*, int));
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_signature_md, int(EVP_PKEY_CTX*, const EVP_MD*));
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen, int(EVP_PKEY_CTX*, int));
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_mgf1_md, int(EVP_PKEY_CTX*, const EVP_MD*));
-    MOCK_METHOD1(SSL_EVP_PKEY_encrypt_init, int(EVP_PKEY_CTX* ctx));
+                 int(EVP_PKEY_CTX *, const unsigned char *, size_t, const unsigned char *, size_t));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_padding, int(EVP_PKEY_CTX *, int));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_signature_md, int(EVP_PKEY_CTX *, const EVP_MD *));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_pss_saltlen, int(EVP_PKEY_CTX *, int));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_mgf1_md, int(EVP_PKEY_CTX *, const EVP_MD *));
+    MOCK_METHOD1(SSL_EVP_PKEY_encrypt_init, int(EVP_PKEY_CTX *ctx));
     MOCK_METHOD5(SSL_EVP_PKEY_encrypt,
-                 int(EVP_PKEY_CTX* ctx,
-                     unsigned char* out,
-                     size_t* outlen,
-                     const unsigned char* in,
+                 int(EVP_PKEY_CTX *ctx,
+                     unsigned char *out,
+                     size_t *outlen,
+                     const unsigned char *in,
                      size_t inlen));
-    MOCK_METHOD1(SSL_EVP_PKEY_decrypt_init, int(EVP_PKEY_CTX* ctx));
+    MOCK_METHOD1(SSL_EVP_PKEY_decrypt_init, int(EVP_PKEY_CTX *ctx));
     MOCK_METHOD5(SSL_EVP_PKEY_decrypt,
-                 int(EVP_PKEY_CTX* ctx,
-                     unsigned char* out,
-                     size_t* outlen,
-                     const unsigned char* in,
+                 int(EVP_PKEY_CTX *ctx,
+                     unsigned char *out,
+                     size_t *outlen,
+                     const unsigned char *in,
                      size_t inlen));
-    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_oaep_md, int(EVP_PKEY_CTX* ctx, const EVP_MD* md));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_oaep_md, int(EVP_PKEY_CTX *ctx, const EVP_MD *md));
     MOCK_METHOD3(SSL_EVP_PKEY_CTX_set_rsa_oaep_label,
-                 int(EVP_PKEY_CTX* ctx, unsigned char* l, int llen));
-    MOCK_METHOD1(SSL_RSA_size, int(const RSA* r));
-    MOCK_METHOD1(SSL_EVP_MD_size, int(const EVP_MD* md));
-    MOCK_METHOD1(SSL_EVP_PKEY_get0_EC_KEY, EC_KEY*(EVP_PKEY* pkey));
+                 int(EVP_PKEY_CTX *ctx, unsigned char *l, int llen));
+    MOCK_METHOD1(SSL_RSA_size, int(const RSA *r));
+    MOCK_METHOD1(SSL_EVP_MD_size, int(const EVP_MD *md));
+    MOCK_METHOD1(SSL_EVP_PKEY_get0_EC_KEY, EC_KEY *(EVP_PKEY *pkey));
     MOCK_METHOD8(SSL_PKCS5_PBKDF2_HMAC,
-                 int(const char* pass,
+                 int(const char *pass,
                      int passlen,
-                     const unsigned char* salt,
+                     const unsigned char *salt,
                      int saltlen,
                      int iter,
-                     const EVP_MD* digest,
+                     const EVP_MD *digest,
                      int keylen,
-                     unsigned char* out));
+                     unsigned char *out));
     MOCK_METHOD7(SSL_ECDH_KDF_X9_63,
-                 int(unsigned char* out,
+                 int(unsigned char *out,
                      size_t outlen,
-                     const unsigned char* Z,
+                     const unsigned char *Z,
                      size_t Zlen,
-                     const unsigned char* sinfo,
+                     const unsigned char *sinfo,
                      size_t sinfolen,
-                     const EVP_MD* md));
+                     const EVP_MD *md));
 
     /* CMAC */
-    MOCK_METHOD0(SSL_CMAC_CTX_new, CMAC_CTX*());
-    MOCK_METHOD1(SSL_CMAC_CTX_cleanup, void(CMAC_CTX*));
-    MOCK_METHOD1(SSL_CMAC_CTX_free, void(CMAC_CTX*));
-    MOCK_METHOD1(SSL_CMAC_CTX_get0_cipher_ctx, EVP_CIPHER_CTX*(CMAC_CTX*));
-    MOCK_METHOD2(SSL_CMAC_CTX_copy, int(CMAC_CTX*, const CMAC_CTX*));
-    MOCK_METHOD5(SSL_CMAC_Init, int(CMAC_CTX*, const void*, size_t, const EVP_CIPHER*, ENGINE*));
-    MOCK_METHOD3(SSL_CMAC_Update, int(CMAC_CTX*, const void*, size_t));
-    MOCK_METHOD3(SSL_CMAC_Final, int(CMAC_CTX*, unsigned char*, size_t*));
-    MOCK_METHOD1(SSL_CMAC_resume, int(CMAC_CTX*));
+    MOCK_METHOD0(SSL_CMAC_CTX_new, CMAC_CTX *());
+    MOCK_METHOD1(SSL_CMAC_CTX_cleanup, void(CMAC_CTX *));
+    MOCK_METHOD1(SSL_CMAC_CTX_free, void(CMAC_CTX *));
+    MOCK_METHOD1(SSL_CMAC_CTX_get0_cipher_ctx, EVP_CIPHER_CTX *(CMAC_CTX *));
+    MOCK_METHOD2(SSL_CMAC_CTX_copy, int(CMAC_CTX *, const CMAC_CTX *));
+    MOCK_METHOD5(SSL_CMAC_Init,
+                 int(CMAC_CTX *, const void *, size_t, const EVP_CIPHER *, ENGINE *));
+    MOCK_METHOD3(SSL_CMAC_Update, int(CMAC_CTX *, const void *, size_t));
+    MOCK_METHOD3(SSL_CMAC_Final, int(CMAC_CTX *, unsigned char *, size_t *));
+    MOCK_METHOD1(SSL_CMAC_resume, int(CMAC_CTX *));
 };
 
 /**
@@ -728,7 +736,7 @@ public:
      * Access the OpenSSLLibMock instance currently
      * maintained. Create a new one, if none is present.
      */
-    static ::testing::NiceMock<OpenSSLLibMock>& getMockInterface();
+    static ::testing::NiceMock<OpenSSLLibMock> &getMockInterface();
 
     /**
      * Reset the current OpenSSLLibMock instance

--- a/tests/unit/test_asymmetric_encryption.cpp
+++ b/tests/unit/test_asymmetric_encryption.cpp
@@ -33,7 +33,7 @@ using namespace mococrw;
 /// \brief Structure to hold a private/public key pair
 struct KeyPair
 {
-    KeyPair(const std::string& publicKey, const std::string& privateKey)
+    KeyPair(const std::string &publicKey, const std::string &privateKey)
             : pubKey(AsymmetricPublicKey::readPublicKeyFromPEM(publicKey))
             , privKey(AsymmetricPrivateKey::readPrivateKeyFromPEM(privateKey, ""))
     {
@@ -46,9 +46,9 @@ struct KeyPair
 /// \brief Structure to hold the input data set for the test cases
 struct NominalDataSet
 {
-    NominalDataSet(const std::string& message,
-                   const std::vector<uint8_t>& encrypted,
-                   const KeyPair& keyPair,
+    NominalDataSet(const std::string &message,
+                   const std::vector<uint8_t> &encrypted,
+                   const KeyPair &keyPair,
                    std::shared_ptr<RSAEncryptionPadding> padding)
             : message(message)
             , encrypted(encrypted)
@@ -70,7 +70,7 @@ class AsymmetricEncryptionTest : public ::testing::Test,
 public:
     static const std::vector<NominalDataSet> nominalDataSet;
 
-    static const NominalDataSet& OAEPPaddingDataSet;
+    static const NominalDataSet &OAEPPaddingDataSet;
 };
 
 /// \brief RSA 1024-bit Pair public/private key
@@ -310,7 +310,7 @@ const std::vector<NominalDataSet> AsymmetricEncryptionTest::nominalDataSet{
          keyPairs2048bit,
          std::make_shared<NoPadding>()}};
 
-const NominalDataSet& AsymmetricEncryptionTest::OAEPPaddingDataSet = nominalDataSet[2];
+const NominalDataSet &AsymmetricEncryptionTest::OAEPPaddingDataSet = nominalDataSet[2];
 
 /**
  * @brief Tests the nominal scenarios of the decryption functionality. The nominal encryption data

--- a/tests/unit/test_ca.cpp
+++ b/tests/unit/test_ca.cpp
@@ -51,8 +51,8 @@ class CATest : public ::testing::Test, public ::testing::WithParamInterface<cert
 public:
     void SetUp() override;
 
-    rootCertAndCa getRootCertAndCa(const AsymmetricKeypair& key,
-                                   const CertificateSigningParameters& caSignParams)
+    rootCertAndCa getRootCertAndCa(const AsymmetricKeypair &key,
+                                   const CertificateSigningParameters &caSignParams)
     {
         auto rootCert = CertificateAuthority::createRootCertificate(
                 key, *_rootCertDetails, 0, _caSignParams);
@@ -188,7 +188,7 @@ void CATest::SetUp()
     _eccCa = std::make_unique<CertificateAuthority>(_signParams, 1, *_rootEccCert, *_rootEccKey);
 }
 
-void testValiditySpan(const X509Certificate& cert,
+void testValiditySpan(const X509Certificate &cert,
                       Asn1Time::Seconds validitySpan,
                       Asn1Time certificationTime)
 {
@@ -269,7 +269,7 @@ TEST_F(CATest, testIterateOnExtensionMap)
              _exampleConstraints->getConfigurationString()},
             {openssl::X509Extension_NID::KeyUsage, _exampleUsage->getConfigurationString()}};
 
-    for (auto& it : _signParams.extensionMap()) {
+    for (auto &it : _signParams.extensionMap()) {
         EXPECT_EQ(it.second.get()->getConfigurationString(), compareStringMap[it.first]);
     }
 

--- a/tests/unit/test_csr.cpp
+++ b/tests/unit/test_csr.cpp
@@ -155,7 +155,7 @@ TEST_P(CSRTest, testCreateCsrFromDerFile)
     auto name = csr.getSubjectName();
 
     std::ofstream of(_derFile);
-    of.write(reinterpret_cast<const char*>(derData.data()), derData.size());
+    of.write(reinterpret_cast<const char *>(derData.data()), derData.size());
     of.close();
 
     CertificateSigningRequest csrCheck = CertificateSigningRequest::fromDERFile(_derFile);
@@ -256,7 +256,7 @@ TEST_P(CSRTest, testCsrSignatureDigest)
         return;
     }
 
-    for (const auto& hashAlgo : hashAlgorithms) {
+    for (const auto &hashAlgo : hashAlgorithms) {
         CertificateSigningRequest csr{*_distinguishedName, data.keypair, std::get<0>(hashAlgo)};
         std::ofstream of(_pemFile, std::ios::trunc);
         of << csr.toPEM();

--- a/tests/unit/test_hash.cpp
+++ b/tests/unit/test_hash.cpp
@@ -201,38 +201,38 @@ TEST_F(HashTest, sha1SingleUpdateBinaryArray)
 {
     EXPECT_THAT(
             utility::toHex(
-                    Hash::sha1().update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3).digest()),
+                    Hash::sha1().update(reinterpret_cast<const uint8_t *>(&"foo"[0]), 3).digest()),
             Eq(sha1_foo));
 }
 
 TEST_F(HashTest, sha256SingleUpdateBinaryArray)
 {
-    EXPECT_THAT(
-            utility::toHex(
-                    Hash::sha256().update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3).digest()),
-            Eq(sha256_foo));
+    EXPECT_THAT(utility::toHex(Hash::sha256()
+                                       .update(reinterpret_cast<const uint8_t *>(&"foo"[0]), 3)
+                                       .digest()),
+                Eq(sha256_foo));
 }
 
 TEST_F(HashTest, sha384SingleUpdateBinaryArray)
 {
-    EXPECT_THAT(
-            utility::toHex(
-                    Hash::sha384().update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3).digest()),
-            Eq(sha384_foo));
+    EXPECT_THAT(utility::toHex(Hash::sha384()
+                                       .update(reinterpret_cast<const uint8_t *>(&"foo"[0]), 3)
+                                       .digest()),
+                Eq(sha384_foo));
 }
 
 TEST_F(HashTest, sha512SingleUpdateBinaryArray)
 {
-    EXPECT_THAT(
-            utility::toHex(
-                    Hash::sha512().update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3).digest()),
-            Eq(sha512_foo));
+    EXPECT_THAT(utility::toHex(Hash::sha512()
+                                       .update(reinterpret_cast<const uint8_t *>(&"foo"[0]), 3)
+                                       .digest()),
+                Eq(sha512_foo));
 }
 
 TEST_F(HashTest, sha3_256SingleUpdateBinaryArray)
 {
     EXPECT_THAT(utility::toHex(Hash::sha3_256()
-                                       .update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3)
+                                       .update(reinterpret_cast<const uint8_t *>(&"foo"[0]), 3)
                                        .digest()),
                 Eq(sha3_256_foo));
 }
@@ -240,7 +240,7 @@ TEST_F(HashTest, sha3_256SingleUpdateBinaryArray)
 TEST_F(HashTest, sha3_384SingleUpdateBinaryArray)
 {
     EXPECT_THAT(utility::toHex(Hash::sha3_384()
-                                       .update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3)
+                                       .update(reinterpret_cast<const uint8_t *>(&"foo"[0]), 3)
                                        .digest()),
                 Eq(sha3_384_foo));
 }
@@ -248,7 +248,7 @@ TEST_F(HashTest, sha3_384SingleUpdateBinaryArray)
 TEST_F(HashTest, sha3_512SingleUpdateBinaryArray)
 {
     EXPECT_THAT(utility::toHex(Hash::sha3_512()
-                                       .update(reinterpret_cast<const uint8_t*>(&"foo"[0]), 3)
+                                       .update(reinterpret_cast<const uint8_t *>(&"foo"[0]), 3)
                                        .digest()),
                 Eq(sha3_512_foo));
 }
@@ -369,7 +369,7 @@ TEST_F(HashTest, sha1StandaloneFunctionBinaryVersion)
 {
     std::string message = "foo";
     std::vector<uint8_t> digest =
-            sha1(reinterpret_cast<const uint8_t*>(message.c_str()), message.length());
+            sha1(reinterpret_cast<const uint8_t *>(message.c_str()), message.length());
     EXPECT_THAT(utility::toHex(digest), Eq(sha1_foo));
 }
 
@@ -377,7 +377,7 @@ TEST_F(HashTest, sha256StandaloneFunctionBinaryVersion)
 {
     std::string message = "foo";
     std::vector<uint8_t> digest =
-            sha256(reinterpret_cast<const uint8_t*>(message.c_str()), message.length());
+            sha256(reinterpret_cast<const uint8_t *>(message.c_str()), message.length());
     EXPECT_THAT(utility::toHex(digest), Eq(sha256_foo));
 }
 
@@ -385,7 +385,7 @@ TEST_F(HashTest, sha384StandaloneFunctionBinaryVersion)
 {
     std::string message = "foo";
     std::vector<uint8_t> digest =
-            sha384(reinterpret_cast<const uint8_t*>(message.c_str()), message.length());
+            sha384(reinterpret_cast<const uint8_t *>(message.c_str()), message.length());
     EXPECT_THAT(utility::toHex(digest), Eq(sha384_foo));
 }
 
@@ -393,7 +393,7 @@ TEST_F(HashTest, sha512StandaloneFunctionBinaryVersion)
 {
     std::string message = "foo";
     std::vector<uint8_t> digest =
-            sha512(reinterpret_cast<const uint8_t*>(message.c_str()), message.length());
+            sha512(reinterpret_cast<const uint8_t *>(message.c_str()), message.length());
     EXPECT_THAT(utility::toHex(digest), Eq(sha512_foo));
 }
 
@@ -401,7 +401,7 @@ TEST_F(HashTest, sha3_256StandaloneFunctionBinaryVersion)
 {
     std::string message = "foo";
     std::vector<uint8_t> digest =
-            sha3_256(reinterpret_cast<const uint8_t*>(message.c_str()), message.length());
+            sha3_256(reinterpret_cast<const uint8_t *>(message.c_str()), message.length());
     EXPECT_THAT(utility::toHex(digest), Eq(sha3_256_foo));
 }
 
@@ -409,7 +409,7 @@ TEST_F(HashTest, sha3_384StandaloneFunctionBinaryVersion)
 {
     std::string message = "foo";
     std::vector<uint8_t> digest =
-            sha3_384(reinterpret_cast<const uint8_t*>(message.c_str()), message.length());
+            sha3_384(reinterpret_cast<const uint8_t *>(message.c_str()), message.length());
     EXPECT_THAT(utility::toHex(digest), Eq(sha3_384_foo));
 }
 
@@ -417,7 +417,7 @@ TEST_F(HashTest, sha3_512StandaloneFunctionBinaryVersion)
 {
     std::string message = "foo";
     std::vector<uint8_t> digest =
-            sha3_512(reinterpret_cast<const uint8_t*>(message.c_str()), message.length());
+            sha3_512(reinterpret_cast<const uint8_t *>(message.c_str()), message.length());
     EXPECT_THAT(utility::toHex(digest), Eq(sha3_512_foo));
 }
 

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -43,7 +43,7 @@ public:
 protected:
     std::string _defaultErrorMessage{"bla bla bla"};
     const unsigned long _defaultErrorCode = 1L;
-    openssl::OpenSSLLibMock& _mock() const
+    openssl::OpenSSLLibMock &_mock() const
     {
         return openssl::OpenSSLLibMockManager::getMockInterface();
     }
@@ -51,11 +51,11 @@ protected:
 
 namespace testutils
 {
-ENGINE* someEnginePtr()
+ENGINE *someEnginePtr()
 {
     /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
     static char dummyBuf[42] = {};
-    return reinterpret_cast<ENGINE*>(&dummyBuf);
+    return reinterpret_cast<ENGINE *>(&dummyBuf);
 }
 }  // namespace testutils
 
@@ -68,7 +68,7 @@ void HSMTest::SetUp()
     openssl::OpenSSLLibMockManager::resetMock();
     ON_CALL(_mock(), SSL_ERR_get_error()).WillByDefault(Return(_defaultErrorCode));
     ON_CALL(_mock(), SSL_ERR_error_string(_, nullptr))
-            .WillByDefault(Return(const_cast<char*>(_defaultErrorMessage.c_str())));
+            .WillByDefault(Return(const_cast<char *>(_defaultErrorMessage.c_str())));
     // TODO: Get rid of the uninteresting calls by default here somehow...
 }
 

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -172,9 +172,9 @@ TEST_F(KeyHandlingTests, testReadExternalEccPEMKey)
 
     auto privSpec = eccPrivKey.getKeySpec();
     auto pubSpec = eccPubKey.getKeySpec();
-    EXPECT_EQ(dynamic_cast<ECCSpec*>(privSpec.get())->curve(),
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(privSpec.get())->curve(),
               openssl::ellipticCurveNid::SECT_409k1);
-    EXPECT_EQ(dynamic_cast<ECCSpec*>(pubSpec.get())->curve(),
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(pubSpec.get())->curve(),
               openssl::ellipticCurveNid::SECT_409k1);
 
     /*Write key to a new pem file and read back to compare with original*/
@@ -202,8 +202,8 @@ TEST_F(KeyHandlingTests, testReadExternalEd25519PEMKey)
 
     auto privSpec = eccPrivKey.getKeySpec();
     auto pubSpec = eccPubKey.getKeySpec();
-    EXPECT_EQ(dynamic_cast<ECCSpec*>(privSpec.get())->curve(), openssl::ellipticCurveNid::Ed25519);
-    EXPECT_EQ(dynamic_cast<ECCSpec*>(pubSpec.get())->curve(), openssl::ellipticCurveNid::Ed25519);
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(privSpec.get())->curve(), openssl::ellipticCurveNid::Ed25519);
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(pubSpec.get())->curve(), openssl::ellipticCurveNid::Ed25519);
 
     /*Write key to a new pem file and read back to compare with original*/
     /*Public key*/
@@ -364,18 +364,18 @@ TEST_F(KeyHandlingTests, testGetKeySpec)
     auto Ed448Spec = _Ed448KeyPair.getKeySpec();
     auto Ed25519Spec = _Ed25519KeyPair.getKeySpec();
 
-    EXPECT_EQ(dynamic_cast<ECCSpec*>(defaultSpec.get())->curve(),
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(defaultSpec.get())->curve(),
               openssl::ellipticCurveNid::PRIME_256v1);
-    EXPECT_EQ(dynamic_cast<ECCSpec*>(Sect571r1Spec.get())->curve(),
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(Sect571r1Spec.get())->curve(),
               openssl::ellipticCurveNid::SECT_571r1);
-    EXPECT_EQ(dynamic_cast<ECCSpec*>(Secp521Spec.get())->curve(),
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(Secp521Spec.get())->curve(),
               openssl::ellipticCurveNid::SECP_521r1);
-    EXPECT_EQ(dynamic_cast<ECCSpec*>(Ed448Spec.get())->curve(), openssl::ellipticCurveNid::Ed448);
-    EXPECT_EQ(dynamic_cast<ECCSpec*>(Ed25519Spec.get())->curve(),
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(Ed448Spec.get())->curve(), openssl::ellipticCurveNid::Ed448);
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(Ed25519Spec.get())->curve(),
               openssl::ellipticCurveNid::Ed25519);
 
     std::unique_ptr<RSASpec> defaultRSASpec(
-            dynamic_cast<RSASpec*>(_rsaKeyPair.getKeySpec().release()));
+            dynamic_cast<RSASpec *>(_rsaKeyPair.getKeySpec().release()));
     EXPECT_EQ(defaultRSASpec->numberOfBits(), 2048);
 }
 

--- a/tests/unit/test_opensslwrapper.cpp
+++ b/tests/unit/test_opensslwrapper.cpp
@@ -52,30 +52,30 @@ public:
 protected:
     std::string _defaultErrorMessage{"bla bla bla"};
     const unsigned long _defaultErrorCode = 1L;
-    OpenSSLLibMock& _mock() const { return OpenSSLLibMockManager::getMockInterface(); }
+    OpenSSLLibMock &_mock() const { return OpenSSLLibMockManager::getMockInterface(); }
 };
 
 namespace testutils
 {
-EVP_PKEY_CTX* somePkeyCtxPtr()
+EVP_PKEY_CTX *somePkeyCtxPtr()
 {
     /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
     static char dummyBuf[42] = {};
-    return reinterpret_cast<EVP_PKEY_CTX*>(&dummyBuf);
+    return reinterpret_cast<EVP_PKEY_CTX *>(&dummyBuf);
 }
 
-EVP_PKEY* somePkeyPtr()
+EVP_PKEY *somePkeyPtr()
 {
     /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
     static char dummyBuf[42] = {};
-    return reinterpret_cast<EVP_PKEY*>(&dummyBuf);
+    return reinterpret_cast<EVP_PKEY *>(&dummyBuf);
 }
 
-ENGINE* someEnginePtr()
+ENGINE *someEnginePtr()
 {
     /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
     static char dummyBuf[42] = {};
-    return reinterpret_cast<ENGINE*>(&dummyBuf);
+    return reinterpret_cast<ENGINE *>(&dummyBuf);
 }
 }  // namespace testutils
 
@@ -88,7 +88,7 @@ void OpenSSLWrapperTest::SetUp()
     OpenSSLLibMockManager::resetMock();
     ON_CALL(_mock(), SSL_ERR_get_error()).WillByDefault(Return(_defaultErrorCode));
     ON_CALL(_mock(), SSL_ERR_error_string(_, nullptr))
-            .WillByDefault(Return(const_cast<char*>(_defaultErrorMessage.c_str())));
+            .WillByDefault(Return(const_cast<char *>(_defaultErrorMessage.c_str())));
     // TODO: Get rid of the uninteresting calls by default here somehow...
 }
 
@@ -178,7 +178,7 @@ TEST_F(OpenSSLWrapperTest, keyGenTest)
  */
 TEST_F(OpenSSLWrapperTest, testAddEntryByNID)
 {
-    X509_NAME* name = nullptr;
+    X509_NAME *name = nullptr;
     constexpr int bufsize = 47;
     std::vector<unsigned char> buffer(bufsize);
     EXPECT_CALL(_mock(),
@@ -203,15 +203,15 @@ TEST_F(OpenSSLWrapperTest, testAddEntryByNID)
 MATCHER_P(IsSameCString, expectedString, "Expect same C-string")
 {
     return 0 == std::strncmp(expectedString.c_str(),
-                             reinterpret_cast<char*>(arg),
+                             reinterpret_cast<char *>(arg),
                              expectedString.size());
 }
 
 TEST_F(OpenSSLWrapperTest, testThatWritingPrivateKeyHandlesArgumentsCorrectly)
 {
-    BIO* bio = nullptr;
-    EVP_PKEY* pkey = nullptr;
-    EVP_CIPHER* cipher = nullptr;
+    BIO *bio = nullptr;
+    EVP_PKEY *pkey = nullptr;
+    EVP_CIPHER *cipher = nullptr;
     const auto pwd = "some password"s;
     EXPECT_CALL(_mock(),
                 SSL_PEM_write_bio_PKCS8PrivateKey(
@@ -228,7 +228,7 @@ TEST_F(OpenSSLWrapperTest, testThatWritingPrivateKeyHandlesArgumentsCorrectly)
 
 TEST_F(OpenSSLWrapperTest, testThatX509ParsingThrowsOnNullptr)
 {
-    BIO* bio = nullptr;
+    BIO *bio = nullptr;
     EXPECT_CALL(_mock(), SSL_PEM_read_bio_X509(bio, nullptr, nullptr, nullptr))
             .WillOnce(Return(nullptr));
     EXPECT_THROW(_PEM_read_bio_X509(bio), OpenSSLException);

--- a/tests/unit/test_padding_mode.cpp
+++ b/tests/unit/test_padding_mode.cpp
@@ -34,8 +34,8 @@ using namespace mococrw;
 /// \brief Structure to hold the data set used to test the message size
 struct MessageSizeDataSet
 {
-    MessageSizeDataSet(const std::string& message,
-                       const AsymmetricPublicKey& pubKey,
+    MessageSizeDataSet(const std::string &message,
+                       const AsymmetricPublicKey &pubKey,
                        std::shared_ptr<RSAEncryptionPadding> padding,
                        bool expectThrow)
             : message(message)

--- a/tests/unit/test_signature.cpp
+++ b/tests/unit/test_signature.cpp
@@ -76,13 +76,13 @@ protected:
     static const X509Certificate _validEd448Certificate;
 
     /* The signatures of the hashed test message with the previously declared private key */
-    static const std::vector<uint8_t>& _validEd25519Signature;
-    static const std::vector<uint8_t>& _validEd448Signature;
-    static const std::vector<uint8_t>& _validPKCS1SignatureSHA256;
-    static const std::vector<uint8_t>& _validEccSignatureSHA1;
+    static const std::vector<uint8_t> &_validEd25519Signature;
+    static const std::vector<uint8_t> &_validEd448Signature;
+    static const std::vector<uint8_t> &_validPKCS1SignatureSHA256;
+    static const std::vector<uint8_t> &_validEccSignatureSHA1;
 
-    static const std::vector<uint8_t>& _validEccIEEE1363SignatureSHA1;
-    static const std::vector<uint8_t>& _eccIEEE1363SignatureSHA1SwappedInts;
+    static const std::vector<uint8_t> &_validEccIEEE1363SignatureSHA1;
+    static const std::vector<uint8_t> &_eccIEEE1363SignatureSHA1SwappedInts;
 
     /* Pre-configured padding modes for RSA operations */
     static const std::shared_ptr<PKCSPadding> _PKCSPadding;
@@ -525,16 +525,16 @@ const std::vector<SignatureTestsStrategy> SignatureTest::SignatureTestData = {
           0xb7, 0x15, 0xb5, 0x33, 0x0e, 0x77, 0xe1, 0xa5, 0x88, 0x9c, 0x77, 0x19, 0xc9,
           0x08, 0x07, 0x44, 0xcc, 0x4e, 0x84, 0xae, 0xda, 0x9c, 0xd7, 0x3a, 0x02}}};
 
-const std::vector<uint8_t>& SignatureTest::_validPKCS1SignatureSHA256 =
+const std::vector<uint8_t> &SignatureTest::_validPKCS1SignatureSHA256 =
         SignatureTestData[1].validSignature;
-const std::vector<uint8_t>& SignatureTest::_validEccSignatureSHA1 =
+const std::vector<uint8_t> &SignatureTest::_validEccSignatureSHA1 =
         SignatureTestData[8].validSignature;
-const std::vector<uint8_t>& SignatureTest::_validEd448Signature =
+const std::vector<uint8_t> &SignatureTest::_validEd448Signature =
         SignatureTestData[12].validSignature;
-const std::vector<uint8_t>& SignatureTest::_validEd25519Signature =
+const std::vector<uint8_t> &SignatureTest::_validEd25519Signature =
         SignatureTestData[14].validSignature;
 
-const std::vector<uint8_t>& SignatureTest::_validEccIEEE1363SignatureSHA1 = {
+const std::vector<uint8_t> &SignatureTest::_validEccIEEE1363SignatureSHA1 = {
         /* r */
         0x08,
         0x2d,
@@ -603,7 +603,7 @@ const std::vector<uint8_t>& SignatureTest::_validEccIEEE1363SignatureSHA1 = {
         0x20,
 };
 
-const std::vector<uint8_t>& SignatureTest::_eccIEEE1363SignatureSHA1SwappedInts = {
+const std::vector<uint8_t> &SignatureTest::_eccIEEE1363SignatureSHA1SwappedInts = {
         /* s */
         0x59,
         0x5f,

--- a/tests/unit/test_symmetric_memory.cpp
+++ b/tests/unit/test_symmetric_memory.cpp
@@ -36,11 +36,11 @@ protected:
     }
 
     void assembleFromChunksAndCompareWithExpected(
-            const std::vector<uint8_t>& expected,
-            const std::vector<std::vector<uint8_t>>& actualChunks) const
+            const std::vector<uint8_t> &expected,
+            const std::vector<std::vector<uint8_t>> &actualChunks) const
     {
         std::vector<uint8_t> readData;
-        for (const auto& chunk : actualChunks) {
+        for (const auto &chunk : actualChunks) {
             readData.insert(std::end(readData), std::begin(chunk), std::end(chunk));
         }
         ASSERT_THAT(readData, ::testing::ElementsAreArray(expected));

--- a/tests/unit/test_verification.cpp
+++ b/tests/unit/test_verification.cpp
@@ -162,7 +162,7 @@ TEST_F(VerificationTest, testExpiredEccCertValidationFails)
             {
                 try {
                     _eccExpiredCert->verify(trustStore, intermediateCAs);
-                } catch (const MoCOCrWException& e) {
+                } catch (const MoCOCrWException &e) {
                     EXPECT_STREQ("certificate has expired", e.what());
                     throw;
                 }
@@ -573,7 +573,7 @@ TEST_F(VerificationTest, testThatLValueInitializerListsAreCopiedToContext)
     EXPECT_NO_THROW(_root1->verify(ctx));
 }
 
-void putCertsInContext(std::initializer_list<X509Certificate>& certs)
+void putCertsInContext(std::initializer_list<X509Certificate> &certs)
 {
     VerificationContext ctx;
     ctx.addTrustedCertificates(certs);


### PR DESCRIPTION
Arranges Pointer alignment setting in clang-format such that alignment is done on the right. Also, removes DerivePointerAlignment so that formatting is deterministic.

Code-base is formatted accordingly.