### PR TITLE
hsm: stop linking to libp11 since it's not necessary

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,7 +99,6 @@ add_library(${PROJECT_NAME}::${LIBRARY_NAME} ALIAS ${LIBRARY_NAME})
 target_link_libraries(${LIBRARY_NAME} PUBLIC OpenSSL::Crypto OpenSSL::SSL Boost::boost)
 
 if(HSM_ENABLED)
-  target_link_libraries(${LIBRARY_NAME} PUBLIC LibP11::P11)
   target_compile_definitions(${LIBRARY_NAME} PUBLIC HSM_ENABLED)
 endif()
 


### PR DESCRIPTION
libp11 engine which is dlopened by openssl is already statically linked
to libp11's wrapper