### PR TITLE
Prepare release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ## Fixed
 
+
+# Release 4.2.1
+## Changed
+
+## Fixed
+
 * CA Tests' SetUp was changed so that all the objects involved do not depend on time when
   construction of object is made. This led to problems where object of CA class had notBefore
   attribute set to greater value than CA's certificate's notBefore which should never happen.
@@ -36,6 +42,11 @@ All notable changes to this project will be documented in this file.
     - Loading Public Keys
     - Loading Private Keys
     - Generating EC and RSA keypairs
+* Post Quantum Cryptography support has been added.
+  [Dilithium](https://www.pq-crystals.org/dilithium/)
+  is used to offer signing and verification functionality. To build MoCOCrW with dilithium support
+  please follow the instructions in the [README](README.md). Please note that the API for
+  dilithium will slightly change in the future once openssl officially supports dilithium.
 
 # Release 4.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ All notable changes to this project will be documented in this file.
 * Clang-Format has been applied to the existing code-base of MoCOCrW and a `.clang-format`
   file has been included to format the code of of future PRs.
 * A foundational PKCS#11 HSM interface, based OpenSSL's ENGINE API, has been introduced
-  to MoCOCrW. Currently, the following functionality is supported:
+  to MoCOCrW. To build MoCOCrW with this API, follow the instruction in the [README](README.md).
+  Currently, the following functionality is supported:
     - Loading Public Keys
     - Loading Private Keys
     - Generating EC and RSA keypairs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 ## Fixed
 
 
-# Release 4.2.1
+# Release 4.2.0
 ## Changed
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,17 +37,22 @@ All notable changes to this project will be documented in this file.
   This change just improves the error reporting.
 * Clang-Format has been applied to the existing code-base of MoCOCrW and a `.clang-format`
   file has been included to format the code of of future PRs.
-* A foundational PKCS#11 HSM interface, based OpenSSL's ENGINE API, has been introduced
-  to MoCOCrW. To build MoCOCrW with this API, follow the instruction in the [README](README.md).
+* A foundational PKCS#11 HSM interface, based on OpenSSL's ENGINE API, has been introduced
+  to MoCOCrW. This functionality is disabled by default. See [README](README.md) to get more
+  information on how to enable it.
   Currently, the following functionality is supported:
     - Loading Public Keys
     - Loading Private Keys
     - Generating EC and RSA keypairs
 * Post Quantum Cryptography support has been added.
   [Dilithium](https://www.pq-crystals.org/dilithium/)
-  is used to offer signing and verification functionality. To build MoCOCrW with dilithium support
-  please follow the instructions in the [README](README.md). Please note that the API for
-  dilithium will slightly change in the future once openssl officially supports dilithium.
+  is used to offer signing and verification functionality. Please note that the API is
+  provisional as there is currently no OpenSSL support for Dilithium. This library intends to
+  switch to an OpenSSL implementation once available. As a consequence of this, the interfaces
+  around Dilithium are subject to future changes. We support dilithium for experimentation and
+  getting early hands-on experience but we discourage using it as it's not yet standardized.
+  This functionality is disabled by default. See [README](README.md) to get more
+  information on how to enable it.
 
 # Release 4.1.1
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The first [PR](https://github.com/pq-crystals/dilithium/pull/68) contains the ad
 retreiving the public key from a private key and is REQUIRED in order to compile MoCOCrW with
 dilithium support.
 
-The second [PR](https://github.com/pq-crystals/dilithium/pull/69) improves the cmake file, so that
+The second [PR](https://github.com/pq-crystals/dilithium/pull/69) improves the cmake file so that
 the static libraries and the header can be installed using cmake. It is recommended to use this PR
 for compiling and installing dilithium.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ build/$ cmake -DBUILD_TESTING=True -DDILITHIUM_ENABLED=ON ..
 
 Make sure that the adapted version of libdilithium can be found by the linker.
 
-HSM and dilithium support can be enabled independently.
+Note, HSM and dilithium support can be enabled independently via CMake arguments.
 
 #### Dilithium Adaptions
 
@@ -87,19 +87,36 @@ The second [PR](https://github.com/pq-crystals/dilithium/pull/69) improves the C
 the static libraries and the header can be installed using CMake. It is recommended to use this PR
 for compiling and installing dilithium.
 
+To get the local copy of libdilithium with above PRs:
+```
+git clone https://github.com/pq-crystals/dilithium.git && cd dilithium
+git reset --hard 3e9b9f1412f6c7435dbeb4e10692ea58f181ee51
+git checkout -b pub-key-extraction
+git pull origin pull/68/head:pub-key-extraction
+git checkout master
+git checkout -b cmake-improvements
+git pull origin pull/69/head:cmake-improvements
+git checkout master
+git merge --no-edit cmake-improvements
+git merge --no-edit pub-key-extraction
+```
+
+and then build with:
+`mkdir build && cd build && cmake .. && cmake --build .`
+
 ### Build with HSM support
 
-HSM support is an **optional** feature for MoCOCrW. To build MoCOCrW with HSM support replace the
-CMake invocation with
+HSM support is an **optional** feature for MoCOCrW. To build MoCOCrW with HSM support, replace the
+CMake invocation with:
 ```
 build/$ cmake -DBUILD_TESTING=True -DHSM_ENABLED=ON ..
 ```
 
 [libp11 release 0.4.12](https://github.com/OpenSC/libp11/releases/tag/libp11-0.4.12) patched with
 [patch for key generation](https://github.com/bmwcarit/MoCOCrW/blob/openssl1.1/dockerfiles/feature-support/hsm-patches/0001-Introduce-generic-keypair-generation-interface-and-e.patch) is required for building MoCOCrW with
-HSM feature enabled.
+HSM feature enabled. To build patched libp11, check out [how it's done](https://github.com/bmwcarit/MoCOCrW/blob/openssl1.1/dockerfiles/feature-support/Dockerfile#L31) in our CI or (official instructions by libp11)[https://github.com/OpenSC/libp11/blob/master/INSTALL.md].
 
-HSM and dilithium support can be enabled independently.
+Note, HSM and dilithium support can be enabled independently via CMake arguments.
 
 ## Installation / Usage / Packaging
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ CMake invocation with
 build/$ cmake -DBUILD_TESTING=True -DHSM_ENABLED=ON ..
 ```
 
-[libp11](https://github.com/OpenSC/libp11/) `>=libp11-0.4.12` is required for building MoCOCrW with
+[libp11 release 0.4.12](https://github.com/OpenSC/libp11/releases/tag/libp11-0.4.12) patched with
+[patch for key generation](https://github.com/bmwcarit/MoCOCrW/blob/openssl1.1/dockerfiles/feature-support/hsm-patches/0001-Introduce-generic-keypair-generation-interface-and-e.patch) is required for building MoCOCrW with
 HSM feature enabled.
 
 HSM and dilithium support can be enabled independently.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,48 @@ build/$ ctest . --output-on-failure
 
 The bci.config file is used by our internal validation environment, please just ignore it.
 
+### Build with dilithium support
+
+Dilithium is an optional feature for MoCOCrW. For enabling it
+replace the cmake invocation from abovei:
+```
+build/$ cmake -DBUILD_TESTING=True -DDILITHIUM_ENABLED=ON ..
+```
+
+Make sure that the adapted version of libdilithium can be found by the linker.
+
+HSM and dilithium support can be enabled independently.
+
+#### Dilithium Adaptions
+
+It is not possible to take the bare dilithium implementation. The dilithium implementation was
+adapted. A new function for retrieving the public key from a private key was added. This change is
+required to compile MoCOCrW with dilithium support.
+
+There are two PRs created for dilithium. These can be found in dilithium's [github
+repository](https://github.com/pq-crystals/dilithium/).
+
+The first [PR](https://github.com/pq-crystals/dilithium/pull/68) contains the adaptions for
+retreiving the public key from a private key and is REQUIRED in order to compile MoCOCrW with
+dilithium support.
+
+The second [PR](https://github.com/pq-crystals/dilithium/pull/69) improves the cmake file, so that
+the static libraries and the header can be installed using cmake. It is recommended to use this PR
+for compiling and installing dilithium.
+
+### Build with HSM support
+
+HSM support is an OPTIONAL feature for MoCOCrW. For building MoCOCrW with HSM support replace the
+cmake invocation from above with
+```
+build/$ cmake -DBUILD_TESTING=True -DHSM_ENABLED=ON ..
+```
+
+[libp11](https://github.com/OpenSC/libp11/) `>=libp11-0.4.11` is required for building MoCOCrW with
+HSM feature enabled.
+
+HSM and dilithium support can be enabled independently.
+
 ## Installation / Usage / Packaging
 
 MoCOCrW is prepared to be installed or packaged into an SDK. It also provides a cmake

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The bci.config file is used by our internal validation environment, please just 
 ### Build with dilithium support
 
 Dilithium is an optional feature provided by MoCOCrW. To enable the feature,
-replace the cmake invocation from abovei:
+replace the CMake invocation with:
 ```
 build/$ cmake -DBUILD_TESTING=True -DDILITHIUM_ENABLED=ON ..
 ```
@@ -80,30 +80,30 @@ There are two PRs created for dilithium. These can be found in dilithium's [gith
 repository](https://github.com/pq-crystals/dilithium/).
 
 The first [PR](https://github.com/pq-crystals/dilithium/pull/68) contains the adaptions for
-retreiving the public key from a private key and is REQUIRED in order to compile MoCOCrW with
+retreiving the public key from a private key and is **required** in order to compile MoCOCrW with
 dilithium support.
 
-The second [PR](https://github.com/pq-crystals/dilithium/pull/69) improves the cmake file so that
-the static libraries and the header can be installed using cmake. It is recommended to use this PR
+The second [PR](https://github.com/pq-crystals/dilithium/pull/69) improves the CMake file so that
+the static libraries and the header can be installed using CMake. It is recommended to use this PR
 for compiling and installing dilithium.
 
 ### Build with HSM support
 
-HSM support is an OPTIONAL feature for MoCOCrW. For building MoCOCrW with HSM support replace the
-cmake invocation from above with
+HSM support is an **optional** feature for MoCOCrW. To build MoCOCrW with HSM support replace the
+CMake invocation with
 ```
 build/$ cmake -DBUILD_TESTING=True -DHSM_ENABLED=ON ..
 ```
 
-[libp11](https://github.com/OpenSC/libp11/) `>=libp11-0.4.11` is required for building MoCOCrW with
+[libp11](https://github.com/OpenSC/libp11/) `>=libp11-0.4.12` is required for building MoCOCrW with
 HSM feature enabled.
 
 HSM and dilithium support can be enabled independently.
 
 ## Installation / Usage / Packaging
 
-MoCOCrW is prepared to be installed or packaged into an SDK. It also provides a cmake
-exported target that you can use in your projects. A minimal example how to use this cmake
+MoCOCrW is prepared to be installed or packaged into an SDK. It also provides a CMake
+exported target that you can use in your projects. A minimal example how to use this CMake
 integration can be found in `tests/sdk`. This can also be used as an integration test if you
 want to ship MoCOCrW with an SDK.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ build/$ cmake -DBUILD_TESTING=True -DHSM_ENABLED=ON ..
 
 [libp11 release 0.4.12](https://github.com/OpenSC/libp11/releases/tag/libp11-0.4.12) patched with
 [patch for key generation](https://github.com/bmwcarit/MoCOCrW/blob/openssl1.1/dockerfiles/feature-support/hsm-patches/0001-Introduce-generic-keypair-generation-interface-and-e.patch) is required for building MoCOCrW with
-HSM feature enabled. To build patched libp11, check out [how it's done](https://github.com/bmwcarit/MoCOCrW/blob/openssl1.1/dockerfiles/feature-support/Dockerfile#L31) in our CI or (official instructions by libp11)[https://github.com/OpenSC/libp11/blob/master/INSTALL.md].
+HSM feature enabled. To build and install patched libp11, check out [how it's done](https://github.com/bmwcarit/MoCOCrW/blob/openssl1.1/dockerfiles/feature-support/Dockerfile#L31) in our CI or [official instructions by libp11](https://github.com/OpenSC/libp11/blob/master/INSTALL.md).
 
 Note, HSM and dilithium support can be enabled independently via CMake arguments.
 

--- a/README.md
+++ b/README.md
@@ -60,63 +60,39 @@ The bci.config file is used by our internal validation environment, please just 
 
 ### Build with dilithium support
 
-Dilithium is an optional feature provided by MoCOCrW. To enable the feature,
-replace the CMake invocation with:
+Dilithium is an **optional** feature provided by MoCOCrW.
+
+This feature depends on [reference implementation of the Dilithium signature scheme](https://github.com/pq-crystals/dilithium/)
+since OpenSSL still doesn't have a support for Dilithium. In order to sucessfully compile MoCOCrW
+with Dilithium feature the following adaptations are necessary. 
+
+#### Dilithium Adaptions
+
+It is not possible to take the bare Dilithium implementation. The Dilithium implementation was
+adapted with the following PRs: [PR#1](https://github.com/pq-crystals/dilithium/pull/68)
+[PR#2](https://github.com/pq-crystals/dilithium/pull/69). These PRs need to be pulled and used
+to build and install libdilithium locally before trying to use it with MoCOCrW.
+
+Then, to use the Dilithium feature, replace the CMake invocation with:
 ```
 build/$ cmake -DBUILD_TESTING=True -DDILITHIUM_ENABLED=ON ..
 ```
 
-Make sure that the adapted version of libdilithium can be found by the linker.
-
-Note, HSM and dilithium support can be enabled independently via CMake arguments.
-
-#### Dilithium Adaptions
-
-It is not possible to take the bare dilithium implementation. The dilithium implementation was
-adapted. A new function for retrieving the public key from a private key was added. This change is
-required to compile MoCOCrW with dilithium support.
-
-There are two PRs created for dilithium. These can be found in dilithium's [github
-repository](https://github.com/pq-crystals/dilithium/).
-
-The first [PR](https://github.com/pq-crystals/dilithium/pull/68) contains the adaptions for
-retreiving the public key from a private key and is **required** in order to compile MoCOCrW with
-dilithium support.
-
-The second [PR](https://github.com/pq-crystals/dilithium/pull/69) improves the CMake file so that
-the static libraries and the header can be installed using CMake. It is recommended to use this PR
-for compiling and installing dilithium.
-
-To get the local copy of libdilithium with above PRs:
-```
-git clone https://github.com/pq-crystals/dilithium.git && cd dilithium
-git reset --hard 3e9b9f1412f6c7435dbeb4e10692ea58f181ee51
-git checkout -b pub-key-extraction
-git pull origin pull/68/head:pub-key-extraction
-git checkout master
-git checkout -b cmake-improvements
-git pull origin pull/69/head:cmake-improvements
-git checkout master
-git merge --no-edit cmake-improvements
-git merge --no-edit pub-key-extraction
-```
-
-and then build with:
-`mkdir build && cd build && cmake .. && cmake --build .`
-
 ### Build with HSM support
 
-HSM support is an **optional** feature for MoCOCrW. To build MoCOCrW with HSM support, replace the
-CMake invocation with:
-```
-build/$ cmake -DBUILD_TESTING=True -DHSM_ENABLED=ON ..
-```
+HSM support is an **optional** feature for MoCOCrW. This allows for loading and storing keys on HSM
+and using those keys in various cryptographic algorithms without having keys in memory. To build
+MoCOCrW with HSM support, a patched version of libp11 is necessary since upstream libp11 does not
+support key generation through OpenSSL's ENGINE API.
 
 [libp11 release 0.4.12](https://github.com/OpenSC/libp11/releases/tag/libp11-0.4.12) patched with
 [patch for key generation](https://github.com/bmwcarit/MoCOCrW/blob/openssl1.1/dockerfiles/feature-support/hsm-patches/0001-Introduce-generic-keypair-generation-interface-and-e.patch) is required for building MoCOCrW with
 HSM feature enabled. To build and install patched libp11, check out [how it's done](https://github.com/bmwcarit/MoCOCrW/blob/openssl1.1/dockerfiles/feature-support/Dockerfile#L31) in our CI or [official instructions by libp11](https://github.com/OpenSC/libp11/blob/master/INSTALL.md).
 
-Note, HSM and dilithium support can be enabled independently via CMake arguments.
+Then, to use the HSM feature, replace the CMake invocation with:
+```
+build/$ cmake -DBUILD_TESTING=True -DHSM_ENABLED=ON ..
+```
 
 ## Installation / Usage / Packaging
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The bci.config file is used by our internal validation environment, please just 
 Dilithium is an **optional** feature provided by MoCOCrW.
 
 This feature depends on [reference implementation of the Dilithium signature scheme](https://github.com/pq-crystals/dilithium/)
-since OpenSSL still doesn't have a support for Dilithium. In order to sucessfully compile MoCOCrW
-with Dilithium feature the following adaptations are necessary. 
+since OpenSSL still doesn't have a support for Dilithium. The following adaptations are necessary
+in order to successfully compile MoCOCrW with the Dilithium feature . 
 
 #### Dilithium Adaptions
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The bci.config file is used by our internal validation environment, please just 
 
 ### Build with dilithium support
 
-Dilithium is an optional feature for MoCOCrW. For enabling it
+Dilithium is an optional feature provided by MoCOCrW. To enable the feature,
 replace the cmake invocation from abovei:
 ```
 build/$ cmake -DBUILD_TESTING=True -DDILITHIUM_ENABLED=ON ..


### PR DESCRIPTION
Bumping the minor version since the release contains new features. The new features are:
* HSM support
* Dilithium support

Both are optional features.