### PR TITLE
HSM: Raise MoCOCrW Exception for unknown key ID

### DIFF
--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -221,6 +221,8 @@ public:
     /* Error handling */
     static char *SSL_ERR_error_string(unsigned long error, char *buf) noexcept;
     static unsigned long SSL_ERR_get_error() noexcept;
+    static const char *SSL_ERR_lib_error_string(unsigned long error) noexcept;
+    static const char *SSL_ERR_reason_error_string(unsigned long error) noexcept;
 
     /* BIO Stuff */
     static const BIO_METHOD *SSL_BIO_s_mem() noexcept;

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -128,13 +128,22 @@ public:
      * as message.
      *
      */
-    OpenSSLException() : _message{generateOpenSSLErrorString()} {}
+    OpenSSLException();
 
     const char *what() const noexcept override { return _message.c_str(); }
 
+    /**
+     * The following functions enable fine-tuned error handling via sub-library and reason
+     * information
+     */
+    std::string getLib() const { return _library; };
+    std::string getReason() const { return _reason; };
+
 private:
-    static std::string generateOpenSSLErrorString();
+    static std::string generateOpenSSLErrorString(unsigned long error);
     std::string _message;
+    std::string _library;
+    std::string _reason;
 };
 
 /*

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -163,6 +163,16 @@ char *OpenSSLLib::SSL_ERR_error_string(unsigned long error, char *buf) noexcept
     return ERR_error_string(error, buf);
 }
 
+const char *OpenSSLLib::SSL_ERR_lib_error_string(unsigned long error) noexcept
+{
+    return ERR_lib_error_string(error);
+}
+
+const char *OpenSSLLib::SSL_ERR_reason_error_string(unsigned long error) noexcept
+{
+    return ERR_reason_error_string(error);
+}
+
 unsigned long OpenSSLLib::SSL_ERR_get_error() noexcept { return ERR_get_error(); }
 
 X509_NAME *OpenSSLLib::SSL_X509_NAME_new() noexcept { return X509_NAME_new(); }

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -41,9 +41,20 @@ namespace mococrw
 {
 namespace openssl
 {
-std::string OpenSSLException::generateOpenSSLErrorString()
+OpenSSLException::OpenSSLException()
 {
     auto error = lib::OpenSSLLib::SSL_ERR_get_error();
+    _message = generateOpenSSLErrorString(error);
+
+    auto libraryCharStr = lib::OpenSSLLib::SSL_ERR_lib_error_string(error);
+    _library = (libraryCharStr == nullptr) ? "" : std::string(libraryCharStr);
+
+    auto reasonCharStr = lib::OpenSSLLib::SSL_ERR_reason_error_string(error);
+    _reason = (reasonCharStr == nullptr) ? "" : std::string(reasonCharStr);
+}
+
+std::string OpenSSLException::generateOpenSSLErrorString(unsigned long error)
+{
     auto formatter = boost::format("%s: %d");
     formatter % lib::OpenSSLLib::SSL_ERR_error_string(error, nullptr) % error;
     return formatter.str();

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -231,6 +231,16 @@ unsigned long OpenSSLLib::SSL_ERR_get_error() noexcept
     return OpenSSLLibMockManager::getMockInterface().SSL_ERR_get_error();
 }
 
+const char *OpenSSLLib::SSL_ERR_lib_error_string(unsigned long error) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ERR_lib_error_string(error);
+}
+
+const char *OpenSSLLib::SSL_ERR_reason_error_string(unsigned long error) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_ERR_reason_error_string(error);
+}
+
 X509_NAME *OpenSSLLib::SSL_X509_NAME_new() noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_X509_NAME_new();

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -213,6 +213,8 @@ public:
     /* Error handling */
     virtual char *SSL_ERR_error_string(unsigned long error, char *buf) = 0;
     virtual unsigned long SSL_ERR_get_error() = 0;
+    virtual const char *SSL_ERR_lib_error_string(unsigned long error) = 0;
+    virtual const char *SSL_ERR_reason_error_string(unsigned long error) = 0;
 
     /* X509_NAME related things */
     virtual X509_NAME *SSL_X509_NAME_new() = 0;
@@ -583,6 +585,8 @@ public:
 
     MOCK_METHOD0(SSL_ERR_get_error, unsigned long());
     MOCK_METHOD2(SSL_ERR_error_string, char *(unsigned long, char *));
+    MOCK_METHOD1(SSL_ERR_lib_error_string, const char *(unsigned long));
+    MOCK_METHOD1(SSL_ERR_reason_error_string, const char *(unsigned long));
 
     MOCK_METHOD0(SSL_X509_NAME_new, X509_NAME *());
     MOCK_METHOD1(SSL_X509_NAME_free, void(X509_NAME *));

--- a/tests/unit/test_opensslwrapper.cpp
+++ b/tests/unit/test_opensslwrapper.cpp
@@ -50,7 +50,10 @@ public:
     void TearDown() override;
 
 protected:
-    std::string _defaultErrorMessage{"bla bla bla"};
+    std::string _defaultErrorMessage{"bla bla err msg"};
+    std::string _defaultErrorLibrary{"bla bla err lib"};
+    std::string _defaultErrorReason{"bla bla err reason"};
+
     const unsigned long _defaultErrorCode = 1L;
     OpenSSLLibMock &_mock() const { return OpenSSLLibMockManager::getMockInterface(); }
 };
@@ -89,6 +92,11 @@ void OpenSSLWrapperTest::SetUp()
     ON_CALL(_mock(), SSL_ERR_get_error()).WillByDefault(Return(_defaultErrorCode));
     ON_CALL(_mock(), SSL_ERR_error_string(_, nullptr))
             .WillByDefault(Return(const_cast<char *>(_defaultErrorMessage.c_str())));
+    ON_CALL(_mock(), SSL_ERR_lib_error_string(_))
+            .WillByDefault(Return(const_cast<char *>(_defaultErrorLibrary.c_str())));
+    ON_CALL(_mock(), SSL_ERR_reason_error_string(_))
+            .WillByDefault(Return(const_cast<char *>(_defaultErrorReason.c_str())));
+
     // TODO: Get rid of the uninteresting calls by default here somehow...
 }
 
@@ -106,6 +114,8 @@ TEST_F(OpenSSLWrapperTest, keyMemoryManagement)
 
     EXPECT_CALL(_mock(), SSL_ERR_get_error()).WillOnce(Return(_defaultErrorCode));
     EXPECT_CALL(_mock(), SSL_ERR_error_string(_defaultErrorCode, nullptr));
+    EXPECT_CALL(_mock(), SSL_ERR_lib_error_string(_defaultErrorCode));
+    EXPECT_CALL(_mock(), SSL_ERR_reason_error_string(_defaultErrorCode));
 
     EXPECT_THROW(_EVP_PKEY_new(), OpenSSLException);
 }
@@ -128,6 +138,8 @@ TEST_F(OpenSSLWrapperTest, keyContextMemoryManagement)
 
     EXPECT_CALL(_mock(), SSL_ERR_get_error()).WillOnce(Return(_defaultErrorCode));
     EXPECT_CALL(_mock(), SSL_ERR_error_string(_defaultErrorCode, nullptr));
+    EXPECT_CALL(_mock(), SSL_ERR_lib_error_string(_defaultErrorCode));
+    EXPECT_CALL(_mock(), SSL_ERR_reason_error_string(_defaultErrorCode));
 
     EXPECT_THROW(_EVP_PKEY_CTX_new_id(0), OpenSSLException);
     auto key = _EVP_PKEY_CTX_new_id(0);


### PR DESCRIPTION
When attempting to load a key with an unknown ID,
MoCOCrW raises an OpenSSLException. This is not
ideal, as such exceptions are usually raised for
internal problems within OpenSSL. For cases where
an ID is unknown, one would expect a MoCOCrWException
to be thrown back to the user.

To make matters worse, the current catch-all
approach of using OpenSSLException makes it
difficult to distinguish different types of
errors.

In order to specifically identify the error where the passed key is unknown,
we check that the error stems from the pkcs11 engine and that the reason is
"object not found". To obtain this information,
SSL_ERR_lib_error_string() and SSL_ERR_reason_error_string() wrappings
are introduced.

Inside HsmEngine::loadPrivateKey() and
HsmEngine::loadPublicKey(), the OpenSSLException
is caught and checked whether it has been raised
due to unknown ID. If so, a MoCOCrWException is
thrown. Otherwise, the original OpenSSLException
is thrown again.