### PR TITLE
CI: Enable UBSAN, TSAN and Coverage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,17 @@ jobs:
       fail-fast: false
       matrix:
         compiler: ["g++", "clang++"]
-        build_type: ["", "ASAN"]
+        build_type: ["", "ASAN", "UBSAN", "TSAN", "Coverage"]
         hsm_flag: ["HSM_ENABLED=ON", "HSM_ENABLED=OFF"]
+
+        exclude:
+          # UBSAN, TSAN and Coverage are only executed with HSM feature enabled
+          - build_type: "UBSAN"
+            hsm_flag: "HSM_ENABLED=OFF"
+          - build_type: "TSAN"
+            hsm_flag: "HSM_ENABLED=OFF"
+          - build_type: "Coverage"
+            hsm_flag: "HSM_ENABLED=OFF"
 
         include:
           - build_type: "ASAN"


### PR DESCRIPTION
The targets for UBSAN, TSAN and Coverage are defined in CMakeLists.txt, but not enabled in CI, yet.

Enable it!