### PR TITLE
hsm: don't allow creating keys with the same ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
             fi \
             && ctest --verbose -j $(nproc) \
             && if [ "${{ matrix.hsm_flag }}" = "MOCOCRW_HSM_ENABLED=ON" ]; then \
+                echo "HsmIntegrationTest stderr:"
+                cat /tmp/hsm-int-test.log
                 softhsm2-util --delete-token --token ${{ env.TOKEN_LABEL1 }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
                 softhsm2-util --delete-token --token ${{ env.TOKEN_LABEL2 }} --pin ${{ env.USER_PIN }} --so-pin ${{ env.SO_PIN  }}; \
             fi'

--- a/dockerfiles/feature-support/hsm-patches/0001-Introduce-generic-keypair-generation-interface-and-e.patch
+++ b/dockerfiles/feature-support/hsm-patches/0001-Introduce-generic-keypair-generation-interface-and-e.patch
@@ -1,4 +1,4 @@
-From e39fd1f3831294c6b1d3d636e4563bff86b9cf8c Mon Sep 17 00:00:00 2001
+From 828282b17f40237bb875e93df0e216e12c4f2504 Mon Sep 17 00:00:00 2001
 From: istepic <ivan.stepich@gmail.com>
 Date: Mon, 5 Dec 2022 22:44:25 +0100
 Subject: [PATCH] Introduce generic keypair generation interface and engine
@@ -46,12 +46,13 @@ Signed-off-by: istepic <ivan.stepich@gmail.com>
  src/libp11-int.h     |  15 ++-
  src/libp11.h         |  48 +++++++---
  src/p11_front.c      |  32 +++++--
- src/p11_key.c        |  94 ++++++++++++++++++-
+ src/p11_key.c        | 119 +++++++++++++++++++++++-
  src/p11_misc.c       |  75 +++++++++++++++
+ src/p11_slot.c       |   1 +
  tests/Makefile.am    |   6 +-
  tests/keygen.c       | 215 +++++++++++++++++++++++++++++++++++++++++++
  tests/keygen.softhsm |  39 ++++++++
- 11 files changed, 562 insertions(+), 32 deletions(-)
+ 12 files changed, 587 insertions(+), 33 deletions(-)
  create mode 100644 tests/keygen.c
  create mode 100755 tests/keygen.softhsm
 
@@ -329,7 +330,7 @@ index f74f209..f82c9a3 100644
  {
  	PKCS11_OBJECT_private *key = PRIVKEY(pkey);
 diff --git a/src/p11_key.c b/src/p11_key.c
-index ec7f279..8466700 100644
+index ec7f279..57cba43 100644
 --- a/src/p11_key.c
 +++ b/src/p11_key.c
 @@ -252,8 +252,8 @@ int pkcs11_reload_object(PKCS11_OBJECT_private *obj)
@@ -343,16 +344,31 @@ index ec7f279..8466700 100644
  
  	PKCS11_CTX_private *ctx = slot->ctx;
  	CK_SESSION_HANDLE session;
-@@ -266,8 +266,6 @@ int pkcs11_generate_key(PKCS11_SLOT_private *slot, int algorithm, unsigned int b
+@@ -266,10 +266,20 @@ int pkcs11_generate_key(PKCS11_SLOT_private *slot, int algorithm, unsigned int b
  	CK_OBJECT_HANDLE pub_key_obj, priv_key_obj;
  	int rv;
  
 -	(void)algorithm; /* squash the unused parameter warning */
 -
- 	if (pkcs11_get_session(slot, 1, &session))
+-	if (pkcs11_get_session(slot, 1, &session))
++	// R/W session is mandatory for key generation.
++	if (pkcs11_open_session(slot, 1)) {
++		return -1;
++	}
++	// open_session might call C_CloseAllSessions if current session is not R/W.
++	// C_CloseAllSessions logs everyone out
++	if (slot->logged_in <= 0) {
++		if (pkcs11_login(slot, 0, slot->prev_pin)) {
++			return -1;
++		}
++	}
++	if (pkcs11_get_session(slot, 1, &session)) {
  		return -1;
++	}
  
-@@ -310,6 +308,94 @@ int pkcs11_generate_key(PKCS11_SLOT_private *slot, int algorithm, unsigned int b
+ 	/* pubkey attributes */
+ 	pkcs11_addattr(&pubtmpl, CKA_ID, id, id_len);
+@@ -310,6 +320,105 @@ int pkcs11_generate_key(PKCS11_SLOT_private *slot, int algorithm, unsigned int b
  	return 0;
  }
  
@@ -375,6 +391,17 @@ index ec7f279..8466700 100644
 +	ASN1_OBJECT *curve_obj = NULL;
 +	int curve_nid = NID_undef;
 +
++	// R/W session is mandatory for key generation.
++	if (pkcs11_open_session(slot, 1)) {
++		return -1;
++	}
++	// open_session might call C_CloseAllSessions if current session is not R/W.
++	// C_CloseAllSessions logs everyone out
++	if (slot->logged_in <= 0) {
++		if (pkcs11_login(slot, 0, slot->prev_pin)) {
++			return -1;
++		}
++	}
 +	if (pkcs11_get_session(slot, 1, &session)) {
 +		return -1;
 +	}
@@ -531,6 +558,18 @@ index 1b0e64d..1d9a845 100644
 +
 +
  /* vim: set noexpandtab: */
+diff --git a/src/p11_slot.c b/src/p11_slot.c
+index 3c00e22..c5c322b 100644
+--- a/src/p11_slot.c
++++ b/src/p11_slot.c
+@@ -111,6 +111,7 @@ int pkcs11_open_session(PKCS11_SLOT_private *slot, int rw)
+ 	if (rw != slot->rw_mode) {
+ 		CRYPTOKI_call(ctx, C_CloseAllSessions(slot->id));
+ 		slot->rw_mode = rw;
++		slot->logged_in = -1;
+ 	}
+ 	slot->num_sessions = 0;
+ 	slot->session_head = slot->session_tail = 0;
 diff --git a/tests/Makefile.am b/tests/Makefile.am
 index b1bc0fb..a71327d 100644
 --- a/tests/Makefile.am
@@ -822,5 +861,5 @@ index 0000000..83f8175
 +
 +exit 0
 -- 
-2.25.1
+2.39.2
 

--- a/examples/hsm-example.cpp
+++ b/examples/hsm-example.cpp
@@ -37,7 +37,7 @@ int main(void)
     utility::stringCleanse(pin);
 
     /************** ECC key generation **************/
-    std::vector<uint8_t> keyIDECC{};
+    std::vector<uint8_t> keyIDECC{0x97};
     std::string keyLabelECC("ecc-key-label");
     ECCSpec ecspec;
     // Keypair containing private and public key
@@ -47,7 +47,7 @@ int main(void)
     auto pubKeyEcc = AsymmetricPublicKey::readPublicKeyFromHSM(hsmEngine, keyLabelECC, keyIDECC);
 
     /************** RSA key generation **************/
-    std::vector<uint8_t> keyIDRSA{0x12, 0x34};
+    std::vector<uint8_t> keyIDRSA{0x97, 0x34};
     std::string keyLabelRSA{"rsa-key-label"};
     mococrw::RSASpec rsaSpec;
     // AsymmetricPrivateKey is an alias for AsymmetricKeypair so it can be used as well

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -82,16 +82,11 @@ std::string HsmEngine::_constructPkcs11URI(const std::vector<uint8_t> &keyID) co
 std::string HsmEngine::_constructPkcs11URI(const std::string &keyLabel,
                                            const std::vector<uint8_t> &keyID) const
 {
-    if (keyID.empty()) {
-        // libp11 doesn't fetch keys in deterministic manner if multiple keys have the
-        // the same label and we provide empty keyID
-        throw MoCOCrWException("keyID can't be empty");
+    auto pkcs11URI = _constructPkcs11URI(keyID);
+    if (keyLabel.empty()) {
+        throw MoCOCrWException("keyLabel can't be empty");
     }
-    auto keyIDPctEncoded = pctEncode(keyID);
-    std::string pkcs11URI = "pkcs11:token=" + _tokenLabel + ";id=" + keyIDPctEncoded;
-    if (!keyLabel.empty()) {
-        pkcs11URI += ";object=" + keyLabel;
-    }
+    pkcs11URI += ";object=" + keyLabel;
     return pkcs11URI;
 }
 
@@ -185,7 +180,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
     pkcs11RSAKeygen.token_label = _tokenLabel.c_str();
     pkcs11RSAKeygen.key_label = keyLabel.c_str();
     _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11RSAKeygen);
-    return loadPrivateKey(keyLabel, keyID);
+    return loadPrivateKey(keyID);
 }
 
 openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
@@ -215,6 +210,6 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
     pkcs11ECCKeygen.token_label = _tokenLabel.c_str();
     pkcs11ECCKeygen.key_label = keyLabel.c_str();
     _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11ECCKeygen);
-    return loadPrivateKey(keyLabel, keyID);
+    return loadPrivateKey(keyID);
 }
 }  // namespace mococrw

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -23,6 +23,7 @@
 
 #include "libp11.h"
 
+#include "mococrw/error.h"
 #include "mococrw/key.h"
 
 namespace mococrw
@@ -63,12 +64,26 @@ HsmEngine::HsmEngine(const std::string &id,
 
 HsmEngine::~HsmEngine() { _ENGINE_finish(_engine.get()); }
 
+std::string HsmEngine::_constructPkcs11URI(const std::string &keyLabel,
+                                           const std::vector<uint8_t> &keyID) const
+{
+    if (keyID.empty()) {
+        // libp11 doesn't fetch keys in deterministic manner if multiple keys have the
+        // the same label and we provide empty keyID
+        throw MoCOCrWException("keyID can't be empty");
+    }
+    auto keyIDPctEncoded = pctEncode(keyID);
+    std::string pkcs11URI = "pkcs11:token=" + _tokenLabel + ";id=" + keyIDPctEncoded;
+    if (!keyLabel.empty()) {
+        pkcs11URI += ";object=" + keyLabel;
+    }
+    return pkcs11URI;
+}
+
 openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPublicKey(const std::string &keyLabel,
                                                    const std::vector<uint8_t> &keyID) const
 {
-    auto keyIDPctEncoded = pctEncode(keyID);
-    std::string pkcs11URI =
-            "pkcs11:token=" + _tokenLabel + ";object=" + keyLabel + ";id=" + keyIDPctEncoded;
+    auto pkcs11URI = _constructPkcs11URI(keyLabel, keyID);
     try {
         return _ENGINE_load_public_key(_engine.get(), pkcs11URI);
     } catch (const OpenSSLException &e) {
@@ -87,9 +102,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPublicKey(const std::string &keyLabel,
 openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPrivateKey(const std::string &keyLabel,
                                                     const std::vector<uint8_t> &keyID) const
 {
-    auto keyIDPctEncoded = pctEncode(keyID);
-    std::string pkcs11URI =
-            "pkcs11:token=" + _tokenLabel + ";object=" + keyLabel + ";id=" + keyIDPctEncoded;
+    auto pkcs11URI = _constructPkcs11URI(keyLabel, keyID);
     try {
         return _ENGINE_load_private_key(_engine.get(), pkcs11URI);
     } catch (const OpenSSLException &e) {
@@ -104,36 +117,60 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
                                                  const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID)
 {
-    std::string keyIDHexString = utility::toHex(keyID);
-    PKCS11_RSA_KGEN pkcs11RSASpec;
-    pkcs11RSASpec.bits = spec.numberOfBits();
-    PKCS11_KGEN_ATTRS pkcs11RSAKeygen;
-    pkcs11RSAKeygen.type = EVP_PKEY_RSA;
-    pkcs11RSAKeygen.kgen.rsa = &pkcs11RSASpec;
-    pkcs11RSAKeygen.key_id = keyIDHexString.c_str();
-    pkcs11RSAKeygen.token_label = _tokenLabel.c_str();
-    pkcs11RSAKeygen.key_label = keyLabel.c_str();
+    try {
+        // We need to make sure that we don't have 2 keys with the same ID.
+        // For that we need to pass empty keyLabel. Otherwise libp11 tries to find
+        // a key with exact keyLabel/keyID combination. This means that libp11 might
+        // not recognize that the key with the same ID is already there.
+        loadPrivateKey("", keyID);
+    } catch (const MoCOCrWException &e) {
+        if (e.what() == std::string("Unable to load private key. Private key not found!")) {
+            std::string keyIDHexString = utility::toHex(keyID);
+            PKCS11_RSA_KGEN pkcs11RSASpec;
+            pkcs11RSASpec.bits = spec.numberOfBits();
+            PKCS11_KGEN_ATTRS pkcs11RSAKeygen;
+            pkcs11RSAKeygen.type = EVP_PKEY_RSA;
+            pkcs11RSAKeygen.kgen.rsa = &pkcs11RSASpec;
+            pkcs11RSAKeygen.key_id = keyIDHexString.c_str();
+            pkcs11RSAKeygen.token_label = _tokenLabel.c_str();
+            pkcs11RSAKeygen.key_label = keyLabel.c_str();
 
-    _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11RSAKeygen);
-    return loadPrivateKey(keyLabel, keyID);
+            _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11RSAKeygen);
+            return loadPrivateKey(keyLabel, keyID);
+        }
+        throw;
+    }
+    throw MoCOCrWException("Key with that keyID already exists");
 }
 
 openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
                                                  const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID)
 {
-    std::string curve = spec.curveName();
-    std::string keyIDHexString = utility::toHex(keyID);
-    PKCS11_EC_KGEN pkcs11ECCSpec;
-    pkcs11ECCSpec.curve = curve.c_str();
-    PKCS11_KGEN_ATTRS pkcs11ECCKeygen;
-    pkcs11ECCKeygen.type = EVP_PKEY_EC;
-    pkcs11ECCKeygen.kgen.ec = &pkcs11ECCSpec;
-    pkcs11ECCKeygen.key_id = keyIDHexString.c_str();
-    pkcs11ECCKeygen.token_label = _tokenLabel.c_str();
-    pkcs11ECCKeygen.key_label = keyLabel.c_str();
+    try {
+        // We need to make sure that we don't have 2 keys with the same ID.
+        // For that we need to pass empty keyLabel. Otherwise libp11 tries to find
+        // a key with exact keyLabel/keyID combination. This means that libp11 might
+        // not recognize that the key with the same ID is already there.
+        loadPrivateKey("", keyID);
+    } catch (const MoCOCrWException &e) {
+        if (e.what() == std::string("Unable to load private key. Private key not found!")) {
+            std::string curve = spec.curveName();
+            std::string keyIDHexString = utility::toHex(keyID);
+            PKCS11_EC_KGEN pkcs11ECCSpec;
+            pkcs11ECCSpec.curve = curve.c_str();
+            PKCS11_KGEN_ATTRS pkcs11ECCKeygen;
+            pkcs11ECCKeygen.type = EVP_PKEY_EC;
+            pkcs11ECCKeygen.kgen.ec = &pkcs11ECCSpec;
+            pkcs11ECCKeygen.key_id = keyIDHexString.c_str();
+            pkcs11ECCKeygen.token_label = _tokenLabel.c_str();
+            pkcs11ECCKeygen.key_label = keyLabel.c_str();
 
-    _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11ECCKeygen);
-    return loadPrivateKey(keyLabel, keyID);
+            _ENGINE_ctrl_cmd(_engine.get(), "KEYGEN", &pkcs11ECCKeygen);
+            return loadPrivateKey(keyLabel, keyID);
+        }
+        throw;
+    }
+    throw MoCOCrWException("Key with that keyID already exists");
 }
 }  // namespace mococrw

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -46,6 +46,9 @@ std::string pctEncode(const std::vector<uint8_t> &bytes)
     }
     return result.str();
 }
+
+constexpr const char privKeyNotFoundError[] = "Unable to load private key. Private key not found!";
+constexpr const char pubKeyNotFoundError[] = "Unable to load public key. Public key not found!";
 }  // namespace
 
 HsmEngine::HsmEngine(const std::string &id,
@@ -104,7 +107,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPublicKey(const std::string &keyLabel,
         // key is unknown, we check that the error stems from the pkcs11 engine and that the
         // reason is "object not found".
         if (e.getLib() == "pkcs11 engine" && e.getReason() == "object not found") {
-            throw MoCOCrWException("Unable to load public key. Public key not found!");
+            throw MoCOCrWException(pubKeyNotFoundError);
         }
         // If not Unknown Key error, then throw again the original exception.
         throw;
@@ -122,7 +125,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPublicKey(const std::vector<uint8_t> &k
         // key is unknown, we check that the error stems from the pkcs11 engine and that the
         // reason is "object not found".
         if (e.getLib() == "pkcs11 engine" && e.getReason() == "object not found") {
-            throw MoCOCrWException("Unable to load public key. Public key not found!");
+            throw MoCOCrWException(pubKeyNotFoundError);
         }
         // If not Unknown Key error, then throw again the original exception.
         throw;
@@ -137,7 +140,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPrivateKey(const std::string &keyLabel,
         return _ENGINE_load_private_key(_engine.get(), pkcs11URI);
     } catch (const OpenSSLException &e) {
         if (e.getLib() == "pkcs11 engine" && e.getReason() == "object not found") {
-            throw MoCOCrWException("Unable to load private key. Private key not found!");
+            throw MoCOCrWException(privKeyNotFoundError);
         }
         throw;
     }
@@ -150,7 +153,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::loadPrivateKey(const std::vector<uint8_t> &
         return _ENGINE_load_private_key(_engine.get(), pkcs11URI);
     } catch (const OpenSSLException &e) {
         if (e.getLib() == "pkcs11 engine" && e.getReason() == "object not found") {
-            throw MoCOCrWException("Unable to load private key. Private key not found!");
+            throw MoCOCrWException(privKeyNotFoundError);
         }
         throw;
     }
@@ -168,7 +171,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
         loadPrivateKey(keyID);
         throw MoCOCrWException("Key with that keyID already exists");
     } catch (const MoCOCrWException &e) {
-        if (e.what() != std::string("Unable to load private key. Private key not found!")) {
+        if (e.what() != std::string(privKeyNotFoundError)) {
             throw;
         }
     }
@@ -197,7 +200,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
         loadPrivateKey(keyID);
         throw MoCOCrWException("Key with that keyID already exists");
     } catch (const MoCOCrWException &e) {
-        if (e.what() != std::string("Unable to load private key. Private key not found!")) {
+        if (e.what() != std::string(privKeyNotFoundError)) {
             throw;
         }
     }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -111,8 +111,13 @@ AsymmetricPublicKey AsymmetricPublicKey::readPublicKeyFromHSM(const HSM &hsm,
                                                               const std::string &keyLabel,
                                                               const std::vector<uint8_t> &keyID)
 {
-    auto key = hsm.loadPublicKey(keyLabel, keyID);
-    return AsymmetricPublicKey{std::move(key)};
+    return AsymmetricPublicKey{hsm.loadPublicKey(keyLabel, keyID)};
+}
+
+AsymmetricPublicKey AsymmetricPublicKey::readPublicKeyFromHSM(const HSM &hsm,
+                                                              const std::vector<uint8_t> &keyID)
+{
+    return AsymmetricPublicKey{hsm.loadPublicKey(keyID)};
 }
 #endif
 
@@ -192,8 +197,13 @@ AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromHSM(const HSM &hsm,
                                                            const std::string &keyLabel,
                                                            const std::vector<uint8_t> &keyID)
 {
-    auto key = hsm.loadPrivateKey(keyLabel, keyID);
-    return AsymmetricKeypair{std::move(key)};
+    return AsymmetricKeypair{hsm.loadPrivateKey(keyLabel, keyID)};
+}
+
+AsymmetricKeypair AsymmetricKeypair::readPrivateKeyFromHSM(const HSM &hsm,
+                                                           const std::vector<uint8_t> &keyID)
+{
+    return AsymmetricKeypair{hsm.loadPrivateKey(keyID)};
 }
 
 AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
@@ -206,8 +216,7 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
         throw MoCOCrWException("Invalid keyID - key longer than 63 bytes");
     }
     try {
-        auto key = hsm.generateKey(spec, keyLabel, keyID);
-        return AsymmetricKeypair{std::move(key)};
+        return AsymmetricKeypair{hsm.generateKey(spec, keyLabel, keyID)};
     } catch (const openssl::OpenSSLException &e) {
         throw MoCOCrWException(
                 // wrong token-label? using unsupported ECC curve? HSM module implementation?
@@ -226,8 +235,7 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
         throw MoCOCrWException("Invalid keyID - key longer than 63 bytes");
     }
     try {
-        auto key = hsm.generateKey(spec, keyLabel, keyID);
-        return AsymmetricKeypair{std::move(key)};
+        return AsymmetricKeypair{hsm.generateKey(spec, keyLabel, keyID)};
     } catch (const openssl::OpenSSLException &e) {
         throw MoCOCrWException(
                 // wrong token-label? using unsupported ECC curve? HSM module implementation?

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -45,27 +45,35 @@ protected:
     /**
      *  Loads public key from HSM.
      *
-     * @param keyLabel String based identifer of a key on the token
+     * @param keyLabel String based description of an object on the token. It
+     * can be used in combination with keyID to identify an object.
      * @param keyID Vector of raw bytes that identifies a key on the token
-     * @note keyID can not be empty
+     * @note keyID must not be empty
      */
     virtual openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyLabel,
                                                     const std::vector<uint8_t> &keyID) const = 0;
+    virtual openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::vector<uint8_t> &keyID) const = 0;
 
     /**
      * Loads private key from HSM.
      *
+     * @param keyLabel String based description of an object on the token. It
+     * can be used in combination with keyID to identify an object.
      * @param keyID Vector of raw bytes that identifies a key on the token
-     * @note keyID can not be empty
+     * @note keyID must not be empty
      */
     virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyLabel,
                                                      const std::vector<uint8_t> &keyID) const = 0;
+    virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::vector<uint8_t> &keyID) const = 0;
 
     /**
      * @brief Generate a RSA key pair on the HSM
      *
      * @param spec The RSA specification @ref RSASpec
-     * @note keyID can not be empty
+     * @param keyLabel String based description of an object on the token. It
+     * can be used in combination with keyID to identify an object.
+     * @param keyID Vector of raw bytes that identifies a key on the token
+     * @note keyID must not be empty
      */
     virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
                                                   const std::string &keyLabel,
@@ -75,7 +83,10 @@ protected:
      * @brief Generate a ECC key pair on the HSM
      *
      * @param spec The ECC specification @ref ECCSpec
-     * @note keyID can not be empty
+     * @param keyLabel String based description of an object on the token. It
+     * can be used in combination with keyID to identify an object.
+     * @param keyID Vector of raw bytes that identifies a key on the token
+     * @note keyID must not be empty
      */
     virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
                                                   const std::string &keyLabel,
@@ -118,8 +129,12 @@ protected:
     openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyLabel,
                                             const std::vector<uint8_t> &keyID) const override;
 
+    openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::vector<uint8_t> &keyID) const override;
+
     openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyLabel,
                                              const std::vector<uint8_t> &keyID) const override;
+
+    openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::vector<uint8_t> &keyID) const override;
 
     openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
                                           const std::string &keyLabel,
@@ -135,6 +150,8 @@ private:
      */
     std::string _constructPkcs11URI(const std::string &keyLabel,
                                     const std::vector<uint8_t> &keyId) const;
+
+    std::string _constructPkcs11URI(const std::vector<uint8_t> &keyId) const;
 };
 
 }  // namespace mococrw

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -45,8 +45,9 @@ protected:
     /**
      *  Loads public key from HSM.
      *
-     *  @param keyLabel String based identifer of a key on the token
-     *  @param keyID Vector of raw bytes that identifies a key on the token
+     * @param keyLabel String based identifer of a key on the token
+     * @param keyID Vector of raw bytes that identifies a key on the token
+     * @note keyID can not be empty
      */
     virtual openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyLabel,
                                                     const std::vector<uint8_t> &keyID) const = 0;
@@ -55,6 +56,7 @@ protected:
      * Loads private key from HSM.
      *
      * @param keyID Vector of raw bytes that identifies a key on the token
+     * @note keyID can not be empty
      */
     virtual openssl::SSL_EVP_PKEY_Ptr loadPrivateKey(const std::string &keyLabel,
                                                      const std::vector<uint8_t> &keyID) const = 0;
@@ -63,6 +65,7 @@ protected:
      * @brief Generate a RSA key pair on the HSM
      *
      * @param spec The RSA specification @ref RSASpec
+     * @note keyID can not be empty
      */
     virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
                                                   const std::string &keyLabel,
@@ -72,6 +75,7 @@ protected:
      * @brief Generate a ECC key pair on the HSM
      *
      * @param spec The ECC specification @ref ECCSpec
+     * @note keyID can not be empty
      */
     virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
                                                   const std::string &keyLabel,
@@ -124,6 +128,13 @@ protected:
     openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
                                           const std::string &keyLabel,
                                           const std::vector<uint8_t> &keyID) override;
+
+private:
+    /**
+     * @brief Construct a PKCS11 URI according to RFC 7512
+     */
+    std::string _constructPkcs11URI(const std::string &keyLabel,
+                                    const std::vector<uint8_t> &keyId) const;
 };
 
 }  // namespace mococrw

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -89,11 +89,22 @@ public:
     /**
      * @brief Loads a public key from an HSM, creating an @ref AsymmetricPublicKey
      * object as a result.
-     * @param keyLabel string based key identifer
+     * @param keyLabel String based description of an object on the token. It
+     * can be used in combination with keyID to identify an object.
      * @param keyID raw bytes based key identifer
+     * @note keyID and keyLabel must not be empty
      */
     static AsymmetricPublicKey readPublicKeyFromHSM(const HSM &hsm,
                                                     const std::string &keyLabel,
+                                                    const std::vector<uint8_t> &keyID);
+
+    /**
+     * @brief Loads a public key from an HSM, creating an @ref AsymmetricPublicKey
+     * object as a result.
+     * @param keyID raw bytes based key identifer
+     * @note keyID must not be empty
+     */
+    static AsymmetricPublicKey readPublicKeyFromHSM(const HSM &hsm,
                                                     const std::vector<uint8_t> &keyID);
 #endif
 
@@ -270,24 +281,35 @@ public:
 
 #ifdef MOCOCRW_HSM_ENABLED
     /**
-     * @brief Loads a private key from an HSM, creating an @ref AsymmetricPublicKey
+     * @brief Loads a private key from an HSM, creating an @ref AsymmetricKeypair
      * object as a result.
-     * @param keyLabel string based key identifer
+     * @param keyLabel String based description of an object on the token. It
+     * can be used in combination with keyID to identify an object.
      * @param keyID raw bytes based key identifer
+     * @note keyID and keyLabel must not be empty
      */
     static AsymmetricKeypair readPrivateKeyFromHSM(const HSM &hsm,
                                                    const std::string &keyLabel,
                                                    const std::vector<uint8_t> &keyID);
 
     /**
+     * @brief Loads a private key from an HSM, creating an @ref AsymmetricKeypair
+     * object as a result.
+     * @param keyID raw bytes based key identifer
+     * @note keyID and keyLabel must not be empty
+     */
+    static AsymmetricKeypair readPrivateKeyFromHSM(const HSM &hsm,
+                                                   const std::vector<uint8_t> &keyID);
+
+    /**
      * @brief Generates RSA keypair on HSM token according to the spec given.
      * @note PKCS#11 standard has no rule to avoid having keys with duplicate labels and/or ids.
-     * Therefore care should be taken when generating keys on the same token.
+     * Therefore care should be taken when generating keys with other tools on the same token.
      * @param hsm HSM engine handle
      * @param spec @ref RSASpec
-     * @param keyLabel string based key identifier. This can be used to identify and fetch the keys
-     * @param keyID raw bytes based key identifier. This may be used in combination with keyLabel
-     * to identify keys.
+     * @param keyLabel String based description of an object on the token. It
+     * can be used in combination with keyID to identify an object.
+     * @param keyID raw bytes based key identifer
      * @return AsymmetricKeypair @ref AsymmetricKeypair
      * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
      * libp11 and HSM module implementation, we can't know exactly what went wrong. libp11 does log
@@ -301,12 +323,12 @@ public:
     /**
      * @brief Generates ECC keypair on HSM token according to the spec given.
      * @note PKCS#11 standard has no rule to avoid having keys with duplicate labels and/or ids.
-     * Therefore care should be taken when generating keys on the same token.
+     * Therefore care should be taken when generating keys with other tools on the same token.
      * @param hsm HSM engine handle
      * @param spec @ref ECCSpec
-     * @param keyLabel string based key identifier. This can be used to identify and fetch the keys
-     * @param keyID raw bytes based key identifier. This may be used in combination with keyLabel
-     * to identify keys.
+     * @param keyLabel String based description of an object on the token. It
+     * can be used in combination with keyID to identify an object.
+     * @param keyID raw bytes based key identifer
      * @return AsymmetricKeypair @ref AsymmetricKeypair
      * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
      * libp11 and HSM module implementation, we can't know exactly what went wrong. libp11 does log

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -11,7 +11,7 @@ add_compile_options(
     -Wfatal-errors
 )
 
-if(HSM_ENABLED)
+if(MOCOCRW_HSM_ENABLED)
     add_executable(hsm-integration-test hsm-integration-test.cpp)
     target_link_libraries(hsm-integration-test PRIVATE MoCOCrW::mococrw)
     target_compile_definitions(hsm-integration-test PRIVATE HSM_ENABLED)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -18,7 +18,7 @@ if(MOCOCRW_HSM_ENABLED)
     # libp11 writes to stderr on unsuccessful key loading. Pipe it to devnull
     add_test(
         NAME HsmIntegrationTest
-        COMMAND sh -c "${CMAKE_BINARY_DIR}/tests/integration/hsm-integration-test 2>/dev/null"
+        COMMAND sh -c "${CMAKE_BINARY_DIR}/tests/integration/hsm-integration-test 2>/tmp/hsm-int-test.log"
     )
 endif()
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -15,9 +15,10 @@ if(MOCOCRW_HSM_ENABLED)
     add_executable(hsm-integration-test hsm-integration-test.cpp)
     target_link_libraries(hsm-integration-test PRIVATE MoCOCrW::mococrw)
     target_compile_definitions(hsm-integration-test PRIVATE HSM_ENABLED)
+    # libp11 writes to stderr on unsuccessful key loading. Pipe it to devnull
     add_test(
         NAME HsmIntegrationTest
-        COMMAND hsm-integration-test
+        COMMAND sh -c "${CMAKE_BINARY_DIR}/tests/integration/hsm-integration-test 2>/dev/null"
     )
 endif()
 

--- a/tests/integration/hsm-integration-test.cpp
+++ b/tests/integration/hsm-integration-test.cpp
@@ -46,8 +46,8 @@ EciesEncryptResult encryptData(const std::vector<uint8_t> &message,
         encryptedData = encCtx->finish();
     } catch (const openssl::OpenSSLException &e) {
         /* low level OpenSSL failure */
-        std::cerr << "Error encrypting data." << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::cout << "Error encrypting data." << std::endl;
+        std::cout << e.what() << std::endl;
         exit(EXIT_FAILURE);
     } catch (const MoCOCrWException &e) {
         /* Possible reasons:
@@ -60,8 +60,8 @@ EciesEncryptResult encryptData(const std::vector<uint8_t> &message,
          * - MAC's finish() is already invoked
          * - MAC's update() is invoked after MAC's finish()
          */
-        std::cerr << "Error encrypting data." << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::cout << "Error encrypting data." << std::endl;
+        std::cout << e.what() << std::endl;
         exit(EXIT_FAILURE);
     }
 
@@ -71,15 +71,15 @@ EciesEncryptResult encryptData(const std::vector<uint8_t> &message,
                 openssl::EllipticCurvePointConversionForm::uncompressed);
     } catch (const openssl::OpenSSLException &e) {
         /* low level OpenSSL failure */
-        std::cerr << "Failure transforming EC key." << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::cout << "Failure transforming EC key." << std::endl;
+        std::cout << e.what() << std::endl;
         exit(EXIT_FAILURE);
     } catch (const MoCOCrWException &e) {
         /* Possible reasons:
          * - Key object doesn't contain an EC key
          */
-        std::cerr << "Failure transforming EC key." << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::cout << "Failure transforming EC key." << std::endl;
+        std::cout << e.what() << std::endl;
         exit(EXIT_FAILURE);
     }
     return EciesEncryptResult{
@@ -100,7 +100,7 @@ void decryptData(const EciesEncryptResult &eciesData, const AsymmetricPrivateKey
     std::shared_ptr<AsymmetricKey::Spec> spec = privKey.getKeySpec();
     auto eccSpec = std::dynamic_pointer_cast<ECCSpec>(spec);
     if (!eccSpec) {
-        std::cerr << "Given key is not an ECC key." << std::endl;
+        std::cout << "Given key is not an ECC key." << std::endl;
         exit(EXIT_FAILURE);
     }
 
@@ -121,8 +121,8 @@ void decryptData(const EciesEncryptResult &eciesData, const AsymmetricPrivateKey
         decryptedData = decCtx->finish();
     } catch (const openssl::OpenSSLException &e) {
         /* low level OpenSSL failure */
-        std::cerr << "Failure decrypting data." << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::cout << "Failure decrypting data." << std::endl;
+        std::cout << e.what() << std::endl;
         exit(EXIT_FAILURE);
     } catch (const MoCOCrWException &e) {
         /* Possible reasons:
@@ -137,8 +137,8 @@ void decryptData(const EciesEncryptResult &eciesData, const AsymmetricPrivateKey
          * - MAC is not set before invoking finish()
          * - MAC verification failed
          */
-        std::cerr << "Error decrypting integrated encryption scheme." << std::endl;
-        std::cerr << e.what();
+        std::cout << "Error decrypting integrated encryption scheme." << std::endl;
+        std::cout << e.what();
         exit(EXIT_FAILURE);
     }
 }
@@ -156,8 +156,8 @@ std::vector<uint8_t> rsaSign(const AsymmetricPrivateKey &privKey,
     try {
         signCtx = std::make_shared<RSASignaturePrivateKeyCtx>(privKey, digestType);
     } catch (const MoCOCrWException &e) {
-        std::cerr << "Please check your RSA key. Failure creating context." << std::endl;
-        std::cerr << e.what();
+        std::cout << "Please check your RSA key. Failure creating context." << std::endl;
+        std::cout << e.what();
         exit(EXIT_FAILURE);
     }
 
@@ -169,8 +169,8 @@ std::vector<uint8_t> rsaSign(const AsymmetricPrivateKey &privKey,
          * - error in openssl (sign, padding, ...)
          * - Hash function's digest size doesn't match the message's digest size
          */
-        std::cerr << "Failure occurred during signing." << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::cout << "Failure occurred during signing." << std::endl;
+        std::cout << e.what() << std::endl;
         exit(EXIT_FAILURE);
     }
     return signature;
@@ -185,8 +185,8 @@ void rsaVerify(const AsymmetricPublicKey &pubKey,
     try {
         verifyCtx = std::make_shared<RSASignaturePublicKeyCtx>(pubKey, digestType);
     } catch (const MoCOCrWException &e) {
-        std::cerr << "Please check your RSA key. Failure creating context." << std::endl;
-        std::cerr << e.what();
+        std::cout << "Please check your RSA key. Failure creating context." << std::endl;
+        std::cout << e.what();
         exit(EXIT_FAILURE);
     }
 
@@ -198,8 +198,8 @@ void rsaVerify(const AsymmetricPublicKey &pubKey,
          * - Hash function's digest size doesn't match the message's digest size
          * - Invalid signature
          */
-        std::cerr << "Verification failed!" << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::cout << "Verification failed!" << std::endl;
+        std::cout << e.what() << std::endl;
         exit(EXIT_FAILURE);
     }
 }
@@ -213,8 +213,8 @@ std::vector<uint8_t> ecdsaSign(const AsymmetricPrivateKey &privKey,
     try {
         signCtx = std::make_shared<ECDSASignaturePrivateKeyCtx>(privKey, digestType, sigFormat);
     } catch (MoCOCrWException &e) {
-        std::cerr << "Please check your ECC key. Failure creating context." << std::endl;
-        std::cerr << e.what();
+        std::cout << "Please check your ECC key. Failure creating context." << std::endl;
+        std::cout << e.what();
         exit(EXIT_FAILURE);
     }
 
@@ -227,8 +227,8 @@ std::vector<uint8_t> ecdsaSign(const AsymmetricPrivateKey &privKey,
          * - Hash function's digest size doesn't match the message's digest size
          * - Invalid signature format set
          */
-        std::cerr << "Failure occurred during signing." << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::cout << "Failure occurred during signing." << std::endl;
+        std::cout << e.what() << std::endl;
         exit(EXIT_FAILURE);
     }
     return signature;
@@ -244,8 +244,8 @@ void ecdsaVerify(const AsymmetricPublicKey &pubKey,
     try {
         verifyCtx = std::make_shared<ECDSASignaturePublicKeyCtx>(pubKey, digestType, sigFormat);
     } catch (const MoCOCrWException &e) {
-        std::cerr << "Please check your ECC key. Failure creating context." << std::endl;
-        std::cerr << e.what();
+        std::cout << "Please check your ECC key. Failure creating context." << std::endl;
+        std::cout << e.what();
         exit(EXIT_FAILURE);
     }
     try {
@@ -258,8 +258,8 @@ void ecdsaVerify(const AsymmetricPublicKey &pubKey,
          * - Signature can't be parsed
          * - Invalid signature
          */
-        std::cerr << "Verification failed!" << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::cout << "Verification failed!" << std::endl;
+        std::cout << e.what() << std::endl;
         exit(EXIT_FAILURE);
     }
 }
@@ -280,43 +280,75 @@ int main(void)
     RSASpec rsaSpec;
 
     /************** Key generation and loading **************/
-    std::cerr << "0. Testing key generation and loading:\n";
-    std::vector<uint8_t> emptyKeyId{};
-    std::string emptyLabel{};
-    std::vector<uint8_t> keyId_1{0x11};
-    std::vector<uint8_t> keyId_2{0x12};
-    std::string keyLabel_1{"key-label-1"};
-    std::string keyLabel_2{"key-label-2"};
+    std::cout << "0. Testing key generation and loading:" << std::endl;
 
-    std::cerr << "Generating a key without specifying the key ID...";
+    std::vector<uint8_t> emptyKeyId{};
+    std::string keyLabel_1{"key-label-1"};
+    std::cout << "Try to generate a key without specifying the key ID...";
     try {
         auto keypair =
                 AsymmetricPrivateKey::generateKeyOnHSM(hsmEngine, eccSpec, keyLabel_1, emptyKeyId);
     } catch (const MoCOCrWException &e) {
-        std::cerr << std::string(e.what()) + "...";
+        std::cout << std::string(e.what()) + "...";
     }
-    std::cerr << "Success\n";
-    std::cerr << "Loading a key without specifying the key ID...";
+    std::cout << "Success" << std::endl;
+
+    std::cout << "Try to load a key without specifying the key ID...";
     try {
         auto keypair =
                 AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmEngine, keyLabel_1, emptyKeyId);
     } catch (const MoCOCrWException &e) {
-        std::cerr << std::string(e.what()) + "...";
+        std::cout << std::string(e.what()) + "...";
     }
-    std::cerr << "Success\n";
-    std::cerr << "Generating a key without specifying the label...";
-    auto key1 = AsymmetricPrivateKey::generateKeyOnHSM(hsmEngine, eccSpec, emptyLabel, keyId_1);
-    std::cerr << "Success\n";
-    std::cerr << "Generating another key without specifying the label...";
-    auto key2 = AsymmetricPrivateKey::generateKeyOnHSM(hsmEngine, eccSpec, emptyLabel, keyId_2);
-    std::cerr << "Success\n";
-    std::cerr << "Load them both and test that different keys have been loaded...";
+    std::cout << "Success" << std::endl;
+
+    std::string emptyLabel{};
+    std::vector<uint8_t> keyId_1{0x11};
+    std::cout << "Generate a key without specifying the label...";
+    AsymmetricPrivateKey::generateKeyOnHSM(hsmEngine, eccSpec, emptyLabel, keyId_1);
+    std::cout << "Success" << std::endl;
+
+    std::vector<uint8_t> keyId_2{0x12};
+    std::cout << "Generate another key without specifying the label...";
+    AsymmetricPrivateKey::generateKeyOnHSM(hsmEngine, eccSpec, emptyLabel, keyId_2);
+    std::cout << "Success" << std::endl;
+
+    std::cout << "Load them both and test that different keys have been loaded...";
     if (AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmEngine, emptyLabel, keyId_1) ==
         AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmEngine, emptyLabel, keyId_2)) {
-        std::cerr << "Generated keys with different IDs should not be the same\n";
+        std::cout << "Generated keys with different IDs and empty labels should not be the same"
+                  << std::endl;
         exit(1);
     }
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
+
+    std::cout << "Try to generate a key with the same ID as in previous steps...";
+    try {
+        AsymmetricPrivateKey::generateKeyOnHSM(hsmEngine, eccSpec, keyLabel_1, keyId_1);
+    } catch (const MoCOCrWException &e) {
+        std::cout << std::string(e.what()) + "...";
+    }
+    std::cout << "Success" << std::endl;
+
+    std::vector<uint8_t> keyId_3{0x13};
+    std::string keyLabel_2{"key-label-2"};
+    std::cout << "Generate another key with some label and unique ID...";
+    AsymmetricPrivateKey::generateKeyOnHSM(hsmEngine, eccSpec, keyLabel_2, keyId_3);
+    std::cout << "Success" << std::endl;
+
+    std::vector<uint8_t> keyId_4{0x14};
+    std::cout << "Generate another key with the same label and unique ID...";
+    AsymmetricPrivateKey::generateKeyOnHSM(hsmEngine, eccSpec, keyLabel_2, keyId_4);
+    std::cout << "Success" << std::endl;
+
+    std::cout << "Load them both and test that different keys have been loaded...";
+    if (AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmEngine, keyLabel_2, keyId_3) ==
+        AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmEngine, keyLabel_2, keyId_4)) {
+        std::cout << "Generated keys with different IDs and same labels should not be the same"
+                  << std::endl;
+        exit(1);
+    }
+    std::cout << "Success\n" << std::endl;
 
     /************** ECC key generation and ECDSA **************/
     std::vector<uint8_t> keyIDECC{0x21};
@@ -324,47 +356,47 @@ int main(void)
     auto ecdsaDigestType = DigestTypes::SHA512;
     auto ecdsaSigFormat = ECDSASignatureFormat::ASN1_SEQUENCE_OF_INTS;
 
-    std::cerr << "1. Testing digital signatures using ECC keys on HSM:\n";
-    std::cerr << "Generating ECC keys on HSM...";
+    std::cout << "1. Testing digital signatures using ECC keys on HSM:" << std::endl;
+    std::cout << "Generating ECC keys on HSM...";
     AsymmetricKeypair eccPrivKey =
             AsymmetricKeypair::generateKeyOnHSM(hsmEngine, eccSpec, keyLabelECC, keyIDECC);
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
     /**
      * Signing is expected to be executed inside softhsm using a PKCS11 function C_Sign.
      * This is expected to be the case whenever key is loaded from HSM, which is the case
      * when generateKeyOnHSM() is called
      */
-    std::cerr << "Signing a message using an ECC private key generated on HSM...";
+    std::cout << "Signing a message using an ECC private key generated on HSM...";
     auto ECDSAsignature = ecdsaSign(eccPrivKey, ecdsaDigestType, ecdsaSigFormat, message);
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
 
     // AsymmetricPrivateKey also contains the public key.
-    std::cerr << "Verifying the message with the corresponding public key...";
+    std::cout << "Verifying the message with the corresponding public key...";
     ecdsaVerify(eccPrivKey, ecdsaDigestType, ecdsaSigFormat, ECDSAsignature, message);
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
 
-    std::cerr << "Explicitly loading a public key from HSM and trying to verify a signature...";
+    std::cout << "Explicitly loading a public key from HSM and trying to verify a signature...";
     auto pubKeyEcc = AsymmetricPublicKey::readPublicKeyFromHSM(hsmEngine, keyLabelECC, keyIDECC);
     ecdsaVerify(pubKeyEcc, ecdsaDigestType, ecdsaSigFormat, ECDSAsignature, message);
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
 
-    std::cerr << "Transforming a public key from HSM to a PKCS8 format that can be written to a "
+    std::cout << "Transforming a public key from HSM to a PKCS8 format that can be written to a "
                  "PEM file...";
     auto pubKeyPem = eccPrivKey.publicKeyToPem();
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
 
-    std::cerr << "Constructing a public key from PKCS8 format...";
+    std::cout << "Constructing a public key from PKCS8 format...";
     auto pubKeyEccFromPem = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pubKeyPem);
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
 
     /**
      * Since this key object is contructed from PEM string, this verification is executed
      * in software.
      */
-    std::cerr << "Doing the verification with public key from PKCS8 format (this verification is "
+    std::cout << "Doing the verification with public key from PKCS8 format (this verification is "
                  "done in software)...";
     ecdsaVerify(pubKeyEccFromPem, ecdsaDigestType, ecdsaSigFormat, ECDSAsignature, message);
-    std::cerr << "Success\n\n";
+    std::cout << "Success\n" << std::endl;
 
     /************** RSA key generation, loading and digital signatures **************/
     std::vector<uint8_t> keyIDRSA{0x31};
@@ -374,36 +406,36 @@ int main(void)
     /**
      * Generate an RSA keypair and load the public part
      */
-    std::cerr << "2. Testing digital signatures using RSA keys on HSM:\n";
-    std::cerr << "Generating ECC keys on HSM...";
+    std::cout << "2. Testing digital signatures using RSA keys on HSM:" << std::endl;
+    std::cout << "Generating ECC keys on HSM...";
     auto rsaPrivKey =
             AsymmetricPrivateKey::generateKeyOnHSM(hsmEngine, rsaSpec, keyLabelRSA, keyIDRSA);
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
 
-    std::cerr << "Explicitly loading a public key from HSM and trying to verify a signature...";
+    std::cout << "Explicitly loading a public key from HSM and trying to verify a signature...";
     auto pubKeyRsa = AsymmetricPublicKey::readPublicKeyFromHSM(hsmEngine, keyLabelRSA, keyIDRSA);
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
 
     /**
      * Do signing/verification
      */
-    std::cerr << "Signing a message using an RSA private key generated on HSM...";
+    std::cout << "Signing a message using an RSA private key generated on HSM...";
     auto RSAsignature = rsaSign(rsaPrivKey, rsaSignatureDigestType, message);
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
     // We can use here the private key, as it also contains the public key.
-    std::cerr << "Verifying the message with the corresponding public key...";
+    std::cout << "Verifying the message with the corresponding public key...";
     rsaVerify(rsaPrivKey, rsaSignatureDigestType, RSAsignature, message);
-    std::cerr << "Success\n\n";
+    std::cout << "Success\n" << std::endl;
 
     /************** ECIES scheme **************/
-    std::cerr << "3. Testing ECIES scheme using ECC keys on HSM:\n";
-    std::cerr << "Encrypting the message...";
+    std::cout << "3. Testing ECIES scheme using ECC keys on HSM:" << std::endl;
+    std::cout << "Encrypting the message...";
     auto eciesData = encryptData(message, pubKeyEcc);
-    std::cerr << "Success\n";
+    std::cout << "Success" << std::endl;
 
-    std::cerr << "Decrypting the message...";
+    std::cout << "Decrypting the message...";
     decryptData(eciesData, eccPrivKey);
-    std::cerr << "Success\n\n";
+    std::cout << "Success\n" << std::endl;
 
     return 0;
 }

--- a/tests/integration/hsm-integration-test.cpp
+++ b/tests/integration/hsm-integration-test.cpp
@@ -319,8 +319,8 @@ int main(void)
         std::cout << "Success" << std::endl;
 
         std::cout << "Load them both and test that different keys have been loaded...";
-        if (AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmEngine, emptyLabel, keyId_1) ==
-            AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmEngine, emptyLabel, keyId_2)) {
+        if (AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmEngine, keyId_1) ==
+            AsymmetricPrivateKey::readPrivateKeyFromHSM(hsmEngine, keyId_2)) {
             std::cout << "Generated keys with different IDs and empty labels should not be the same"
                       << std::endl;
             exit(1);

--- a/tests/unit/hsm_mock.h
+++ b/tests/unit/hsm_mock.h
@@ -32,9 +32,12 @@ namespace mococrw
 class HSMMock final : public HSM
 {
 public:
+    MOCK_CONST_METHOD1(loadPublicKey, openssl::SSL_EVP_PKEY_Ptr(const std::vector<uint8_t> &keyID));
     MOCK_CONST_METHOD2(loadPublicKey,
                        openssl::SSL_EVP_PKEY_Ptr(const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID));
+    MOCK_CONST_METHOD1(loadPrivateKey,
+                       openssl::SSL_EVP_PKEY_Ptr(const std::vector<uint8_t> &keyID));
     MOCK_CONST_METHOD2(loadPrivateKey,
                        openssl::SSL_EVP_PKEY_Ptr(const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID));

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -33,6 +33,7 @@ using ::testing::_;
 using ::testing::Mock;
 using ::testing::Return;
 using ::testing::StrEq;
+using ::testing::Throw;
 
 class HSMTest : public ::testing::Test
 {
@@ -124,18 +125,35 @@ TEST_F(HSMTest, testHSMKeygen)
     auto pkey = ::testutils::somePkeyPtr();
     auto hsm = initialiseEngine();
     std::string keyLabel{"key-label"};
-    std::vector<uint8_t> keyId{};
+    std::vector<uint8_t> keyId{0x12};
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_load_private_key(
+                        engine, StrEq("pkcs11:token=token-label;id=%12"), nullptr, nullptr))
+            .WillOnce(Return(nullptr));
+    ON_CALL(_mock(), SSL_ERR_lib_error_string(_)).WillByDefault(Return("pkcs11 engine"));
+    ON_CALL(_mock(), SSL_ERR_reason_error_string(_)).WillByDefault(Return("object not found"));
     EXPECT_CALL(_mock(), SSL_EC_curve_nid2nist(curve)).WillOnce(Return("P-256"));
     EXPECT_CALL(_mock(),
                 SSL_ENGINE_ctrl_cmd(engine, StrEq("KEYGEN"), 0 /*non-optional*/, _, nullptr, 1))
             .WillOnce(Return(1));
-    EXPECT_CALL(_mock(),
-                SSL_ENGINE_load_private_key(engine,
-                                            StrEq("pkcs11:token=token-label;object=key-label;id="),
-                                            nullptr,
-                                            nullptr))
+    EXPECT_CALL(
+            _mock(),
+            SSL_ENGINE_load_private_key(engine,
+                                        StrEq("pkcs11:token=token-label;id=%12;object=key-label"),
+                                        nullptr,
+                                        nullptr))
             .WillOnce(Return(pkey));
     EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHSM(*hsm, eccSpec, keyLabel, keyId));
+}
+
+TEST_F(HSMTest, testHSMTryLoadKeyWithEmptyId)
+{
+    auto hsm = initialiseEngine();
+    const std::string keyLabel{"key-label"};
+    const std::vector<uint8_t> keyId{};
+
+    EXPECT_THROW(AsymmetricPublicKey::readPublicKeyFromHSM(*hsm, keyLabel, keyId),
+                 MoCOCrWException);
 }
 
 TEST_F(HSMTest, testHSMLoadUnknownPublicKey)
@@ -143,12 +161,13 @@ TEST_F(HSMTest, testHSMLoadUnknownPublicKey)
     auto engine = ::testutils::someEnginePtr();
     auto hsm = initialiseEngine();
     const std::string keyLabel{"key-label"};
-    const std::vector<uint8_t> keyId{};
-    EXPECT_CALL(_mock(),
-                SSL_ENGINE_load_public_key(engine,
-                                           StrEq("pkcs11:token=token-label;object=key-label;id="),
-                                           nullptr,
-                                           nullptr))
+    const std::vector<uint8_t> keyId{0x12};
+    EXPECT_CALL(
+            _mock(),
+            SSL_ENGINE_load_public_key(engine,
+                                       StrEq("pkcs11:token=token-label;id=%12;object=key-label"),
+                                       nullptr,
+                                       nullptr))
             .WillOnce(Return(nullptr));
 
     ON_CALL(_mock(), SSL_ERR_lib_error_string(_)).WillByDefault(Return("pkcs11 engine"));
@@ -163,12 +182,13 @@ TEST_F(HSMTest, testHSMLoadUnknownPrivateKey)
     auto engine = ::testutils::someEnginePtr();
     auto hsm = initialiseEngine();
     const std::string keyLabel{"key-label"};
-    const std::vector<uint8_t> keyId{};
-    EXPECT_CALL(_mock(),
-                SSL_ENGINE_load_private_key(engine,
-                                            StrEq("pkcs11:token=token-label;object=key-label;id="),
-                                            nullptr,
-                                            nullptr))
+    const std::vector<uint8_t> keyId{0x12};
+    EXPECT_CALL(
+            _mock(),
+            SSL_ENGINE_load_private_key(engine,
+                                        StrEq("pkcs11:token=token-label;id=%12;object=key-label"),
+                                        nullptr,
+                                        nullptr))
             .WillOnce(Return(nullptr));
 
     ON_CALL(_mock(), SSL_ERR_lib_error_string(_)).WillByDefault(Return("pkcs11 engine"));

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -129,20 +129,14 @@ TEST_F(HSMTest, testHSMKeygen)
     EXPECT_CALL(_mock(),
                 SSL_ENGINE_load_private_key(
                         engine, StrEq("pkcs11:token=token-label;id=%12"), nullptr, nullptr))
-            .WillOnce(Return(nullptr));
+            .WillOnce(Return(nullptr))
+            .WillOnce(Return(pkey));
     ON_CALL(_mock(), SSL_ERR_lib_error_string(_)).WillByDefault(Return("pkcs11 engine"));
     ON_CALL(_mock(), SSL_ERR_reason_error_string(_)).WillByDefault(Return("object not found"));
     EXPECT_CALL(_mock(), SSL_EC_curve_nid2nist(curve)).WillOnce(Return("P-256"));
     EXPECT_CALL(_mock(),
                 SSL_ENGINE_ctrl_cmd(engine, StrEq("KEYGEN"), 0 /*non-optional*/, _, nullptr, 1))
             .WillOnce(Return(1));
-    EXPECT_CALL(
-            _mock(),
-            SSL_ENGINE_load_private_key(engine,
-                                        StrEq("pkcs11:token=token-label;id=%12;object=key-label"),
-                                        nullptr,
-                                        nullptr))
-            .WillOnce(Return(pkey));
     EXPECT_NO_THROW(AsymmetricKeypair::generateKeyOnHSM(*hsm, eccSpec, keyLabel, keyId));
 }
 


### PR DESCRIPTION
PKCS#11 standard does not enforce unique ids but we want to because
having duplicate ids causes problems on all sides. Before key
generation, key is loaded to check if it already exists. Loading a key
creates a RO session on the token. This represented a problem for key
generation because RW session is needed and libp11 reused previously
created RO session. Key generation patch was slightly modified so that
we always open a RW session before generating a key.