### PR TITLE
hsm: associate each HsmEngine object with a token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ env:
   TOKEN_LABEL: token-label
   USER_PIN: 1234
   SO_PIN: 4321
-  KEY_LABEL: key_label
-  KEY_ID: 1001
 
 jobs:
   check-format:
@@ -107,8 +105,6 @@ jobs:
             -v "$PWD:/src:rw" -w /src/build ${{ matrix.docker_tag }}  bash -c \
             'if [ "${{ matrix.hsm_flag }}" = "HSM_ENABLED=ON" ]; then \
                 softhsm2-util --init-token --free --label ${{ env.TOKEN_LABEL }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
-                pkcs11-tool --module $MY_MOCOCRW_INSTALL/lib/softhsm/libsofthsm2.so -l --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }} \
-                    --token-label ${{ env.TOKEN_LABEL }} -k --key-type EC:prime256v1 --id ${{ env.KEY_ID }} --label ${{ env.KEY_LABEL }};
             fi \
             && ctest --verbose -j $(nproc) \
             && if [ "${{ matrix.hsm_flag }}" = "HSM_ENABLED=ON" ]; then \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
   to MoCOCrW. Currently, the following functionality is supported:
     - Loading Public Keys
     - Loading Private Keys
+    - Generating EC and RSA keypairs
 
 # Release 4.1.1
 

--- a/examples/hsm-example.cpp
+++ b/examples/hsm-example.cpp
@@ -99,12 +99,11 @@ int main(void)
     std::vector<uint8_t> message = utility::fromHex("deadbeef");
     HsmEngine hsmEngine(id, modulePath, pin);
 
-
-    /************** ECDSA signature **************/
+    /************** ECC key generation and ECDSA **************/
     std::string keyIDEcc("5567");
     auto ecdsaDigestType = DigestTypes::SHA512;
     ECCSpec ecspec;
-    auto eccPrivKey = AsymmetricPrivateKey::genKeyOnHsmGetPrivate(
+    auto eccPrivKey = AsymmetricPrivateKey::generateKeyOnHsm(
             hsmEngine, ecspec, keyIDEcc, "token-label", "DobarKey");
     auto ecdsaSigFormat = ECDSASignatureFormat::ASN1_SEQUENCE_OF_INTS;
 
@@ -119,6 +118,7 @@ int main(void)
      */
     ecdsaVerify(eccPrivKey, ecdsaDigestType, ecdsaSigFormat, signature, message);
 
+    /************** Get pubkey from HSM, store it in PEM file for later use **************/
     /* Use-Case 2: The public key used for verification is stored in the HSM */
     auto pubKeyEcc = AsymmetricPublicKey::readPublicKeyFromHSM(hsmEngine, keyIDEcc);
     ecdsaVerify(pubKeyEcc, ecdsaDigestType, ecdsaSigFormat, signature, message);
@@ -132,10 +132,10 @@ int main(void)
     ecdsaVerify(pubKeyEccFromPEm, ecdsaDigestType, ecdsaSigFormat, signature, message);
     /*********************************************/
 
-    /************** RSA key generation **************/
+    /************** RSA key generation and loading **************/
     std::string keyIDRsa("8890");
     mococrw::RSASpec rsaSpec;
-    auto rsaPrivKey = AsymmetricPrivateKey::genKeyOnHsmGetPrivate(
+    auto rsaPrivKey = AsymmetricPrivateKey::generateKeyOnHsm(
             hsmEngine, rsaSpec, keyIDRsa, "token-label", "BarfoKey");
 
     /* Read public key from HSM */

--- a/examples/hsm-example.cpp
+++ b/examples/hsm-example.cpp
@@ -158,17 +158,18 @@ int main(void)
     // Information for engine loading and key management.
     std::string id("pkcs11");
     std::string modulePath("/usr/lib/softhsm/libsofthsm2.so");
+    std::string tokenLabel("token-label");
     // Don't hardcode the pin in your application, this is just for demonstration purposes
     std::string pin("1234");
+    HsmEngine hsmEngine(id, modulePath, tokenLabel, pin);
     std::vector<uint8_t> message = utility::fromHex("deadbeef");
-    HsmEngine hsmEngine(id, modulePath, pin);
 
     /************** ECC key generation and ECDSA **************/
     std::string keyIDEcc("123");
     auto ecdsaDigestType = DigestTypes::SHA512;
     ECCSpec ecspec;
-    auto eccPrivKey = AsymmetricPrivateKey::generateKeyOnHsm(
-            hsmEngine, ecspec, "token-label", keyIDEcc, "DobarKey");
+    auto eccPrivKey =
+            AsymmetricPrivateKey::generateKeyOnHsm(hsmEngine, ecspec, keyIDEcc, "DobarKey");
     auto ecdsaSigFormat = ECDSASignatureFormat::ASN1_SEQUENCE_OF_INTS;
 
     /* The argument hashFunction is optional. Default is SHA256
@@ -207,8 +208,8 @@ int main(void)
     /**
      * Generate an RSA keypair and load the public part
      */
-    auto rsaPrivKey = AsymmetricPrivateKey::generateKeyOnHsm(
-            hsmEngine, rsaSpec, "token-label", keyIDRsa, "BarfoKey");
+    auto rsaPrivKey =
+            AsymmetricPrivateKey::generateKeyOnHsm(hsmEngine, rsaSpec, keyIDRsa, "BarfoKey");
     auto pubKeyRsa = AsymmetricPublicKey::readPublicKeyFromHSM(hsmEngine, keyIDRsa);
 
     /**

--- a/examples/hsm-example.cpp
+++ b/examples/hsm-example.cpp
@@ -111,8 +111,8 @@ int main(void)
      * The default signature format is ECDSASignatureFormat::ASN1_SEQUENCE_OF_INTS */
     auto signature = ecdsaSign(eccPrivKey, ecdsaDigestType, ecdsaSigFormat, message);
 
-    /* Use-Case 1: You want to check your own signature:
-     * we can use here the private key, as it also contains the public key.
+    /* Use-Case 1: You want to check your own signature.
+     * We can use here the private key, as it also contains the public key.
      * In MoCOCrW the AsymmetricPrivateKey is a specialisation of AsymmetricPublicKey. Thus
      * we do an implicit upcast here.
      */

--- a/examples/hsm-example.cpp
+++ b/examples/hsm-example.cpp
@@ -28,6 +28,69 @@
 
 using namespace mococrw;
 
+std::vector<uint8_t> rsaSign(const AsymmetricPrivateKey &privKey,
+                             const DigestTypes digestType,
+                             std::shared_ptr<RSASignaturePadding> padding,
+                             const std::vector<uint8_t> &message)
+{
+    std::shared_ptr<MessageSignatureCtx> signCtx;
+
+    try {
+        /* Padding is optional. Default: PSSPadding with MGF1 as mask generation function.
+         * DigestType is used as hash function for the padding schemes and for MGF1 (if used) */
+        signCtx = std::make_shared<RSASignaturePrivateKeyCtx>(privKey, digestType, padding);
+    } catch (const MoCOCrWException &e) {
+        std::cerr << "Please check your RSA key. Failure creating context." << std::endl;
+        std::cerr << e.what();
+        exit(EXIT_FAILURE);
+    }
+
+    std::vector<uint8_t> signature;
+    try {
+        signature = signCtx->signMessage(message);
+    } catch (const MoCOCrWException &e) {
+        /* Possible reasons:
+         * - error in openssl (sign, padding, ...)
+         * - Hash function's digest size doesn't match the message's digest size
+         */
+        std::cerr << "Failure occurred during signing." << std::endl;
+        std::cerr << e.what() << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    return signature;
+}
+
+void rsaVerify(const AsymmetricPublicKey &pubKey,
+               std::shared_ptr<RSASignaturePadding> rsaPadding,
+               DigestTypes digestType,
+               const std::vector<uint8_t> &signature,
+               const std::vector<uint8_t> &message)
+{
+    std::shared_ptr<MessageVerificationCtx> verifyCtx;
+    try {
+        /* Padding is optional. Default: PSSPadding with MGF1 as mask generation function.
+         * DigestType is used as hash function for the padding schemes and for MGF1 (if used) */
+        verifyCtx = std::make_shared<RSASignaturePublicKeyCtx>(pubKey, digestType, rsaPadding);
+    } catch (const MoCOCrWException &e) {
+        std::cerr << "Please check your RSA key. Failure creating context." << std::endl;
+        std::cerr << e.what();
+        exit(EXIT_FAILURE);
+    }
+
+    try {
+        verifyCtx->verifyMessage(signature, message);
+    } catch (const MoCOCrWException &e) {
+        /* Possible reasons:
+         * - error in openssl (sign, padding, ...)
+         * - Hash function's digest size doesn't match the message's digest size
+         * - Invalid signature
+         */
+        std::cerr << "Verification failed!" << std::endl;
+        std::cerr << e.what() << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
 std::vector<uint8_t> ecdsaSign(const AsymmetricPrivateKey &privKey,
                                const DigestTypes digestType,
                                const ECDSASignatureFormat sigFormat,
@@ -95,56 +158,70 @@ int main(void)
     // Information for engine loading and key management.
     std::string id("pkcs11");
     std::string modulePath("/usr/lib/softhsm/libsofthsm2.so");
+    // Don't hardcode the pin in your application, this is just for demonstration purposes
     std::string pin("1234");
     std::vector<uint8_t> message = utility::fromHex("deadbeef");
     HsmEngine hsmEngine(id, modulePath, pin);
 
     /************** ECC key generation and ECDSA **************/
-    std::string keyIDEcc("5567");
+    std::string keyIDEcc("123");
     auto ecdsaDigestType = DigestTypes::SHA512;
     ECCSpec ecspec;
     auto eccPrivKey = AsymmetricPrivateKey::generateKeyOnHsm(
-            hsmEngine, ecspec, keyIDEcc, "token-label", "DobarKey");
+            hsmEngine, ecspec, "token-label", keyIDEcc, "DobarKey");
     auto ecdsaSigFormat = ECDSASignatureFormat::ASN1_SEQUENCE_OF_INTS;
 
     /* The argument hashFunction is optional. Default is SHA256
      * The default signature format is ECDSASignatureFormat::ASN1_SEQUENCE_OF_INTS */
-    auto signature = ecdsaSign(eccPrivKey, ecdsaDigestType, ecdsaSigFormat, message);
+    auto ECDSAsignature = ecdsaSign(eccPrivKey, ecdsaDigestType, ecdsaSigFormat, message);
 
     /* Use-Case 1: You want to check your own signature.
      * We can use here the private key, as it also contains the public key.
      * In MoCOCrW the AsymmetricPrivateKey is a specialisation of AsymmetricPublicKey. Thus
      * we do an implicit upcast here.
      */
-    ecdsaVerify(eccPrivKey, ecdsaDigestType, ecdsaSigFormat, signature, message);
+    ecdsaVerify(eccPrivKey, ecdsaDigestType, ecdsaSigFormat, ECDSAsignature, message);
 
-    /************** Get pubkey from HSM, store it in PEM file for later use **************/
     /* Use-Case 2: The public key used for verification is stored in the HSM */
     auto pubKeyEcc = AsymmetricPublicKey::readPublicKeyFromHSM(hsmEngine, keyIDEcc);
-    ecdsaVerify(pubKeyEcc, ecdsaDigestType, ecdsaSigFormat, signature, message);
+    ecdsaVerify(pubKeyEcc, ecdsaDigestType, ecdsaSigFormat, ECDSAsignature, message);
 
     /* Use-Case 3: You want to write the public key to a PEM file and use it later
      * for verification
      */
     auto pubKeyPem = eccPrivKey.publicKeyToPem();
-    /* Omitted: Write PEM data to a file and read it again */
-    auto pubKeyEccFromPEm = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pubKeyPem);
-    ecdsaVerify(pubKeyEccFromPEm, ecdsaDigestType, ecdsaSigFormat, signature, message);
+    /* Write PEM data to a file and read it again */
+    auto pubKeyEccFromPem = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pubKeyPem);
+    ecdsaVerify(pubKeyEccFromPem, ecdsaDigestType, ecdsaSigFormat, ECDSAsignature, message);
     /*********************************************/
 
-    /************** RSA key generation and loading **************/
-    std::string keyIDRsa("8890");
+    /************** RSA key generation, loading and digital signatures **************/
+    std::string keyIDRsa("12");
+    auto mgf1DigestType = DigestTypes::SHA256;
     mococrw::RSASpec rsaSpec;
-    auto rsaPrivKey = AsymmetricPrivateKey::generateKeyOnHsm(
-            hsmEngine, rsaSpec, keyIDRsa, "token-label", "BarfoKey");
+    auto rsaSignatureDigestType = DigestTypes::SHA512;
+    auto mgf1 = std::make_shared<MGF1>(mgf1DigestType);
+    int saltLength = mococrw::Hash::getDigestSize(rsaSignatureDigestType);
+    auto padding = std::make_shared<PSSPadding>(mgf1, saltLength);
 
-    /* Read public key from HSM */
+    /**
+     * Generate an RSA keypair and load the public part
+     */
+    auto rsaPrivKey = AsymmetricPrivateKey::generateKeyOnHsm(
+            hsmEngine, rsaSpec, "token-label", keyIDRsa, "BarfoKey");
     auto pubKeyRsa = AsymmetricPublicKey::readPublicKeyFromHSM(hsmEngine, keyIDRsa);
 
-    /* Do whatever you want using the private and public key. See rsa-example.cpp or
-     * sig-example.cpp for further examples.
+    /**
+     * Do signing/verification
      */
-    /*********************************************/
+    auto RSAsignature = rsaSign(rsaPrivKey, rsaSignatureDigestType, padding, message);
+    // We can use here the private key, as it also contains the public key.
+    rsaVerify(rsaPrivKey, padding, rsaSignatureDigestType, RSAsignature, message);
+    // ... or you can use the public key
+    rsaVerify(pubKeyRsa, padding, rsaSignatureDigestType, RSAsignature, message);
+    /**
+     * See rsa-example.cpp or sig-example.cpp for further examples.
+     */
 
     return 0;
 }

--- a/examples/sig-example.cpp
+++ b/examples/sig-example.cpp
@@ -210,9 +210,9 @@ int main(void)
      */
     auto mgf1DigestType = DigestTypes::SHA256;
     auto rsaSignatureDigestType = DigestTypes::SHA512;
-    auto mgf1 = std::make_shared<MGF1>(MGF1(mgf1DigestType));
+    auto mgf1 = std::make_shared<MGF1>(mgf1DigestType);
     int saltLength = mococrw::Hash::getDigestSize(rsaSignatureDigestType);
-    auto padding = std::make_shared<PSSPadding>(PSSPadding(mgf1, saltLength));
+    auto padding = std::make_shared<PSSPadding>(mgf1, saltLength);
 
     /* Padding is optional. Default: PSSPadding with MGF1 as mask generation function
      * (both using the same digest type (e.g. SHA-256) */

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -88,16 +88,16 @@ void HsmEngine::genKey(const RSASpec &spec,
                        const std::string &tokenLabel,
                        const std::string &keyLabel)
 {
-    PKCS11_RSA_KGEN rsa;
-    rsa.bits = spec.numberOfBits();
-    PKCS11_KGEN_ATTRS kg;
-    kg.type = EVP_PKEY_RSA;
-    kg.kgen.rsa = &rsa;
-    kg.key_id = keyID.c_str();
-    kg.token_label = tokenLabel.c_str();
-    kg.key_label = keyLabel.c_str();
+    PKCS11_RSA_KGEN pkcs11_rsa_spec;
+    pkcs11_rsa_spec.bits = spec.numberOfBits();
+    PKCS11_KGEN_ATTRS pkcs11_rsa_kg;
+    pkcs11_rsa_kg.type = EVP_PKEY_RSA;
+    pkcs11_rsa_kg.kgen.rsa = &pkcs11_rsa_spec;
+    pkcs11_rsa_kg.key_id = keyID.c_str();
+    pkcs11_rsa_kg.token_label = tokenLabel.c_str();
+    pkcs11_rsa_kg.key_label = keyLabel.c_str();
 
-    _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &kg);
+    _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11_rsa_kg);
 }
 
 void HsmEngine::genKey(const ECCSpec &spec,
@@ -105,17 +105,17 @@ void HsmEngine::genKey(const ECCSpec &spec,
                        const std::string &tokenLabel,
                        const std::string &keyLabel)
 {
-    PKCS11_EC_KGEN ec;
+    PKCS11_EC_KGEN pkcs11_ec_spec;
     auto curve = _EC_curve_nid2nist(int(spec.curve()));
-    ec.curve = curve.c_str();
-    PKCS11_KGEN_ATTRS kg;
-    kg.type = EVP_PKEY_EC;
-    kg.kgen.ec = &ec;
-    kg.key_id = keyID.c_str();
-    kg.token_label = tokenLabel.c_str();
-    kg.key_label = keyLabel.c_str();
+    pkcs11_ec_spec.curve = curve.c_str();
+    PKCS11_KGEN_ATTRS pkcs11_ec_kg;
+    pkcs11_ec_kg.type = EVP_PKEY_EC;
+    pkcs11_ec_kg.kgen.ec = &pkcs11_ec_spec;
+    pkcs11_ec_kg.key_id = keyID.c_str();
+    pkcs11_ec_kg.token_label = tokenLabel.c_str();
+    pkcs11_ec_kg.key_label = keyLabel.c_str();
 
-    _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &kg);
+    _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11_ec_kg);
 }
 
 }  // namespace mococrw

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -39,53 +39,76 @@ HsmEngine::~HsmEngine() { _ENGINE_finish(_engine.get()); }
 
 openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPublicKey(const std::string &keyID) const
 {
-    return _ENGINE_load_public_key(_engine.get(), keyID);
+    // Do a copy here to avoid function side effects
+    std::string evenLengthKeyID = keyID;
+    if (keyID.length() % 2 != 0) {
+        evenLengthKeyID = "0" + evenLengthKeyID;
+    }
+    return _ENGINE_load_public_key(_engine.get(), evenLengthKeyID);
 }
 
 openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPrivateKey(const std::string &keyID) const
 {
-    return _ENGINE_load_private_key(_engine.get(), keyID);
+    // Do a copy here to avoid function side effects
+    std::string evenLengthKeyID = keyID;
+    if (keyID.length() % 2 != 0) {
+        evenLengthKeyID = "0" + evenLengthKeyID;
+    }
+    return _ENGINE_load_private_key(_engine.get(), evenLengthKeyID);
 }
 
 openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
-                                                 const std::string &keyID,
                                                  const std::string &tokenLabel,
-                                                 const std::string &keyLabel) const
+                                                 const std::string &keyID,
+                                                 const std::string &keyLabel)
 {
-    PKCS11_RSA_KGEN pkcs11_rsa_spec;
-    pkcs11_rsa_spec.bits = spec.numberOfBits();
-    PKCS11_KGEN_ATTRS pkcs11_rsa_kg;
-    pkcs11_rsa_kg.type = EVP_PKEY_RSA;
-    pkcs11_rsa_kg.kgen.rsa = &pkcs11_rsa_spec;
-    pkcs11_rsa_kg.key_id = keyID.c_str();
-    pkcs11_rsa_kg.token_label = tokenLabel.c_str();
-    pkcs11_rsa_kg.key_label = keyLabel.c_str();
+    /** Key IDs are stored on HSM as a series of bytes. In case of odd number of hex characters
+     * in keyID, prepend 0. This should ideally be handled in lower level modules (libp11)
+     * in this case but it's not. This makes sure key IDs are sanely set irrespective
+     * of lower level implementation.
+     */
+    std::string evenLengthKeyID = keyID;
+    if (keyID.length() % 2 != 0) {
+        evenLengthKeyID = "0" + evenLengthKeyID;
+    }
+    PKCS11_RSA_KGEN pkcs11RSASpec;
+    pkcs11RSASpec.bits = spec.numberOfBits();
+    PKCS11_KGEN_ATTRS pkcs11RSAKeygen;
+    pkcs11RSAKeygen.type = EVP_PKEY_RSA;
+    pkcs11RSAKeygen.kgen.rsa = &pkcs11RSASpec;
+    pkcs11RSAKeygen.key_id = evenLengthKeyID.c_str();
+    pkcs11RSAKeygen.token_label = tokenLabel.c_str();
+    pkcs11RSAKeygen.key_label = keyLabel.c_str();
 
-    _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11_rsa_kg);
+    _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11RSAKeygen);
     return loadPrivateKey(keyID);
 }
 
 openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
-                                                 const std::string &keyID,
                                                  const std::string &tokenLabel,
-                                                 const std::string &keyLabel) const
+                                                 const std::string &keyID,
+                                                 const std::string &keyLabel)
 {
-    PKCS11_EC_KGEN pkcs11_ec_spec;
-    std::string curve{};
-    try {
-        curve = _EC_curve_nid2nist(int(spec.curve()));
-    } catch (const OpenSSLException &e) {
-        throw MoCOCrWException("Invalid EC NID. Check the ECCSpec.");
+    std::string curve = spec.curveName();
+    /** Key IDs are stored on HSM as a series of bytes. In case of odd number of hex characters
+     * in keyID, prepend 0. This should ideally be handled in lower level modules (libp11)
+     * in this case but it's not. This makes sure key IDs are sanely set irrespective
+     * of lower level implementation.
+     */
+    std::string evenLengthKeyID = keyID;
+    if (keyID.length() % 2 != 0) {
+        evenLengthKeyID = "0" + evenLengthKeyID;
     }
-    pkcs11_ec_spec.curve = curve.c_str();
-    PKCS11_KGEN_ATTRS pkcs11_ec_kg;
-    pkcs11_ec_kg.type = EVP_PKEY_EC;
-    pkcs11_ec_kg.kgen.ec = &pkcs11_ec_spec;
-    pkcs11_ec_kg.key_id = keyID.c_str();
-    pkcs11_ec_kg.token_label = tokenLabel.c_str();
-    pkcs11_ec_kg.key_label = keyLabel.c_str();
+    PKCS11_EC_KGEN pkcs11ECCSpec;
+    pkcs11ECCSpec.curve = curve.c_str();
+    PKCS11_KGEN_ATTRS pkcs11ECCKeygen;
+    pkcs11ECCKeygen.type = EVP_PKEY_EC;
+    pkcs11ECCKeygen.kgen.ec = &pkcs11ECCSpec;
+    pkcs11ECCKeygen.key_id = evenLengthKeyID.c_str();
+    pkcs11ECCKeygen.token_label = tokenLabel.c_str();
+    pkcs11ECCKeygen.key_label = keyLabel.c_str();
 
-    _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11_ec_kg);
+    _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11ECCKeygen);
     return loadPrivateKey(keyID);
 }
 }  // namespace mococrw

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -192,42 +192,6 @@ AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromHSM(const HSM &hsm, const
     auto key = hsm.loadPrivateKey(keyID);
     return AsymmetricKeypair{std::move(key)};
 }
-
-AsymmetricKeypair AsymmetricKeypair::generateKeyOnHsm(const HSM &hsm,
-                                                      const ECCSpec &spec,
-                                                      const std::string &keyID,
-                                                      const std::string &tokenLabel,
-                                                      const std::string &keyLabel)
-{
-    try {
-        auto key = hsm.generateKey(spec, keyID, tokenLabel, keyLabel);
-        return AsymmetricKeypair{std::move(key)};
-    } catch (const OpenSSLException &e) {
-        throw MoCOCrWException(
-                std::string("Key generation failed for unknown reason. Likely reasons: invalid "
-                            "spec, keyID containing non-hex chars, wrong tokenLabel, broken HSM "
-                            "module implementation. OpenSSL error: ") +
-                e.what());
-    }
-}
-
-AsymmetricKeypair AsymmetricKeypair::generateKeyOnHsm(const HSM &hsm,
-                                                      const RSASpec &spec,
-                                                      const std::string &keyID,
-                                                      const std::string &tokenLabel,
-                                                      const std::string &keyLabel)
-{
-    try {
-        auto key = hsm.generateKey(spec, keyID, tokenLabel, keyLabel);
-        return AsymmetricKeypair{std::move(key)};
-    } catch (const OpenSSLException &e) {
-        throw MoCOCrWException(
-                std::string("Key generation failed for unknown reason. Likely reasons: invalid "
-                            "spec, keyID containing non-hex chars, wrong tokenLabel, broken HSM "
-                            "module implementation. OpenSSL error: ") +
-                e.what());
-    }
-}
 #endif
 
 AsymmetricKey RSASpec::generate() const

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -112,6 +112,26 @@ AsymmetricPublicKey AsymmetricPublicKey::readPublicKeyFromHSM(HSM &hsm, const st
     auto key = hsm.loadPublicKey(keyID);
     return AsymmetricPublicKey{std::move(key)};
 }
+
+AsymmetricPublicKey AsymmetricPublicKey::genKeyOnHsmGetPublic(HSM &hsm,
+                                                              const ECCSpec &spec,
+                                                              const std::string &keyID,
+                                                              const std::string &tokenLabel,
+                                                              const std::string &keyLabel)
+{
+    auto key = hsm.genKeyGetPublic(spec, keyID, tokenLabel, keyLabel);
+    return AsymmetricPublicKey{std::move(key)};
+}
+
+AsymmetricPublicKey AsymmetricPublicKey::genKeyOnHsmGetPublic(HSM &hsm,
+                                                              const RSASpec &spec,
+                                                              const std::string &keyID,
+                                                              const std::string &tokenLabel,
+                                                              const std::string &keyLabel)
+{
+    auto key = hsm.genKeyGetPublic(spec, keyID, tokenLabel, keyLabel);
+    return AsymmetricPublicKey{std::move(key)};
+}
 #endif
 
 AsymmetricPublicKey AsymmetricPublicKey::fromECPoint(const std::shared_ptr<ECCSpec> keySpec,
@@ -189,6 +209,26 @@ AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromPEM(const std::string &pe
 AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromHSM(HSM &hsm, const std::string &keyID)
 {
     auto key = hsm.loadPrivateKey(keyID);
+    return AsymmetricKeypair{std::move(key)};
+}
+
+AsymmetricKeypair AsymmetricKeypair::genKeyOnHsmGetPrivate(HSM &hsm,
+                                                           const ECCSpec &spec,
+                                                           const std::string &keyID,
+                                                           const std::string &tokenLabel,
+                                                           const std::string &keyLabel)
+{
+    auto key = hsm.genKeyGetPrivate(spec, keyID, tokenLabel, keyLabel);
+    return AsymmetricKeypair{std::move(key)};
+}
+
+AsymmetricKeypair AsymmetricKeypair::genKeyOnHsmGetPrivate(HSM &hsm,
+                                                           const RSASpec &spec,
+                                                           const std::string &keyID,
+                                                           const std::string &tokenLabel,
+                                                           const std::string &keyLabel)
+{
+    auto key = hsm.genKeyGetPrivate(spec, keyID, tokenLabel, keyLabel);
     return AsymmetricKeypair{std::move(key)};
 }
 #endif

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -195,7 +195,6 @@ AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromHSM(const HSM &hsm, const
 
 AsymmetricKeypair AsymmetricKeypair::generateKeyOnHsm(HSM &hsm,
                                                       const RSASpec &spec,
-                                                      const std::string &tokenLabel,
                                                       const std::string &keyID,
                                                       const std::string &keyLabel)
 {
@@ -208,7 +207,7 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHsm(HSM &hsm,
         throw MoCOCrWException("Invalid keyID - key contains non-hex characters");
     }
     try {
-        auto key = hsm.generateKey(spec, tokenLabel, keyID, keyLabel);
+        auto key = hsm.generateKey(spec, keyID, keyLabel);
         return AsymmetricKeypair{std::move(key)};
     } catch (const openssl::OpenSSLException &e) {
         throw MoCOCrWException(
@@ -220,7 +219,6 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHsm(HSM &hsm,
 
 AsymmetricKeypair AsymmetricKeypair::generateKeyOnHsm(HSM &hsm,
                                                       const ECCSpec &spec,
-                                                      const std::string &tokenLabel,
                                                       const std::string &keyID,
                                                       const std::string &keyLabel)
 {
@@ -233,7 +231,7 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHsm(HSM &hsm,
         throw MoCOCrWException("Invalid keyID - key contains non-hex characters");
     }
     try {
-        auto key = hsm.generateKey(spec, tokenLabel, keyID, keyLabel);
+        auto key = hsm.generateKey(spec, keyID, keyLabel);
         return AsymmetricKeypair{std::move(key)};
     } catch (const openssl::OpenSSLException &e) {
         throw MoCOCrWException(

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -192,6 +192,56 @@ AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromHSM(const HSM &hsm, const
     auto key = hsm.loadPrivateKey(keyID);
     return AsymmetricKeypair{std::move(key)};
 }
+
+AsymmetricKeypair AsymmetricKeypair::generateKeyOnHsm(HSM &hsm,
+                                                      const RSASpec &spec,
+                                                      const std::string &tokenLabel,
+                                                      const std::string &keyID,
+                                                      const std::string &keyLabel)
+{
+    // libp11 uses 128 byte buffer
+    if (keyID.length() > 127) {
+        throw MoCOCrWException("Invalid keyID - key longer than 127 characters");
+    }
+    if (!std::all_of(
+                keyID.begin(), keyID.end(), [](unsigned char c) { return std::isxdigit(c); })) {
+        throw MoCOCrWException("Invalid keyID - key contains non-hex characters");
+    }
+    try {
+        auto key = hsm.generateKey(spec, tokenLabel, keyID, keyLabel);
+        return AsymmetricKeypair{std::move(key)};
+    } catch (const openssl::OpenSSLException &e) {
+        throw MoCOCrWException(
+                // wrong token-label? using unsupported ECC curve? HSM module implementation?
+                std::string("Key generation failed for unknown reason. OpenSSL error: ") +
+                e.what());
+    }
+}
+
+AsymmetricKeypair AsymmetricKeypair::generateKeyOnHsm(HSM &hsm,
+                                                      const ECCSpec &spec,
+                                                      const std::string &tokenLabel,
+                                                      const std::string &keyID,
+                                                      const std::string &keyLabel)
+{
+    // libp11 uses 128 byte buffer
+    if (keyID.length() > 127) {
+        throw MoCOCrWException("Invalid keyID - key longer than 127 characters");
+    }
+    if (!std::all_of(
+                keyID.begin(), keyID.end(), [](unsigned char c) { return std::isxdigit(c); })) {
+        throw MoCOCrWException("Invalid keyID - key contains non-hex characters");
+    }
+    try {
+        auto key = hsm.generateKey(spec, tokenLabel, keyID, keyLabel);
+        return AsymmetricKeypair{std::move(key)};
+    } catch (const openssl::OpenSSLException &e) {
+        throw MoCOCrWException(
+                // wrong token-label? using unsupported ECC curve? HSM module implementation?
+                std::string("Key generation failed for unknown reason. OpenSSL error: ") +
+                e.what());
+    }
+}
 #endif
 
 AsymmetricKey RSASpec::generate() const

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -94,16 +94,6 @@ public:
     HsmEngine(const std::string &id, const std::string &modulePath, const std::string &pin);
     virtual ~HsmEngine();
 
-    openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
-                                          const std::string &keyID,
-                                          const std::string &tokenLabel,
-                                          const std::string &keyLabel) const override;
-
-    openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
-                                          const std::string &keyID,
-                                          const std::string &tokenLabel,
-                                          const std::string &keyLabel) const override;
-
 protected:
     /** Pointer to OpenSSL ENGINE. */
     openssl::SSL_ENGINE_Ptr _engine;
@@ -117,6 +107,16 @@ protected:
     openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) const override;
 
     openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) const override;
+
+    openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
+                                          const std::string &keyID,
+                                          const std::string &tokenLabel,
+                                          const std::string &keyLabel) const override;
+
+    openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
+                                          const std::string &keyID,
+                                          const std::string &tokenLabel,
+                                          const std::string &keyLabel) const override;
 };
 
 }  // namespace mococrw

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -62,7 +62,6 @@ protected:
      * @param spec The RSA specification @ref RSASpec
      */
     virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
-                                                  const std::string &tokenLabel,
                                                   const std::string &keyID,
                                                   const std::string &keyLabel) = 0;
 
@@ -72,18 +71,24 @@ protected:
      * @param spec The ECC specification @ref ECCSpec
      */
     virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
-                                                  const std::string &tokenLabel,
                                                   const std::string &keyID,
                                                   const std::string &keyLabel) = 0;
 };
 
 /**
- * Abstract class of an HSMEngine that leverages OpenSSL's ENGINE_* API interface.
+ * Hsm handling that leverages OpenSSL's ENGINE_* API interface.
  */
 class HsmEngine : public HSM
 {
 public:
-    HsmEngine(const std::string &id, const std::string &modulePath, const std::string &pin);
+    /**
+     * @note Each HsmEngine object is associated with a specific token and a pin to login to that
+     * token
+     */
+    HsmEngine(const std::string &id,
+              const std::string &modulePath,
+              const std::string &tokenLabel,
+              const std::string &pin);
     virtual ~HsmEngine();
 
 protected:
@@ -93,6 +98,8 @@ protected:
     const std::string _id;
     /** Path to Module. */
     const std::string _modulePath;
+    /** Token label used to uniquely identify a token on which objects reside */
+    const std::string _tokenLabel;
     /** Pin to access PKCS11 Engine. */
     const std::string _pin;
 
@@ -101,12 +108,10 @@ protected:
     openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) const override;
 
     openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
-                                          const std::string &tokenLabel,
                                           const std::string &keyID,
                                           const std::string &keyLabel) override;
 
     openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
-                                          const std::string &tokenLabel,
                                           const std::string &keyID,
                                           const std::string &keyLabel) override;
 };

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -22,6 +22,8 @@
 
 namespace mococrw
 {
+class ECCSpec;
+class RSASpec;
 /**
  * The highest-level abstract class of a Hardware Security Module (HSM).
  *
@@ -53,6 +55,36 @@ protected:
      * @param keyID The ID of the private key to load.
      */
     virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) = 0;
+
+    virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPublic(const RSASpec &spec,
+                                                      const std::string &keyID,
+                                                      const std::string &tokenLabel,
+                                                      const std::string &keyLabel) = 0;
+
+    virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPublic(const ECCSpec &spec,
+                                                      const std::string &keyID,
+                                                      const std::string &tokenLabel,
+                                                      const std::string &keyLabel) = 0;
+
+    virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPrivate(const RSASpec &spec,
+                                                       const std::string &keyID,
+                                                       const std::string &tokenLabel,
+                                                       const std::string &keyLabel) = 0;
+
+    virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPrivate(const ECCSpec &spec,
+                                                       const std::string &keyID,
+                                                       const std::string &tokenLabel,
+                                                       const std::string &keyLabel) = 0;
+
+    virtual void genKey(const RSASpec &spec,
+                        const std::string &keyID,
+                        const std::string &tokenLabel,
+                        const std::string &keyLabel) = 0;
+
+    virtual void genKey(const ECCSpec &spec,
+                        const std::string &keyID,
+                        const std::string &tokenLabel,
+                        const std::string &keyLabel) = 0;
 };
 
 /**
@@ -77,6 +109,36 @@ protected:
     openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) override;
 
     openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) override;
+
+    openssl::SSL_EVP_PKEY_Ptr genKeyGetPublic(const RSASpec &spec,
+                                              const std::string &keyID,
+                                              const std::string &tokenLabel,
+                                              const std::string &keyLabel) override;
+
+    openssl::SSL_EVP_PKEY_Ptr genKeyGetPublic(const ECCSpec &spec,
+                                              const std::string &keyID,
+                                              const std::string &tokenLabel,
+                                              const std::string &keyLabel) override;
+
+    openssl::SSL_EVP_PKEY_Ptr genKeyGetPrivate(const RSASpec &spec,
+                                               const std::string &keyID,
+                                               const std::string &tokenLabel,
+                                               const std::string &keyLabel) override;
+
+    openssl::SSL_EVP_PKEY_Ptr genKeyGetPrivate(const ECCSpec &spec,
+                                               const std::string &keyID,
+                                               const std::string &tokenLabel,
+                                               const std::string &keyLabel) override;
+
+    void genKey(const RSASpec &spec,
+                const std::string &keyID,
+                const std::string &tokenLabel,
+                const std::string &keyLabel) override;
+
+    void genKey(const ECCSpec &spec,
+                const std::string &keyID,
+                const std::string &tokenLabel,
+                const std::string &keyLabel) override;
 };
 
 }  // namespace mococrw

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -56,21 +56,44 @@ protected:
      */
     virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) = 0;
 
+    /**
+     * @brief Generate a key pair in the HSM, return the public key
+     *
+     * @param spec The RSA specification, which shall be used for key generation
+     * @param keyID The key identifier
+     * @param tokenLabel The token label
+     * @param keyLabel The key label
+     * @return openssl::SSL_EVP_PKEY_Ptr
+     */
     virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPublic(const RSASpec &spec,
                                                       const std::string &keyID,
                                                       const std::string &tokenLabel,
                                                       const std::string &keyLabel) = 0;
-
+    /**
+     * @brief Overloaded for ECC specs
+     */
     virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPublic(const ECCSpec &spec,
                                                       const std::string &keyID,
                                                       const std::string &tokenLabel,
                                                       const std::string &keyLabel) = 0;
 
+    /**
+     * @brief Generate a key pair in the HSM, return the private key
+     *
+     * @param spec The RSA specification, which shall be used for key generation
+     * @param keyID The key identifier
+     * @param tokenLabel The token label
+     * @param keyLabel The key label
+     * @return openssl::SSL_EVP_PKEY_Ptr
+     */
     virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPrivate(const RSASpec &spec,
                                                        const std::string &keyID,
                                                        const std::string &tokenLabel,
                                                        const std::string &keyLabel) = 0;
 
+    /**
+     * @brief Overloaded for ECC specs
+     */
     virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPrivate(const ECCSpec &spec,
                                                        const std::string &keyID,
                                                        const std::string &tokenLabel,

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -43,71 +43,46 @@ public:
 
 protected:
     /**
+     * @brief Generate a RSA key pair on the HSM
+     *
+     * @param spec The RSA specification @ref RSASpec
+     * @param keyID The key identifier
+     * @param tokenLabel The token label
+     * @param keyLabel The key label
+     * @return AsymmetricKeypair @ref AsymmetricKeypair
+     */
+    virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
+                                                  const std::string &keyID,
+                                                  const std::string &tokenLabel,
+                                                  const std::string &keyLabel) const = 0;
+
+    /**
+     * @brief Generate a ECC key pair on the HSM
+     *
+     * @param spec The ECC specification @ref ECCSpec
+     * @param keyID The key identifier
+     * @param tokenLabel The token label
+     * @param keyLabel The key label
+     * @return AsymmetricKeypair @ref AsymmetricKeypair
+     */
+    virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
+                                                  const std::string &keyID,
+                                                  const std::string &tokenLabel,
+                                                  const std::string &keyLabel) const = 0;
+
+    /**
      *  Loads public key from HSM.
      *
      *  @param keyID The ID of the public key to load.
      */
-    virtual openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) = 0;
+    virtual openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) const = 0;
 
     /**
      * Loads private key from HSM.
      *
      * @param keyID The ID of the private key to load.
      */
-    virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) = 0;
-
-    /**
-     * @brief Generate a key pair in the HSM, return the public key
-     *
-     * @param spec The RSA specification, which shall be used for key generation
-     * @param keyID The key identifier
-     * @param tokenLabel The token label
-     * @param keyLabel The key label
-     * @return openssl::SSL_EVP_PKEY_Ptr
-     */
-    virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPublic(const RSASpec &spec,
-                                                      const std::string &keyID,
-                                                      const std::string &tokenLabel,
-                                                      const std::string &keyLabel) = 0;
-    /**
-     * @brief Overloaded for ECC specs
-     */
-    virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPublic(const ECCSpec &spec,
-                                                      const std::string &keyID,
-                                                      const std::string &tokenLabel,
-                                                      const std::string &keyLabel) = 0;
-
-    /**
-     * @brief Generate a key pair in the HSM, return the private key
-     *
-     * @param spec The RSA specification, which shall be used for key generation
-     * @param keyID The key identifier
-     * @param tokenLabel The token label
-     * @param keyLabel The key label
-     * @return openssl::SSL_EVP_PKEY_Ptr
-     */
-    virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPrivate(const RSASpec &spec,
-                                                       const std::string &keyID,
-                                                       const std::string &tokenLabel,
-                                                       const std::string &keyLabel) = 0;
-
-    /**
-     * @brief Overloaded for ECC specs
-     */
-    virtual openssl::SSL_EVP_PKEY_Ptr genKeyGetPrivate(const ECCSpec &spec,
-                                                       const std::string &keyID,
-                                                       const std::string &tokenLabel,
-                                                       const std::string &keyLabel) = 0;
-
-    virtual void genKey(const RSASpec &spec,
-                        const std::string &keyID,
-                        const std::string &tokenLabel,
-                        const std::string &keyLabel) = 0;
-
-    virtual void genKey(const ECCSpec &spec,
-                        const std::string &keyID,
-                        const std::string &tokenLabel,
-                        const std::string &keyLabel) = 0;
+    virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) const = 0;
 };
 
 /**
@@ -119,6 +94,16 @@ public:
     HsmEngine(const std::string &id, const std::string &modulePath, const std::string &pin);
     virtual ~HsmEngine();
 
+    openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
+                                          const std::string &keyID,
+                                          const std::string &tokenLabel,
+                                          const std::string &keyLabel) const override;
+
+    openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
+                                          const std::string &keyID,
+                                          const std::string &tokenLabel,
+                                          const std::string &keyLabel) const override;
+
 protected:
     /** Pointer to OpenSSL ENGINE. */
     openssl::SSL_ENGINE_Ptr _engine;
@@ -129,39 +114,9 @@ protected:
     /** Pin to access PKCS11 Engine. */
     const std::string _pin;
 
-    openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) override;
+    openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyID) const override;
 
-    openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) override;
-
-    openssl::SSL_EVP_PKEY_Ptr genKeyGetPublic(const RSASpec &spec,
-                                              const std::string &keyID,
-                                              const std::string &tokenLabel,
-                                              const std::string &keyLabel) override;
-
-    openssl::SSL_EVP_PKEY_Ptr genKeyGetPublic(const ECCSpec &spec,
-                                              const std::string &keyID,
-                                              const std::string &tokenLabel,
-                                              const std::string &keyLabel) override;
-
-    openssl::SSL_EVP_PKEY_Ptr genKeyGetPrivate(const RSASpec &spec,
-                                               const std::string &keyID,
-                                               const std::string &tokenLabel,
-                                               const std::string &keyLabel) override;
-
-    openssl::SSL_EVP_PKEY_Ptr genKeyGetPrivate(const ECCSpec &spec,
-                                               const std::string &keyID,
-                                               const std::string &tokenLabel,
-                                               const std::string &keyLabel) override;
-
-    void genKey(const RSASpec &spec,
-                const std::string &keyID,
-                const std::string &tokenLabel,
-                const std::string &keyLabel) override;
-
-    void genKey(const ECCSpec &spec,
-                const std::string &keyID,
-                const std::string &tokenLabel,
-                const std::string &keyLabel) override;
+    openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) const override;
 };
 
 }  // namespace mococrw

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -43,34 +43,6 @@ public:
 
 protected:
     /**
-     * @brief Generate a RSA key pair on the HSM
-     *
-     * @param spec The RSA specification @ref RSASpec
-     * @param keyID The key identifier
-     * @param tokenLabel The token label
-     * @param keyLabel The key label
-     * @return AsymmetricKeypair @ref AsymmetricKeypair
-     */
-    virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
-                                                  const std::string &keyID,
-                                                  const std::string &tokenLabel,
-                                                  const std::string &keyLabel) const = 0;
-
-    /**
-     * @brief Generate a ECC key pair on the HSM
-     *
-     * @param spec The ECC specification @ref ECCSpec
-     * @param keyID The key identifier
-     * @param tokenLabel The token label
-     * @param keyLabel The key label
-     * @return AsymmetricKeypair @ref AsymmetricKeypair
-     */
-    virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
-                                                  const std::string &keyID,
-                                                  const std::string &tokenLabel,
-                                                  const std::string &keyLabel) const = 0;
-
-    /**
      *  Loads public key from HSM.
      *
      *  @param keyID The ID of the public key to load.
@@ -83,6 +55,26 @@ protected:
      * @param keyID The ID of the private key to load.
      */
     virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) const = 0;
+
+    /**
+     * @brief Generate a RSA key pair on the HSM
+     *
+     * @param spec The RSA specification @ref RSASpec
+     */
+    virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
+                                                  const std::string &tokenLabel,
+                                                  const std::string &keyID,
+                                                  const std::string &keyLabel) = 0;
+
+    /**
+     * @brief Generate a ECC key pair on the HSM
+     *
+     * @param spec The ECC specification @ref ECCSpec
+     */
+    virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
+                                                  const std::string &tokenLabel,
+                                                  const std::string &keyID,
+                                                  const std::string &keyLabel) = 0;
 };
 
 /**
@@ -109,14 +101,14 @@ protected:
     openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyID) const override;
 
     openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
-                                          const std::string &keyID,
                                           const std::string &tokenLabel,
-                                          const std::string &keyLabel) const override;
+                                          const std::string &keyID,
+                                          const std::string &keyLabel) override;
 
     openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
-                                          const std::string &keyID,
                                           const std::string &tokenLabel,
-                                          const std::string &keyLabel) const override;
+                                          const std::string &keyID,
+                                          const std::string &keyLabel) override;
 };
 
 }  // namespace mococrw

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -92,6 +92,18 @@ public:
      * object as a result.
      */
     static AsymmetricPublicKey readPublicKeyFromHSM(HSM &hsm, const std::string &keyID);
+
+    static AsymmetricPublicKey genKeyOnHsmGetPublic(HSM &hsm,
+                                                    const RSASpec &spec,
+                                                    const std::string &keyID,
+                                                    const std::string &tokenLabel,
+                                                    const std::string &keyLabel);
+    static AsymmetricPublicKey genKeyOnHsmGetPublic(HSM &hsm,
+                                                    const ECCSpec &spec,
+                                                    const std::string &keyID,
+                                                    const std::string &tokenLabel,
+                                                    const std::string &keyLabel);
+
 #endif
 
     /**
@@ -271,6 +283,17 @@ public:
      * object as a result.
      */
     static AsymmetricKeypair readPrivateKeyFromHSM(HSM &hsm, const std::string &keyID);
+
+    static AsymmetricKeypair genKeyOnHsmGetPrivate(HSM &hsm,
+                                                   const RSASpec &spec,
+                                                   const std::string &keyID,
+                                                   const std::string &tokenLabel,
+                                                   const std::string &keyLabel);
+    static AsymmetricKeypair genKeyOnHsmGetPrivate(HSM &hsm,
+                                                   const ECCSpec &spec,
+                                                   const std::string &keyID,
+                                                   const std::string &tokenLabel,
+                                                   const std::string &keyLabel);
 #endif
 
 private:

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -282,8 +282,6 @@ public:
      * @param spec @ref RSASpec
      * @param keyID ID of the key on HSM. _Only_ hex values are valid because key IDs are stored as
      * raw bytes.
-     * @param tokenLabel Label of the token on HSM. An HSM can have multiple tokens where the keys
-     * are stored. This determines on which token the key shall be stored.
      * @param keyLabel Arbitrary key label
      * @return AsymmetricKeypair @ref AsymmetricKeypair
      * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
@@ -292,7 +290,6 @@ public:
      */
     static AsymmetricKeypair generateKeyOnHsm(HSM &hsm,
                                               const RSASpec &spec,
-                                              const std::string &tokenLabel,
                                               const std::string &keyID,
                                               const std::string &keyLabel);
 
@@ -306,8 +303,6 @@ public:
      * @param spec @ref ECCSpec
      * @param keyID ID of the key on HSM. _Only_ hex values are valid because key IDs are stored as
      * raw bytes.
-     * @param tokenLabel Label of the token on HSM. An HSM can have multiple tokens where the keys
-     * are stored. This determines on which token the key shall be stored.
      * @param keyLabel Arbitrary key label
      * @return AsymmetricKeypair @ref AsymmetricKeypair
      * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
@@ -316,7 +311,6 @@ public:
      */
     static AsymmetricKeypair generateKeyOnHsm(HSM &hsm,
                                               const ECCSpec &spec,
-                                              const std::string &tokenLabel,
                                               const std::string &keyID,
                                               const std::string &keyLabel);
 #endif

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -91,19 +91,7 @@ public:
      * Loads a public key from an HSM, creating an @ref AsymmetricPublicKey
      * object as a result.
      */
-    static AsymmetricPublicKey readPublicKeyFromHSM(HSM &hsm, const std::string &keyID);
-
-    static AsymmetricPublicKey genKeyOnHsmGetPublic(HSM &hsm,
-                                                    const RSASpec &spec,
-                                                    const std::string &keyID,
-                                                    const std::string &tokenLabel,
-                                                    const std::string &keyLabel);
-    static AsymmetricPublicKey genKeyOnHsmGetPublic(HSM &hsm,
-                                                    const ECCSpec &spec,
-                                                    const std::string &keyID,
-                                                    const std::string &tokenLabel,
-                                                    const std::string &keyLabel);
-
+    static AsymmetricPublicKey readPublicKeyFromHSM(const HSM &hsm, const std::string &keyID);
 #endif
 
     /**
@@ -282,18 +270,53 @@ public:
      * Loads a private key from an HSM, creating an @ref AsymmetricPublicKey
      * object as a result.
      */
-    static AsymmetricKeypair readPrivateKeyFromHSM(HSM &hsm, const std::string &keyID);
+    static AsymmetricKeypair readPrivateKeyFromHSM(const HSM &hsm, const std::string &keyID);
 
-    static AsymmetricKeypair genKeyOnHsmGetPrivate(HSM &hsm,
-                                                   const RSASpec &spec,
-                                                   const std::string &keyID,
-                                                   const std::string &tokenLabel,
-                                                   const std::string &keyLabel);
-    static AsymmetricKeypair genKeyOnHsmGetPrivate(HSM &hsm,
-                                                   const ECCSpec &spec,
-                                                   const std::string &keyID,
-                                                   const std::string &tokenLabel,
-                                                   const std::string &keyLabel);
+    /**
+     * @brief Generates RSA keypair on HSM token according to the spec given. The keys are fetched
+     * _only_ by key ID so generating multiple keys with the same ID must be avoided!
+     * @param hsm Initialized HSM engine handle
+     * @param spec @ref RSASpec
+     * @param keyID ID of the key on HSM. We use IDs to fetch keys from HSM. _Only_ hex values are
+     * valid! Generating 2 keys with the same ID must be avoided. This is not prohibited by PKCS#11
+     * standard but since we currently only fetch by key ID, there is no way of ensuring that the
+     * correct key is fetched.
+     * @param tokenLabel Label of the token on HSM. This determines where they key shall be stored.
+     * @param keyLabel Arbitrary key label
+     * @return AsymmetricKeypair @ref AsymmetricKeypair
+     * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
+     * libp11 and HSM module implementation, exception's what() tries to list the most common things
+     * that could go wrong. libp11 does log some things to stderr, check if there's more context
+     * there
+     */
+    static AsymmetricKeypair generateKeyOnHsm(const HSM &hsm,
+                                              const RSASpec &spec,
+                                              const std::string &keyID,
+                                              const std::string &tokenLabel,
+                                              const std::string &keyLabel);
+
+    /**
+     * @brief Generates ECC keypair on HSM token according to the spec given. The keys are fetched
+     * _only_ by key ID so generating multiple keys with the same ID must be avoided!
+     * @param hsm Initialized HSM engine handle
+     * @param spec @ref ECCSpec
+     * @param keyID ID of the key on HSM. We use IDs to fetch keys from HSM. _Only_ hex values are
+     * valid! Generating 2 keys with the same ID must be avoided. This is not prohibited by PKCS#11
+     * standard but since we currently only fetch by key ID, there is no way of ensuring that the
+     * correct key is fetched.
+     * @param tokenLabel Label of the token on HSM. This determines where they key shall be stored.
+     * @param keyLabel Arbitrary key label
+     * @return AsymmetricKeypair @ref AsymmetricKeypair
+     * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
+     * libp11 and HSM module implementation, exception's what() tries to list the most common things
+     * that could go wrong. libp11 does log some things to stderr, check if there's more context
+     * there
+     */
+    static AsymmetricKeypair generateKeyOnHsm(const HSM &hsm,
+                                              const ECCSpec &spec,
+                                              const std::string &keyID,
+                                              const std::string &tokenLabel,
+                                              const std::string &keyLabel);
 #endif
 
 private:

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -377,6 +377,7 @@ public:
     explicit ECCSpec(openssl::ellipticCurveNid curveNid) : _curveNid{curveNid} {}
     ECCSpec() : ECCSpec{defaultCurveNid} {}
     inline openssl::ellipticCurveNid curve() const { return _curveNid; }
+    inline std::string curveName() const { return openssl::_EC_curve_nid2nist(int(_curveNid)); }
     AsymmetricKey generate() const override;
 
 private:

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -289,34 +289,32 @@ public:
      * that could go wrong. libp11 does log some things to stderr, check if there's more context
      * there
      */
+    template <typename T>
     static AsymmetricKeypair generateKeyOnHsm(const HSM &hsm,
-                                              const RSASpec &spec,
+                                              const T &spec,
                                               const std::string &keyID,
                                               const std::string &tokenLabel,
-                                              const std::string &keyLabel);
-
-    /**
-     * @brief Generates ECC keypair on HSM token according to the spec given. The keys are fetched
-     * _only_ by key ID so generating multiple keys with the same ID must be avoided!
-     * @param hsm Initialized HSM engine handle
-     * @param spec @ref ECCSpec
-     * @param keyID ID of the key on HSM. We use IDs to fetch keys from HSM. _Only_ hex values are
-     * valid! Generating 2 keys with the same ID must be avoided. This is not prohibited by PKCS#11
-     * standard but since we currently only fetch by key ID, there is no way of ensuring that the
-     * correct key is fetched.
-     * @param tokenLabel Label of the token on HSM. This determines where they key shall be stored.
-     * @param keyLabel Arbitrary key label
-     * @return AsymmetricKeypair @ref AsymmetricKeypair
-     * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
-     * libp11 and HSM module implementation, exception's what() tries to list the most common things
-     * that could go wrong. libp11 does log some things to stderr, check if there's more context
-     * there
-     */
-    static AsymmetricKeypair generateKeyOnHsm(const HSM &hsm,
-                                              const ECCSpec &spec,
-                                              const std::string &keyID,
-                                              const std::string &tokenLabel,
-                                              const std::string &keyLabel);
+                                              const std::string &keyLabel)
+    {
+        static_assert(std::is_base_of<AsymmetricKey::Spec, T>::value,
+                      "T must be a subclass of AsymmetricKey::Spec");
+        // libp11 uses 128 byte buffer
+        if (keyID.length() > 127 || !std::all_of(keyID.begin(), keyID.end(), [](unsigned char c) {
+                return std::isxdigit(c);
+            })) {
+            throw MoCOCrWException(std::string("invalid keyID"));
+        }
+        try {
+            auto key = hsm.generateKey(spec, keyID, tokenLabel, keyLabel);
+            return AsymmetricKeypair{std::move(key)};
+        } catch (const openssl::OpenSSLException &e) {
+            throw MoCOCrWException(
+                    std::string("Key generation failed for unknown reason. Likely reasons: invalid "
+                                "spec, wrong tokenLabel, broken HSM "
+                                "module implementation. OpenSSL error: ") +
+                    e.what());
+        }
+    }
 #endif
 
 private:

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -47,7 +47,7 @@ public:
 
     KeyTypes getType() const;
 
-    int getKeySize() const { return EVP_PKEY_bits(_key.get()); }
+    int getKeySize() const { return openssl::_EVP_PKEY_bits(_key.get()); }
 
     std::unique_ptr<Spec> getKeySpec() const;
 

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -273,48 +273,52 @@ public:
     static AsymmetricKeypair readPrivateKeyFromHSM(const HSM &hsm, const std::string &keyID);
 
     /**
-     * @brief Generates RSA keypair on HSM token according to the spec given. The keys are fetched
-     * _only_ by key ID so generating multiple keys with the same ID must be avoided!
-     * @param hsm Initialized HSM engine handle
+     * @brief Generates RSA keypair on HSM token according to the spec given.
+     * @note libp11 supports fetching the keys only by keyID but generating multiple keys with the
+     * same key is not prohibited by PKCS#11 standard. Care should be taken when generating multiple
+     * keys with the same ID because there are no guarantees the correct one will be fetched given
+     * current libp11 implementation.
+     * @param hsm HSM engine handle
      * @param spec @ref RSASpec
-     * @param keyID ID of the key on HSM. We use IDs to fetch keys from HSM. _Only_ hex values are
-     * valid! Generating 2 keys with the same ID must be avoided. This is not prohibited by PKCS#11
-     * standard but since we currently only fetch by key ID, there is no way of ensuring that the
-     * correct key is fetched.
-     * @param tokenLabel Label of the token on HSM. This determines where they key shall be stored.
+     * @param keyID ID of the key on HSM. _Only_ hex values are valid because key IDs are stored as
+     * raw bytes.
+     * @param tokenLabel Label of the token on HSM. An HSM can have multiple tokens where the keys
+     * are stored. This determines on which token the key shall be stored.
      * @param keyLabel Arbitrary key label
      * @return AsymmetricKeypair @ref AsymmetricKeypair
      * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
-     * libp11 and HSM module implementation, exception's what() tries to list the most common things
-     * that could go wrong. libp11 does log some things to stderr, check if there's more context
-     * there
+     * libp11 and HSM module implementation, we can't know exactly what went wrong. libp11 does log
+     * some things to stderr, check if there's more context there
      */
-    template <typename T>
-    static AsymmetricKeypair generateKeyOnHsm(const HSM &hsm,
-                                              const T &spec,
-                                              const std::string &keyID,
+    static AsymmetricKeypair generateKeyOnHsm(HSM &hsm,
+                                              const RSASpec &spec,
                                               const std::string &tokenLabel,
-                                              const std::string &keyLabel)
-    {
-        static_assert(std::is_base_of<AsymmetricKey::Spec, T>::value,
-                      "T must be a subclass of AsymmetricKey::Spec");
-        // libp11 uses 128 byte buffer
-        if (keyID.length() > 127 || !std::all_of(keyID.begin(), keyID.end(), [](unsigned char c) {
-                return std::isxdigit(c);
-            })) {
-            throw MoCOCrWException(std::string("invalid keyID"));
-        }
-        try {
-            auto key = hsm.generateKey(spec, keyID, tokenLabel, keyLabel);
-            return AsymmetricKeypair{std::move(key)};
-        } catch (const openssl::OpenSSLException &e) {
-            throw MoCOCrWException(
-                    std::string("Key generation failed for unknown reason. Likely reasons: invalid "
-                                "spec, wrong tokenLabel, broken HSM "
-                                "module implementation. OpenSSL error: ") +
-                    e.what());
-        }
-    }
+                                              const std::string &keyID,
+                                              const std::string &keyLabel);
+
+    /**
+     * @brief Generates ECC keypair on HSM token according to the spec given.
+     * @note libp11 supports fetching the keys only by keyID but generating multiple keys with the
+     * same key is not prohibited by PKCS#11 standard. Care should be taken when generating multiple
+     * keys with the same ID because there are no guarantees the correct one will be fetched given
+     * current libp11 implementation.
+     * @param hsm HSM engine handle
+     * @param spec @ref ECCSpec
+     * @param keyID ID of the key on HSM. _Only_ hex values are valid because key IDs are stored as
+     * raw bytes.
+     * @param tokenLabel Label of the token on HSM. An HSM can have multiple tokens where the keys
+     * are stored. This determines on which token the key shall be stored.
+     * @param keyLabel Arbitrary key label
+     * @return AsymmetricKeypair @ref AsymmetricKeypair
+     * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
+     * libp11 and HSM module implementation, we can't know exactly what went wrong. libp11 does log
+     * some things to stderr, check if there's more context there
+     */
+    static AsymmetricKeypair generateKeyOnHsm(HSM &hsm,
+                                              const ECCSpec &spec,
+                                              const std::string &tokenLabel,
+                                              const std::string &keyID,
+                                              const std::string &keyLabel);
 #endif
 
 private:

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -59,6 +59,13 @@ namespace lib
 class OpenSSLLib
 {
 public:
+    static const char *SSL_EC_curve_nid2nist(int nid) noexcept;
+    static int SSL_ENGINE_ctrl_cmd(ENGINE *e,
+                                   const char *cmd_name,
+                                   long i,
+                                   void *p,
+                                   void (*f)(void),
+                                   int cmd_optional) noexcept;
     static int SSL_ENGINE_free(ENGINE *e) noexcept;
     static int SSL_ENGINE_finish(ENGINE *e) noexcept;
     static ENGINE *SSL_ENGINE_by_id(const char *id) noexcept;

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -59,6 +59,7 @@ namespace lib
 class OpenSSLLib
 {
 public:
+    static int SSL_EVP_PKEY_bits(EVP_PKEY *pkey) noexcept;
     static const char *SSL_EC_curve_nid2nist(int nid) noexcept;
     static int SSL_ENGINE_ctrl_cmd(ENGINE *e,
                                    const char *cmd_name,

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -1560,5 +1560,15 @@ SSL_EVP_PKEY_Ptr _ENGINE_load_public_key(ENGINE *e, const std::string &keyId);
  */
 void _ENGINE_finish(ENGINE *e);
 
+/**
+ * Send control command to an engine and pass arbitrary data through \p p
+ */
+void _ENGINE_ctrl_cmd(ENGINE *e, const std::string &cmdName, void *p);
+
+/**
+ *
+ */
+std::string _EC_curve_nid2nist(int nid);
+
 }  // namespace openssl
 }  // namespace mococrw

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -1570,5 +1570,10 @@ void _ENGINE_ctrl_cmd(ENGINE *e, const std::string &cmdName, void *p);
  */
 std::string _EC_curve_nid2nist(int nid);
 
+/**
+ * Get number of bits key has from EVP_PKEY data structure
+ */
+int _EVP_PKEY_bits(EVP_PKEY *);
+
 }  // namespace openssl
 }  // namespace mococrw

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -1566,7 +1566,7 @@ void _ENGINE_finish(ENGINE *e);
 void _ENGINE_ctrl_cmd(ENGINE *e, const std::string &cmdName, void *p);
 
 /**
- *
+ * Convert integer nid to curve name
  */
 std::string _EC_curve_nid2nist(int nid);
 

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -1566,14 +1566,14 @@ void _ENGINE_finish(ENGINE *e);
 void _ENGINE_ctrl_cmd(ENGINE *e, const std::string &cmdName, void *p);
 
 /**
- * Convert integer nid to curve name
+ * Convert integer \p nid to curve name
  */
 std::string _EC_curve_nid2nist(int nid);
 
 /**
- * Get number of bits key has from EVP_PKEY data structure
+ * Get number of bits key has from \p pkey data structure
  */
-int _EVP_PKEY_bits(EVP_PKEY *);
+int _EVP_PKEY_bits(EVP_PKEY *pkey);
 
 }  // namespace openssl
 }  // namespace mococrw

--- a/src/mococrw/util.h
+++ b/src/mococrw/util.h
@@ -23,7 +23,7 @@
 
 #include <openssl/crypto.h>
 
-#include "mococrw/error.h"
+#include "error.h"
 
 namespace mococrw
 {

--- a/src/mococrw/util.h
+++ b/src/mococrw/util.h
@@ -23,7 +23,7 @@
 
 #include <openssl/crypto.h>
 
-#include "error.h"
+#include "mococrw/error.h"
 
 namespace mococrw
 {

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -1031,6 +1031,7 @@ int OpenSSLLib::SSL_ENGINE_ctrl_cmd(ENGINE *e,
     return ENGINE_ctrl_cmd(e, cmd_name, i, p, f, cmd_optional);
 }
 const char *OpenSSLLib::SSL_EC_curve_nid2nist(int nid) noexcept { return EC_curve_nid2nist(nid); }
+int OpenSSLLib::SSL_EVP_PKEY_bits(EVP_PKEY *pkey) noexcept { return EVP_PKEY_bits(pkey); }
 }  // namespace lib
 }  // namespace openssl
 }  // namespace mococrw

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -1021,6 +1021,16 @@ int OpenSSLLib::SSL_ENGINE_init(ENGINE *e) noexcept { return ENGINE_init(e); }
 ENGINE *OpenSSLLib::SSL_ENGINE_by_id(const char *id) noexcept { return ENGINE_by_id(id); }
 int OpenSSLLib::SSL_ENGINE_finish(ENGINE *e) noexcept { return ENGINE_finish(e); }
 int OpenSSLLib::SSL_ENGINE_free(ENGINE *e) noexcept { return ENGINE_free(e); }
+int OpenSSLLib::SSL_ENGINE_ctrl_cmd(ENGINE *e,
+                                    const char *cmd_name,
+                                    long i,
+                                    void *p,
+                                    void (*f)(void),
+                                    int cmd_optional) noexcept
+{
+    return ENGINE_ctrl_cmd(e, cmd_name, i, p, f, cmd_optional);
+}
+const char *OpenSSLLib::SSL_EC_curve_nid2nist(int nid) noexcept { return EC_curve_nid2nist(nid); }
 }  // namespace lib
 }  // namespace openssl
 }  // namespace mococrw

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -1597,5 +1597,16 @@ void _ENGINE_finish(ENGINE *e)
     OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_ENGINE_finish, e);
 }
 
+void _ENGINE_ctrl_cmd(ENGINE *e, const std::string &cmdName, void *p)
+{
+    OpensslCallIsOne::callChecked(
+            lib::OpenSSLLib::SSL_ENGINE_ctrl_cmd, e, cmdName.c_str(), 0, p, nullptr, 1);
+}
+
+std::string _EC_curve_nid2nist(int nid)
+{
+    return std::string{lib::OpenSSLLib::SSL_EC_curve_nid2nist(nid)};
+}
+
 }  // namespace openssl
 }  // namespace mococrw

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -1609,5 +1609,10 @@ std::string _EC_curve_nid2nist(int nid)
     return std::string(nist);
 }
 
+int _EVP_PKEY_bits(EVP_PKEY *pkey)
+{
+    return OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_bits, pkey);
+}
+
 }  // namespace openssl
 }  // namespace mococrw

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -1605,7 +1605,8 @@ void _ENGINE_ctrl_cmd(ENGINE *e, const std::string &cmdName, void *p)
 
 std::string _EC_curve_nid2nist(int nid)
 {
-    return std::string{lib::OpenSSLLib::SSL_EC_curve_nid2nist(nid)};
+    auto nist = OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_EC_curve_nid2nist, nid);
+    return std::string(nist);
 }
 
 }  // namespace openssl

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -1606,7 +1606,7 @@ void _ENGINE_ctrl_cmd(ENGINE *e, const std::string &cmdName, void *p)
 std::string _EC_curve_nid2nist(int nid)
 {
     auto nist = OpensslCallPtr::callChecked(lib::OpenSSLLib::SSL_EC_curve_nid2nist, nid);
-    return std::string(nist);
+    return nist;
 }
 
 int _EVP_PKEY_bits(EVP_PKEY *pkey)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -28,12 +28,14 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
 
     find_package(Threads)
 
-    add_executable(openssltest test_opensslwrapper.cpp ${MOCK_SOURCES})
+    add_executable(openssltest test_opensslwrapper.cpp
+                             ${MOCK_SOURCES})
 
     if(HSM_ENABLED)
         add_executable(hsmtest test_hsm.cpp
-                               "${SRC_DIR}/hsm.cpp"
-                               ${MOCK_SOURCES})
+                            "${SRC_DIR}/key.cpp"
+                            "${SRC_DIR}/hsm.cpp"
+                             ${MOCK_SOURCES})
     endif()
 
     add_executable(asn1timetests test_asn1time.cpp ${REAL_SOURCES})
@@ -194,6 +196,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
 
     if(HSM_ENABLED)
         target_compile_definitions(keytests PUBLIC HSM_ENABLED)
+        target_compile_definitions(hsmtest PUBLIC HSM_ENABLED)
     endif()
 
     add_test(

--- a/tests/unit/hsm_mock.h
+++ b/tests/unit/hsm_mock.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "mococrw/hsm.h"
+#include "mococrw/key.h"
 
 #include <mutex>
 
@@ -33,6 +34,36 @@ class HSMMock final : public HSM
 public:
     MOCK_METHOD1(loadPublicKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
     MOCK_METHOD1(loadPrivateKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
+    MOCK_METHOD4(genKeyGetPublic,
+                 openssl::SSL_EVP_PKEY_Ptr(const RSASpec &spec,
+                                           const std::string &keyID,
+                                           const std::string &tokenLabel,
+                                           const std::string &keyLabel));
+    MOCK_METHOD4(genKeyGetPrivate,
+                 openssl::SSL_EVP_PKEY_Ptr(const RSASpec &spec,
+                                           const std::string &keyID,
+                                           const std::string &tokenLabel,
+                                           const std::string &keyLabel));
+    MOCK_METHOD4(genKeyGetPublic,
+                 openssl::SSL_EVP_PKEY_Ptr(const ECCSpec &spec,
+                                           const std::string &keyID,
+                                           const std::string &tokenLabel,
+                                           const std::string &keyLabel));
+    MOCK_METHOD4(genKeyGetPrivate,
+                 openssl::SSL_EVP_PKEY_Ptr(const ECCSpec &spec,
+                                           const std::string &keyID,
+                                           const std::string &tokenLabel,
+                                           const std::string &keyLabel));
+    MOCK_METHOD4(genKey,
+                 void(const RSASpec &spec,
+                      const std::string &keyID,
+                      const std::string &tokenLabel,
+                      const std::string &keyLabel));
+    MOCK_METHOD4(genKey,
+                 void(const ECCSpec &spec,
+                      const std::string &keyID,
+                      const std::string &tokenLabel,
+                      const std::string &keyLabel));
 };
 
 }  // namespace mococrw

--- a/tests/unit/hsm_mock.h
+++ b/tests/unit/hsm_mock.h
@@ -32,38 +32,18 @@ namespace mococrw
 class HSMMock final : public HSM
 {
 public:
-    MOCK_METHOD1(loadPublicKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
-    MOCK_METHOD1(loadPrivateKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
-    MOCK_METHOD4(genKeyGetPublic,
-                 openssl::SSL_EVP_PKEY_Ptr(const RSASpec &spec,
-                                           const std::string &keyID,
-                                           const std::string &tokenLabel,
-                                           const std::string &keyLabel));
-    MOCK_METHOD4(genKeyGetPrivate,
-                 openssl::SSL_EVP_PKEY_Ptr(const RSASpec &spec,
-                                           const std::string &keyID,
-                                           const std::string &tokenLabel,
-                                           const std::string &keyLabel));
-    MOCK_METHOD4(genKeyGetPublic,
-                 openssl::SSL_EVP_PKEY_Ptr(const ECCSpec &spec,
-                                           const std::string &keyID,
-                                           const std::string &tokenLabel,
-                                           const std::string &keyLabel));
-    MOCK_METHOD4(genKeyGetPrivate,
-                 openssl::SSL_EVP_PKEY_Ptr(const ECCSpec &spec,
-                                           const std::string &keyID,
-                                           const std::string &tokenLabel,
-                                           const std::string &keyLabel));
-    MOCK_METHOD4(genKey,
-                 void(const RSASpec &spec,
-                      const std::string &keyID,
-                      const std::string &tokenLabel,
-                      const std::string &keyLabel));
-    MOCK_METHOD4(genKey,
-                 void(const ECCSpec &spec,
-                      const std::string &keyID,
-                      const std::string &tokenLabel,
-                      const std::string &keyLabel));
+    MOCK_CONST_METHOD1(loadPublicKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
+    MOCK_CONST_METHOD1(loadPrivateKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
+    MOCK_CONST_METHOD4(generateKey,
+                       openssl::SSL_EVP_PKEY_Ptr(const RSASpec &spec,
+                                                 const std::string &keyID,
+                                                 const std::string &tokenLabel,
+                                                 const std::string &keyLabel));
+    MOCK_CONST_METHOD4(generateKey,
+                       openssl::SSL_EVP_PKEY_Ptr(const ECCSpec &spec,
+                                                 const std::string &keyID,
+                                                 const std::string &tokenLabel,
+                                                 const std::string &keyLabel));
 };
 
 }  // namespace mococrw

--- a/tests/unit/hsm_mock.h
+++ b/tests/unit/hsm_mock.h
@@ -34,15 +34,13 @@ class HSMMock final : public HSM
 public:
     MOCK_CONST_METHOD1(loadPublicKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
     MOCK_CONST_METHOD1(loadPrivateKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
-    MOCK_METHOD4(generateKey,
+    MOCK_METHOD3(generateKey,
                  openssl::SSL_EVP_PKEY_Ptr(const RSASpec &spec,
                                            const std::string &keyID,
-                                           const std::string &tokenLabel,
                                            const std::string &keyLabel));
-    MOCK_METHOD4(generateKey,
+    MOCK_METHOD3(generateKey,
                  openssl::SSL_EVP_PKEY_Ptr(const ECCSpec &spec,
                                            const std::string &keyID,
-                                           const std::string &tokenLabel,
                                            const std::string &keyLabel));
 };
 

--- a/tests/unit/hsm_mock.h
+++ b/tests/unit/hsm_mock.h
@@ -34,16 +34,16 @@ class HSMMock final : public HSM
 public:
     MOCK_CONST_METHOD1(loadPublicKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
     MOCK_CONST_METHOD1(loadPrivateKey, openssl::SSL_EVP_PKEY_Ptr(const std::string &keyID));
-    MOCK_CONST_METHOD4(generateKey,
-                       openssl::SSL_EVP_PKEY_Ptr(const RSASpec &spec,
-                                                 const std::string &keyID,
-                                                 const std::string &tokenLabel,
-                                                 const std::string &keyLabel));
-    MOCK_CONST_METHOD4(generateKey,
-                       openssl::SSL_EVP_PKEY_Ptr(const ECCSpec &spec,
-                                                 const std::string &keyID,
-                                                 const std::string &tokenLabel,
-                                                 const std::string &keyLabel));
+    MOCK_METHOD4(generateKey,
+                 openssl::SSL_EVP_PKEY_Ptr(const RSASpec &spec,
+                                           const std::string &keyID,
+                                           const std::string &tokenLabel,
+                                           const std::string &keyLabel));
+    MOCK_METHOD4(generateKey,
+                 openssl::SSL_EVP_PKEY_Ptr(const ECCSpec &spec,
+                                           const std::string &keyID,
+                                           const std::string &tokenLabel,
+                                           const std::string &keyLabel));
 };
 
 }  // namespace mococrw

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -1203,6 +1203,10 @@ const char *OpenSSLLib::SSL_EC_curve_nid2nist(int nid) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EC_curve_nid2nist(nid);
 }
+int OpenSSLLib::SSL_EVP_PKEY_bits(EVP_PKEY *pkey) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_bits(pkey);
+}
 }  // namespace lib
 }  // namespace openssl
 }  // namespace mococrw

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -1193,6 +1193,16 @@ int OpenSSLLib::SSL_ENGINE_free(ENGINE *e) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_free(e);
 }
+int OpenSSLLib::SSL_ENGINE_ctrl_cmd(
+        ENGINE *e, const char *cmd_name, long i, void *p, void (*f)(), int cmd_optional) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ENGINE_ctrl_cmd(
+            e, cmd_name, i, p, f, cmd_optional);
+}
+const char *OpenSSLLib::SSL_EC_curve_nid2nist(int nid) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EC_curve_nid2nist(nid);
+}
 }  // namespace lib
 }  // namespace openssl
 }  // namespace mococrw

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -35,6 +35,7 @@ namespace openssl
 class OpenSSLLibMockInterface
 {
 public:
+    virtual int SSL_EVP_PKEY_bits(EVP_PKEY *pkey) = 0;
     virtual const char *SSL_EC_curve_nid2nist(int nid) = 0;
     virtual int SSL_ENGINE_ctrl_cmd(ENGINE *e,
                                     const char *cmd_name,
@@ -420,6 +421,7 @@ public:
 class OpenSSLLibMock : public OpenSSLLibMockInterface
 {
 public:
+    MOCK_METHOD1(SSL_EVP_PKEY_bits, int(EVP_PKEY *));
     MOCK_METHOD1(SSL_EC_curve_nid2nist, const char *(int));
     MOCK_METHOD6(SSL_ENGINE_ctrl_cmd, int(ENGINE *, const char *, long, void *, void (*)(), int));
     MOCK_METHOD1(SSL_ENGINE_free, int(ENGINE *));

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -35,6 +35,13 @@ namespace openssl
 class OpenSSLLibMockInterface
 {
 public:
+    virtual const char *SSL_EC_curve_nid2nist(int nid) = 0;
+    virtual int SSL_ENGINE_ctrl_cmd(ENGINE *e,
+                                    const char *cmd_name,
+                                    long i,
+                                    void *p,
+                                    void (*f)(void),
+                                    int cmd_optional) = 0;
     virtual int SSL_ENGINE_free(ENGINE *e) = 0;
     virtual int SSL_ENGINE_finish(ENGINE *e) = 0;
     virtual ENGINE *SSL_ENGINE_by_id(const char *id) = 0;
@@ -413,6 +420,8 @@ public:
 class OpenSSLLibMock : public OpenSSLLibMockInterface
 {
 public:
+    MOCK_METHOD1(SSL_EC_curve_nid2nist, const char *(int));
+    MOCK_METHOD6(SSL_ENGINE_ctrl_cmd, int(ENGINE *, const char *, long, void *, void (*)(), int));
     MOCK_METHOD1(SSL_ENGINE_free, int(ENGINE *));
     MOCK_METHOD1(SSL_ENGINE_finish, int(ENGINE *));
     MOCK_METHOD1(SSL_ENGINE_by_id, ENGINE *(const char *));

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "mococrw/hsm.h"
+#include "mococrw/key.h"
 #include "openssl_lib_mock.h"
 
 using namespace ::mococrw;
@@ -50,6 +51,13 @@ protected:
 
 namespace testutils
 {
+EVP_PKEY *somePkeyPtr()
+{
+    /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
+    static char dummyBuf[42] = {};
+    return reinterpret_cast<EVP_PKEY *>(&dummyBuf);
+}
+
 ENGINE *someEnginePtr()
 {
     /* Reserve some memory and cast a pointer to that ; pointers will not be dereferenced */
@@ -101,4 +109,44 @@ TEST_F(HSMTest, testHSMEngine)
     EXPECT_CALL(_mock(), SSL_ENGINE_finish(::testutils::someEnginePtr())).WillOnce(Return(1));
 
     EXPECT_NO_THROW((HsmEngine(engineID, modulePath, pin)));
+}
+
+TEST_F(HSMTest, testHSMKeygen)
+{
+    std::string engineID("engine_id");
+    std::string modulePath("/test_path.so");
+    std::string pin("1234");
+    ECCSpec eccSpec;
+    int curve = int(mococrw::openssl::ellipticCurveNid::PRIME_256v1);
+    auto engine = ::testutils::someEnginePtr();
+    auto pkey = ::testutils::somePkeyPtr();
+
+    EXPECT_CALL(_mock(), SSL_ENGINE_by_id(StrEq(engineID.c_str())))
+            .WillOnce(Return(::testutils::someEnginePtr()));
+
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_ctrl_cmd_string(::testutils::someEnginePtr(),
+                                           StrEq("MODULE_PATH"),
+                                           StrEq(modulePath.c_str()),
+                                           0 /*non-optional*/))
+            .WillOnce(Return(1));
+
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_ctrl_cmd_string(::testutils::someEnginePtr(),
+                                           StrEq("PIN"),
+                                           StrEq(pin.c_str()),
+                                           0 /*non-optional*/))
+            .WillOnce(Return(1));
+
+    EXPECT_CALL(_mock(), SSL_ENGINE_init(engine)).WillOnce(Return(1));
+    EXPECT_CALL(_mock(), SSL_ENGINE_finish(engine)).WillOnce(Return(1));
+    HsmEngine hsm(engineID, modulePath, pin);
+    EXPECT_CALL(_mock(), SSL_EC_curve_nid2nist(curve)).WillOnce(Return("P-256"));
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_ctrl_cmd(engine, StrEq("KEYGEN"), 0 /*non-optional*/, _, nullptr, 1))
+            .WillOnce(Return(1));
+    EXPECT_CALL(_mock(), SSL_ENGINE_load_private_key(engine, StrEq("1000"), nullptr, nullptr))
+            .WillOnce(Return(pkey));
+    EXPECT_NO_THROW(
+            AsymmetricKeypair::generateKeyOnHsm(hsm, eccSpec, "1000", "token-label", "key-label"));
 }

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -22,7 +22,6 @@
 #include <cstring>
 #include <string>
 
-// #include "key.cpp"
 #include "mococrw/hsm.h"
 #include "openssl_lib_mock.h"
 

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -87,6 +87,7 @@ std::unique_ptr<HsmEngine> HSMTest::initialiseEngine()
 {
     std::string engineID("engine_id");
     std::string modulePath("/test_path.so");
+    std::string tokenLabel("token-label");
     std::string pin("1234");
     auto engine = ::testutils::someEnginePtr();
 
@@ -106,7 +107,7 @@ std::unique_ptr<HsmEngine> HSMTest::initialiseEngine()
     EXPECT_CALL(_mock(), SSL_ENGINE_init(engine)).WillOnce(Return(1));
     EXPECT_CALL(_mock(), SSL_ENGINE_finish(engine)).WillOnce(Return(1));
 
-    return std::make_unique<HsmEngine>(engineID, modulePath, pin);
+    return std::make_unique<HsmEngine>(engineID, modulePath, tokenLabel, pin);
 }
 
 TEST_F(HSMTest, testHSMKeygen)
@@ -122,6 +123,5 @@ TEST_F(HSMTest, testHSMKeygen)
             .WillOnce(Return(1));
     EXPECT_CALL(_mock(), SSL_ENGINE_load_private_key(engine, StrEq("1000"), nullptr, nullptr))
             .WillOnce(Return(pkey));
-    EXPECT_NO_THROW(
-            AsymmetricKeypair::generateKeyOnHsm(*hsm, eccSpec, "token-label", "1000", "key-label"));
+    EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(*hsm, eccSpec, "1000", "key-label"));
 }

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -123,5 +123,5 @@ TEST_F(HSMTest, testHSMKeygen)
     EXPECT_CALL(_mock(), SSL_ENGINE_load_private_key(engine, StrEq("1000"), nullptr, nullptr))
             .WillOnce(Return(pkey));
     EXPECT_NO_THROW(
-            AsymmetricKeypair::generateKeyOnHsm(*hsm, eccSpec, "1000", "token-label", "key-label"));
+            AsymmetricKeypair::generateKeyOnHsm(*hsm, eccSpec, "token-label", "1000", "key-label"));
 }

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -319,6 +319,42 @@ TEST_F(KeyHandlingTests, testHSMKeyGeneration)
     EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
             hsmMock, eccSpec, "1000", "token-label", "key-label"));
 }
+
+TEST_F(KeyHandlingTests, testHSMKeyGenerationInvalidKeyId)
+{
+    ECCSpec eccSpec;
+    HSMMock hsmMock;
+    EXPECT_THROW(AsymmetricKeypair::generateKeyOnHsm(
+                         hsmMock, eccSpec, "100z", "token-label", "key-label"),
+                 MoCOCrWException);
+}
+
+TEST_F(KeyHandlingTests, testHSMKeyGenerationValidKeyId)
+{
+    ECCSpec eccSpec;
+    HSMMock hsmMock;
+    EXPECT_CALL(
+            hsmMock,
+            generateKey(
+                    An<const ECCSpec &>(), "100abcdefABCDEFdeadbeef", "token-label", "key-label"));
+    EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
+            hsmMock, eccSpec, "100abcdefABCDEFdeadbeef", "token-label", "key-label"));
+}
+
+TEST_F(KeyHandlingTests, testHSMKeyGenerationValidKeyIdButTooLong)
+{
+    ECCSpec eccSpec;
+    HSMMock hsmMock;
+    // 128 characters keyId
+    EXPECT_THROW(AsymmetricKeypair::generateKeyOnHsm(
+                         hsmMock,
+                         eccSpec,
+                         "c556f2b6b5ce40bda73997cbd4d06f7169fdd7a2609774cead74a7d2a6a206a34c1780a49"
+                         "4ae445601314cdf249c1021e33519d715f00539480db87fcd2e6c03",
+                         "token-label",
+                         "key-label"),
+                 MoCOCrWException);
+}
 #endif
 
 TEST_F(KeyHandlingTests, testBothGeneratedKeysNotTheSame)

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -383,6 +383,18 @@ TEST_F(KeyHandlingTests, testGetKeySpec)
     EXPECT_EQ(dynamic_cast<ECCSpec *>(Ed448Spec.get())->curve(), openssl::ellipticCurveNid::Ed448);
     EXPECT_EQ(dynamic_cast<ECCSpec *>(Ed25519Spec.get())->curve(),
               openssl::ellipticCurveNid::Ed25519);
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(defaultSpec.get())->curveName(), "P-256");
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(Sect571r1Spec.get())->curveName(), "B-571");
+    EXPECT_EQ(dynamic_cast<ECCSpec *>(Secp521Spec.get())->curveName(), "P-521");
+    /* These two curves are not working:
+    openssl::ellipticCurveNid::Ed448,
+    openssl::ellipticCurveNid::Ed25519
+    6: unknown file: Failure
+    6: C++ exception with description "error:23077074:PKCS12 routines:PKCS12_pbe_crypt:pkcs12
+    cipherfinal error: 587690100" thrown in the test body.
+    */
+    // EXPECT_EQ(dynamic_cast<ECCSpec *>(Ed448Spec.get())->curveName(), "no-work");
+    // EXPECT_EQ(dynamic_cast<ECCSpec *>(Ed25519Spec.get())->curveName(), "no-work");
 
     std::unique_ptr<RSASpec> defaultRSASpec(
             dynamic_cast<RSASpec *>(_rsaKeyPair.getKeySpec().release()));

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -310,6 +310,15 @@ TEST_F(KeyHandlingTests, testKeyLoadPrivKeyFromHSM)
     EXPECT_CALL(hsmMock, loadPrivateKey(keyId)).WillOnce(Return(ByMove(std::move(resKey))));
     EXPECT_EQ(eccKeyPair, AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmMock, keyId));
 }
+
+TEST_F(KeyHandlingTests, testHSMKeyGeneration)
+{
+    ECCSpec ecc_spec;
+    HSMMock hsmMock;
+    // TODO: Find a more meaningful way to test this
+    EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
+            hsmMock, ecc_spec, "1000", "token-label", "key-label"));
+}
 #endif
 
 TEST_F(KeyHandlingTests, testBothGeneratedKeysNotTheSame)

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -315,8 +315,7 @@ TEST_F(KeyHandlingTests, testHSMKeyGenerationInvalidKeyId)
 {
     ECCSpec eccSpec;
     HSMMock hsmMock;
-    EXPECT_THROW(AsymmetricKeypair::generateKeyOnHsm(
-                         hsmMock, eccSpec, "token-label", "100z", "key-label"),
+    EXPECT_THROW(AsymmetricKeypair::generateKeyOnHsm(hsmMock, eccSpec, "100z", "key-label"),
                  MoCOCrWException);
 }
 
@@ -324,24 +323,20 @@ TEST_F(KeyHandlingTests, testHSMKeyGenerationECC)
 {
     ECCSpec eccSpec;
     HSMMock hsmMock;
-    EXPECT_CALL(
-            hsmMock,
-            generateKey(
-                    An<const ECCSpec &>(), "token-label", "100abcdefABCDEFdeadbeef", "key-label"));
+    EXPECT_CALL(hsmMock,
+                generateKey(An<const ECCSpec &>(), "100abcdefABCDEFdeadbeef", "key-label"));
     EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
-            hsmMock, eccSpec, "token-label", "100abcdefABCDEFdeadbeef", "key-label"));
+            hsmMock, eccSpec, "100abcdefABCDEFdeadbeef", "key-label"));
 }
 
 TEST_F(KeyHandlingTests, testHSMKeyGenerationRSA)
 {
     RSASpec rsaSpec;
     HSMMock hsmMock;
-    EXPECT_CALL(
-            hsmMock,
-            generateKey(
-                    An<const RSASpec &>(), "token-label", "100abcdefABCDEFdeadbeef", "key-label"));
+    EXPECT_CALL(hsmMock,
+                generateKey(An<const RSASpec &>(), "100abcdefABCDEFdeadbeef", "key-label"));
     EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
-            hsmMock, rsaSpec, "token-label", "100abcdefABCDEFdeadbeef", "key-label"));
+            hsmMock, rsaSpec, "100abcdefABCDEFdeadbeef", "key-label"));
 }
 
 TEST_F(KeyHandlingTests, testHSMKeyGenerationValidKeyIdButTooLong)
@@ -352,7 +347,6 @@ TEST_F(KeyHandlingTests, testHSMKeyGenerationValidKeyIdButTooLong)
     EXPECT_THROW(AsymmetricKeypair::generateKeyOnHsm(
                          hsmMock,
                          eccSpec,
-                         "token-label",
                          "c556f2b6b5ce40bda73997cbd4d06f7169fdd7a2609774cead74a7d2a6a206a34c1780a49"
                          "4ae445601314cdf249c1021e33519d715f00539480db87fcd2e6c03",
                          "key-label"),

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -311,15 +311,6 @@ TEST_F(KeyHandlingTests, testKeyLoadPrivKeyFromHSM)
     EXPECT_EQ(eccKeyPair, AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmMock, keyId));
 }
 
-TEST_F(KeyHandlingTests, testHSMKeyGeneration)
-{
-    ECCSpec eccSpec;
-    HSMMock hsmMock;
-    EXPECT_CALL(hsmMock, generateKey(An<const ECCSpec &>(), "1000", "token-label", "key-label"));
-    EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
-            hsmMock, eccSpec, "1000", "token-label", "key-label"));
-}
-
 TEST_F(KeyHandlingTests, testHSMKeyGenerationInvalidKeyId)
 {
     ECCSpec eccSpec;
@@ -329,7 +320,7 @@ TEST_F(KeyHandlingTests, testHSMKeyGenerationInvalidKeyId)
                  MoCOCrWException);
 }
 
-TEST_F(KeyHandlingTests, testHSMKeyGenerationValidKeyId)
+TEST_F(KeyHandlingTests, testHSMKeyGenerationECC)
 {
     ECCSpec eccSpec;
     HSMMock hsmMock;
@@ -339,6 +330,18 @@ TEST_F(KeyHandlingTests, testHSMKeyGenerationValidKeyId)
                     An<const ECCSpec &>(), "100abcdefABCDEFdeadbeef", "token-label", "key-label"));
     EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
             hsmMock, eccSpec, "100abcdefABCDEFdeadbeef", "token-label", "key-label"));
+}
+
+TEST_F(KeyHandlingTests, testHSMKeyGenerationRSA)
+{
+    RSASpec rsaSpec;
+    HSMMock hsmMock;
+    EXPECT_CALL(
+            hsmMock,
+            generateKey(
+                    An<const RSASpec &>(), "100abcdefABCDEFdeadbeef", "token-label", "key-label"));
+    EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
+            hsmMock, rsaSpec, "100abcdefABCDEFdeadbeef", "token-label", "key-label"));
 }
 
 TEST_F(KeyHandlingTests, testHSMKeyGenerationValidKeyIdButTooLong)

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -313,11 +313,12 @@ TEST_F(KeyHandlingTests, testKeyLoadPrivKeyFromHSM)
 
 TEST_F(KeyHandlingTests, testHSMKeyGeneration)
 {
-    ECCSpec ecc_spec;
+    ECCSpec eccSpec;
     HSMMock hsmMock;
     // TODO: Find a more meaningful way to test this
+    EXPECT_CALL(hsmMock, generateKey(An<const ECCSpec &>(), "1000", "token-label", "key-label"));
     EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
-            hsmMock, ecc_spec, "1000", "token-label", "key-label"));
+            hsmMock, eccSpec, "1000", "token-label", "key-label"));
 }
 #endif
 

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -315,7 +315,6 @@ TEST_F(KeyHandlingTests, testHSMKeyGeneration)
 {
     ECCSpec eccSpec;
     HSMMock hsmMock;
-    // TODO: Find a more meaningful way to test this
     EXPECT_CALL(hsmMock, generateKey(An<const ECCSpec &>(), "1000", "token-label", "key-label"));
     EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
             hsmMock, eccSpec, "1000", "token-label", "key-label"));

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -316,7 +316,7 @@ TEST_F(KeyHandlingTests, testHSMKeyGenerationInvalidKeyId)
     ECCSpec eccSpec;
     HSMMock hsmMock;
     EXPECT_THROW(AsymmetricKeypair::generateKeyOnHsm(
-                         hsmMock, eccSpec, "100z", "token-label", "key-label"),
+                         hsmMock, eccSpec, "token-label", "100z", "key-label"),
                  MoCOCrWException);
 }
 
@@ -327,9 +327,9 @@ TEST_F(KeyHandlingTests, testHSMKeyGenerationECC)
     EXPECT_CALL(
             hsmMock,
             generateKey(
-                    An<const ECCSpec &>(), "100abcdefABCDEFdeadbeef", "token-label", "key-label"));
+                    An<const ECCSpec &>(), "token-label", "100abcdefABCDEFdeadbeef", "key-label"));
     EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
-            hsmMock, eccSpec, "100abcdefABCDEFdeadbeef", "token-label", "key-label"));
+            hsmMock, eccSpec, "token-label", "100abcdefABCDEFdeadbeef", "key-label"));
 }
 
 TEST_F(KeyHandlingTests, testHSMKeyGenerationRSA)
@@ -339,9 +339,9 @@ TEST_F(KeyHandlingTests, testHSMKeyGenerationRSA)
     EXPECT_CALL(
             hsmMock,
             generateKey(
-                    An<const RSASpec &>(), "100abcdefABCDEFdeadbeef", "token-label", "key-label"));
+                    An<const RSASpec &>(), "token-label", "100abcdefABCDEFdeadbeef", "key-label"));
     EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHsm(
-            hsmMock, rsaSpec, "100abcdefABCDEFdeadbeef", "token-label", "key-label"));
+            hsmMock, rsaSpec, "token-label", "100abcdefABCDEFdeadbeef", "key-label"));
 }
 
 TEST_F(KeyHandlingTests, testHSMKeyGenerationValidKeyIdButTooLong)
@@ -352,9 +352,9 @@ TEST_F(KeyHandlingTests, testHSMKeyGenerationValidKeyIdButTooLong)
     EXPECT_THROW(AsymmetricKeypair::generateKeyOnHsm(
                          hsmMock,
                          eccSpec,
+                         "token-label",
                          "c556f2b6b5ce40bda73997cbd4d06f7169fdd7a2609774cead74a7d2a6a206a34c1780a49"
                          "4ae445601314cdf249c1021e33519d715f00539480db87fcd2e6c03",
-                         "token-label",
                          "key-label"),
                  MoCOCrWException);
 }


### PR DESCRIPTION
This prevents using HsmEngine object with set pin
from trying to load/generate keys from/on other tokens

This is based an HSM generation PR and will need a rebase once key generation PR is merged.