### PR TITLE
utils: Add unit test for cleanse utilities

### DIFF
--- a/src/mococrw/util.h
+++ b/src/mococrw/util.h
@@ -75,6 +75,8 @@ void vectorCleanse(std::vector<T> &vec)
     // std::vector<T>::data() is allowed to return a nullptr if the size is 0.
     if (vec.size() > 0) {
         OPENSSL_cleanse(vec.data(), vec.size() * sizeof(T));
+        // Clear all vector metadata
+        vec.clear();
     }
 }
 

--- a/tests/unit/test_util.cpp
+++ b/tests/unit/test_util.cpp
@@ -78,3 +78,41 @@ TEST_F(UtilTest, testFromHex)
 
     ASSERT_THROW(result = mococrw::utility::fromHex("  deadbeef"), mococrw::MoCOCrWException);
 }
+
+TEST_F(UtilTest, stringCleanse)
+{
+    std::string secret{"1234"};
+    mococrw::utility::stringCleanse(secret);
+    ASSERT_EQ(0, secret.size());
+}
+
+TEST_F(UtilTest, stringCleanseCheckMemory)
+{
+    std::string secret{"1234"};
+    auto secretPtr = &secret[0];
+    auto secretSize = secret.size();
+    std::string zeroedOutString(secretSize, '\0');
+    mococrw::utility::stringCleanse(secret);
+    // Capacity of std::string may change, depending on implementation.
+    // Only test this if the memory is still allocated.
+    if (secret.capacity() >= secretSize) {
+        ASSERT_EQ(0, memcmp(secretPtr, &zeroedOutString[0], secretSize));
+    }
+}
+
+TEST_F(UtilTest, vectorCleanse)
+{
+    std::vector<uint8_t> secret = {222, 173, 190, 239};
+    mococrw::utility::vectorCleanse(secret);
+    ASSERT_EQ(0, secret.size());
+}
+
+TEST_F(UtilTest, vectorCleanseCheckMemory)
+{
+    std::vector<uint8_t> secret = {222, 173, 190, 239};
+    auto secretPtr = &secret[0];
+    auto secretSize = secret.size();
+    std::vector<uint8_t> zeroedOutVector(secretSize, 0);
+    mococrw::utility::vectorCleanse(secret);
+    ASSERT_EQ(0, memcmp(secretPtr, &zeroedOutVector[0], secretSize));
+}


### PR DESCRIPTION
std::vector::clear() was added to vector cleanse to clear the vector meta data with may be sensitive