### PR TITLE
Refactor ENABLED MACRO Definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
       matrix:
         compiler: ["g++", "clang++"]
         build_type: ["", "ASAN"]
-        hsm_flag: ["HSM_ENABLED=ON", "HSM_ENABLED=OFF"]
-        dilithium_flag: ["DILITHIUM_ENABLED=ON", "DILITHIUM_ENABLED=OFF"]
+        hsm_flag: ["MOCOCRW_HSM_ENABLED=ON", "MOCOCRW_HSM_ENABLED=OFF"]
+        dilithium_flag: ["MOCOCRW_DILITHIUM_ENABLED=ON", "MOCOCRW_DILITHIUM_ENABLED=OFF"]
 
         include:
           - build_type: "ASAN"
@@ -58,16 +58,16 @@ jobs:
             ASAN_OPTIONS: ""
             LSAN_OPTIONS: ""
 
-          - hsm_flag: "HSM_ENABLED=ON"
+          - hsm_flag: "MOCOCRW_HSM_ENABLED=ON"
             docker_tag: "buildenv_with_features"
             softhsm2_conf: "/usr/share/softhsm/softhsm2.conf"
             softhsm2_grp: ":softhsm"
 
-          - dilithium_flag: "DILITHIUM_ENABLED=ON"
+          - dilithium_flag: "MOCOCRW_DILITHIUM_ENABLED=ON"
             docker_tag: "buildenv_with_features"
 
-          - hsm_flag: "HSM_ENABLED=OFF"
-            dilithium_flag: "DILITHIUM_ENABLED=OFF"
+          - hsm_flag: "MOCOCRW_HSM_ENABLED=OFF"
+            dilithium_flag: "MOCOCRW_DILITHIUM_ENABLED=OFF"
             docker_tag: "buildenv"
             softhsm2_conf: ""
             softhsm2_grp:
@@ -83,7 +83,7 @@ jobs:
           docker_folder_path: ${{ env.DOCKER_FOLDER_PATH }}
 
       - name: "Build Docker Image With HSM"
-        if: ${{ matrix.hsm_flag == 'HSM_ENABLED=ON' || matrix.dilithium_flag == 'DILITHIUM_ENABLED=ON' }}
+        if: ${{ matrix.hsm_flag == 'MOCOCRW_HSM_ENABLED=ON' || matrix.dilithium_flag == 'MOCOCRW_DILITHIUM_ENABLED=ON' }}
         uses: ./.github/actions/build-docker
         with:
           docker_tag: ${{ env.DOCKER_WITH_FEATURE_TAG }}
@@ -111,12 +111,12 @@ jobs:
             -e SOFTHSM2_CONF="${{ matrix.softhsm2_conf }}" \
             -u "$UID"${{ matrix.softhsm2_grp }} \
             -v "$PWD:/src:rw" -w /src/build ${{ matrix.docker_tag }}  bash -c \
-            'if [ "${{ matrix.hsm_flag }}" = "HSM_ENABLED=ON" ]; then \
+            'if [ "${{ matrix.hsm_flag }}" = "MOCOCRW_HSM_ENABLED=ON" ]; then \
                 softhsm2-util --init-token --free --label ${{ env.TOKEN_LABEL1 }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
                 softhsm2-util --init-token --free --label ${{ env.TOKEN_LABEL2 }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
             fi \
             && ctest --verbose -j $(nproc) \
-            && if [ "${{ matrix.hsm_flag }}" = "HSM_ENABLED=ON" ]; then \
+            && if [ "${{ matrix.hsm_flag }}" = "MOCOCRW_HSM_ENABLED=ON" ]; then \
                 softhsm2-util --delete-token --token ${{ env.TOKEN_LABEL1 }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
                 softhsm2-util --delete-token --token ${{ env.TOKEN_LABEL2 }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
             fi'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,10 @@ set(SECURITY_COMPILER_FLAGS
 )
 
 # By default, we do not build MoCOCrW with LibP11.
-option(HSM_ENABLED "Enable HSM features" OFF)
+option(MOCOCRW_HSM_ENABLED "Enable HSM features" OFF)
 
 # By default, we do not build MoCOCrW with dilithium support.
-option(DILITHIUM_ENABLED "Enable Dilithium features" OFF)
+option(MOCOCRW_DILITHIUM_ENABLED "Enable Dilithium features" OFF)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -96,7 +96,7 @@ if(BUILD_DOCUMENTATION)
     add_subdirectory(doc)
 endif()
 
-if(DILITHIUM_ENABLED)
+if(MOCOCRW_DILITHIUM_ENABLED)
     message(STATUS "Dilithium support is enabled. Linking libdilithium statically.")
     find_package(dilithium 3.1 REQUIRED)
 else()
@@ -108,7 +108,7 @@ if(OPENSSL_FOUND)
     message(STATUS "Using OpenSSL ${OPENSSL_VERSION}")
 endif()
 
-if(HSM_ENABLED)
+if(MOCOCRW_HSM_ENABLED)
   message(STATUS "HSM features are enabled. Building with LibP11")
   find_package(LibP11 REQUIRED)
 else()

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Dilithium is an **optional** feature provided by MoCOCrW.
 
 This feature depends on [reference implementation of the Dilithium signature scheme](https://github.com/pq-crystals/dilithium/)
 since OpenSSL still doesn't have a support for Dilithium. The following adaptations are necessary
-in order to successfully compile MoCOCrW with the Dilithium feature . 
+in order to successfully compile MoCOCrW with the Dilithium feature .
 
 #### Dilithium Adaptions
 
@@ -75,7 +75,7 @@ to build and install libdilithium locally before trying to use it with MoCOCrW.
 
 Then, to use the Dilithium feature, replace the CMake invocation with:
 ```
-build/$ cmake -DBUILD_TESTING=True -DDILITHIUM_ENABLED=ON ..
+build/$ cmake -DBUILD_TESTING=True -DMOCOCRW_DILITHIUM_ENABLED=ON ..
 ```
 
 ### Build with HSM support
@@ -91,7 +91,7 @@ HSM feature enabled. To build and install patched libp11, check out [how it's do
 
 Then, to use the HSM feature, replace the CMake invocation with:
 ```
-build/$ cmake -DBUILD_TESTING=True -DHSM_ENABLED=ON ..
+build/$ cmake -DBUILD_TESTING=True -DMOCOCRW_HSM_ENABLED=ON ..
 ```
 
 ## Installation / Usage / Packaging

--- a/doc/examples/example_asymm_crypto.md
+++ b/doc/examples/example_asymm_crypto.md
@@ -532,7 +532,7 @@ If you want to use CMake for compiling and installing libdilithium the following
 
 Dilithium is an optional feature for MoCOCrW. For enabling it add
 ```
--DDILITHIUM_ENABLED=ON
+-DMOCOCRW_DILITHIUM_ENABLED=ON
 ```
 to your CMake invocation.
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,10 +30,10 @@ add_test(
 #
 # TODO: Make the HSM flag be an imported variable so users
 # can easily determine its status.
-if(HSM_ENABLED)
+if(MOCOCRW_HSM_ENABLED)
     add_executable(hsm-example hsm-example.cpp)
     target_link_libraries(hsm-example PUBLIC MoCOCrW::mococrw)
-    target_compile_definitions(hsm-example PUBLIC HSM_ENABLED)
+    target_compile_definitions(hsm-example PUBLIC MOCOCRW_HSM_ENABLED)
 
     add_test(
         NAME hsmExample
@@ -73,8 +73,8 @@ add_test(
 
 add_executable(sig-example sig-example.cpp)
 target_link_libraries(sig-example PUBLIC MoCOCrW::mococrw)
-if(DILITHIUM_ENABLED)
-    target_compile_definitions(sig-example PUBLIC DILITHIUM_ENABLED)
+if(MOCOCRW_DILITHIUM_ENABLED)
+    target_compile_definitions(sig-example PUBLIC MOCOCRW_DILITHIUM_ENABLED)
 endif()
 add_test(
     NAME sigExample

--- a/examples/sig-example.cpp
+++ b/examples/sig-example.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 #include "mococrw/util.h"
 
-#ifdef DILITHIUM_ENABLED
+#ifdef MOCOCRW_DILITHIUM_ENABLED
 #include <mococrw/dilithium.h>
 #endif
 
@@ -205,7 +205,7 @@ void edDsaVerify(const AsymmetricPublicKey &pubKey,
     }
 }
 
-#ifdef DILITHIUM_ENABLED
+#ifdef MOCOCRW_DILITHIUM_ENABLED
 
 std::vector<uint8_t> dilithiumSign(const DilithiumAsymmetricPrivateKey &privKey,
                                    const std::vector<uint8_t> &message)
@@ -244,7 +244,7 @@ void dilithiumVerify(const DilithiumAsymmetricPublicKey &pubKey,
     }
 }
 
-#endif  // DILITHIUM_ENABLED
+#endif  // MOCOCRW_DILITHIUM_ENABLED
 
 int main(void)
 {
@@ -299,7 +299,7 @@ int main(void)
     edDsaVerify(edPrivKey, signature, message);
     /*********************************************/
 
-#ifdef DILITHIUM_ENABLED
+#ifdef MOCOCRW_DILITHIUM_ENABLED
     /************** dilithium signature **********/
     /* Please note that the interface might change slightly once openssl officially supports
      * dilithium
@@ -323,5 +323,5 @@ int main(void)
 
     dilithiumVerify(dilithiumPubKey, signature, message);
     /*********************************************/
-#endif  // DILITHIUM_ENABLED
+#endif  // MOCOCRW_DILITHIUM_ENABLED
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,14 +38,14 @@ set(LIBRARY_SOURCES
 )
 
 # Add additional source files if HSM features are enabled.
-if(HSM_ENABLED)
+if(MOCOCRW_HSM_ENABLED)
   set(LIBRARY_SOURCES
       ${LIBRARY_SOURCES}
       hsm.cpp
   )
 endif()
 
-if(DILITHIUM_ENABLED)
+if(MOCOCRW_DILITHIUM_ENABLED)
     set(LIBRARY_SOURCES
         ${LIBRARY_SOURCES}
         dilithium.cpp
@@ -80,14 +80,14 @@ set(LIBRARY_PUBLIC_HEADERS
 )
 
 # Add additional header files if HSM features are enabled.
-if(HSM_ENABLED)
+if(MOCOCRW_HSM_ENABLED)
   set(LIBRARY_PUBLIC_HEADERS
       ${LIBRARY_PUBLIC_HEADERS}
       mococrw/hsm.h
   )
 endif()
 
-if(DILITHIUM_ENABLED)
+if(MOCOCRW_DILITHIUM_ENABLED)
     set(LIBRARY_PUBLIC_HEADERS
         ${LIBRARY_PUBLIC_HEADERS}
         mococrw/dilithium.h
@@ -98,11 +98,11 @@ add_library(${LIBRARY_NAME} SHARED ${LIBRARY_SOURCES} ${LIBRARY_PUBLIC_HEADERS})
 add_library(${PROJECT_NAME}::${LIBRARY_NAME} ALIAS ${LIBRARY_NAME})
 target_link_libraries(${LIBRARY_NAME} PUBLIC OpenSSL::Crypto OpenSSL::SSL Boost::boost)
 
-if(HSM_ENABLED)
-  target_compile_definitions(${LIBRARY_NAME} PUBLIC HSM_ENABLED)
+if(MOCOCRW_HSM_ENABLED)
+  target_compile_definitions(${LIBRARY_NAME} PUBLIC MOCOCRW_HSM_ENABLED)
 endif()
 
-if(DILITHIUM_ENABLED)
+if(MOCOCRW_DILITHIUM_ENABLED)
     target_link_libraries(${LIBRARY_NAME} PRIVATE dilithium2_ref dilithium3_ref dilithium5_ref aes256ctr_ref fips202_ref)
 endif()
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -106,7 +106,7 @@ AsymmetricPublicKey AsymmetricPublicKey::readPublicKeyFromPEM(const std::string 
     return AsymmetricPublicKey{std::move(key)};
 }
 
-#ifdef HSM_ENABLED
+#ifdef MOCOCRW_HSM_ENABLED
 AsymmetricPublicKey AsymmetricPublicKey::readPublicKeyFromHSM(const HSM &hsm,
                                                               const std::string &keyLabel,
                                                               const std::vector<uint8_t> &keyID)
@@ -187,7 +187,7 @@ AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromPEM(const std::string &pe
     return AsymmetricKeypair{std::move(key)};
 }
 
-#ifdef HSM_ENABLED
+#ifdef MOCOCRW_HSM_ENABLED
 AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromHSM(const HSM &hsm,
                                                            const std::string &keyLabel,
                                                            const std::vector<uint8_t> &keyID)

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -17,7 +17,7 @@
  * #L%
  */
 #pragma once
-#ifdef HSM_ENABLED
+#ifdef MOCOCRW_HSM_ENABLED
 #include "mococrw/hsm.h"
 #endif
 #include "openssl_wrap.h"
@@ -85,7 +85,7 @@ public:
      */
     static AsymmetricPublicKey readPublicKeyFromPEM(const std::string &pem);
 
-#ifdef HSM_ENABLED
+#ifdef MOCOCRW_HSM_ENABLED
     /**
      * @brief Loads a public key from an HSM, creating an @ref AsymmetricPublicKey
      * object as a result.
@@ -268,7 +268,7 @@ public:
     static AsymmetricKeypair readPrivateKeyFromPEM(const std::string &pem,
                                                    const std::string &password);
 
-#ifdef HSM_ENABLED
+#ifdef MOCOCRW_HSM_ENABLED
     /**
      * @brief Loads a private key from an HSM, creating an @ref AsymmetricPublicKey
      * object as a result.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -31,7 +31,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     add_executable(openssltest test_opensslwrapper.cpp
                              ${MOCK_SOURCES})
 
-    if(HSM_ENABLED)
+    if(MOCOCRW_HSM_ENABLED)
         add_executable(hsmtest test_hsm.cpp
                             "${SRC_DIR}/key.cpp"
                             "${SRC_DIR}/hsm.cpp"
@@ -145,7 +145,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
         "${SRC_DIR}/kdf.cpp"
         ${REAL_SOURCES})
 
-    if(DILITHIUM_ENABLED)
+    if(MOCOCRW_DILITHIUM_ENABLED)
         add_executable(dilithiumtests test_dilithium.cpp
             "${SRC_DIR}/asymmetric_crypto_ctx.cpp"
             "${SRC_DIR}/hash.cpp"
@@ -163,12 +163,12 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     # Cannot link to imported OpenSSL and leverage implicit include-dir-propagation, as openssltest uses mocks.
     target_include_directories(openssltest PUBLIC ${OPENSSL_INCLUDE_DIR})
 
-    if(HSM_ENABLED)
+    if(MOCOCRW_HSM_ENABLED)
         target_link_libraries(hsmtest ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
         target_include_directories(hsmtest PUBLIC ${OPENSSL_INCLUDE_DIR})
     endif()
 
-    if(DILITHIUM_ENABLED)
+    if(MOCOCRW_DILITHIUM_ENABLED)
         set(DEFAULT_LINK_LIBRARIES ${DEFAULT_LINK_LIBRARIES} dilithium2_ref dilithium3_ref dilithium5_ref aes256ctr_ref fips202_ref)
         target_link_libraries(dilithiumtests ${DEFAULT_LINK_LIBRARIES})
     endif()
@@ -195,9 +195,9 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     target_link_libraries(cmactests ${DEFAULT_LINK_LIBRARIES})
     target_link_libraries(eciestests ${DEFAULT_LINK_LIBRARIES})
 
-    if(HSM_ENABLED)
-        target_compile_definitions(keytests PUBLIC HSM_ENABLED)
-        target_compile_definitions(hsmtest PUBLIC HSM_ENABLED)
+    if(MOCOCRW_HSM_ENABLED)
+        target_compile_definitions(keytests PUBLIC MOCOCRW_HSM_ENABLED)
+        target_compile_definitions(hsmtest PUBLIC MOCOCRW_HSM_ENABLED)
     endif()
 
     add_test(
@@ -205,7 +205,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
         COMMAND openssltest
     )
 
-    if(HSM_ENABLED)
+    if(MOCOCRW_HSM_ENABLED)
         add_test(
             NAME HSMTest
             COMMAND hsmtest
@@ -301,7 +301,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
 	COMMAND eciestests
     )
 
-    if(DILITHIUM_ENABLED)
+    if(MOCOCRW_DILITHIUM_ENABLED)
         add_test(
             NAME DilithiumSignatureTests
             COMMAND dilithiumtests

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -22,7 +22,7 @@
 #include "key.cpp"
 #include "util.cpp"
 
-#ifdef HSM_ENABLED
+#ifdef MOCOCRW_HSM_ENABLED
 #include "hsm_mock.h"
 #endif
 
@@ -274,7 +274,7 @@ TEST_F(KeyHandlingTests, testPrivKeyFromSavedPemIsSameAsOriginal)
     ASSERT_EQ(pemOfSectEd25519PubKey, retrievedEd25519KeyPair.publicKeyToPem());
 }
 
-#ifdef HSM_ENABLED
+#ifdef MOCOCRW_HSM_ENABLED
 TEST_F(KeyHandlingTests, testKeyLoadPubKeyFromHSM)
 {
     std::vector<uint8_t> keyID{0x44, 0x22, 0x11};


### PR DESCRIPTION
Rename MACRO definitions used for optional features to more specific ones by prefixing them with MOCOCRW_*.