### PR TITLE
hsm: specify pin before managing keys

### DIFF
--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -102,7 +102,8 @@ public:
     /**
      * @brief Constructor for an object that can manage keys on HSM using OpenSSL Engine
      * @note Each HsmEngine object is associated with a specific token and a pin to login to that
-     * token
+     * token.
+     * @warning Using the HsmEngine object is not thread safe.
      * @warning PIN value is not safely cleaned from memory. Make sure you clean it. Check
      * out utility::stringCleanse()
      * @param id unique identifier for an OpenSSL engine
@@ -125,6 +126,8 @@ protected:
     const std::string _modulePath;
     /** Token label used to uniquely identify a token on which objects reside */
     const std::string _tokenLabel;
+    /** Token PIN */
+    std::string _pin;
 
     openssl::SSL_EVP_PKEY_Ptr loadPublicKey(const std::string &keyLabel,
                                             const std::vector<uint8_t> &keyID) const override;

--- a/tests/integration/hsm-integration-test.cpp
+++ b/tests/integration/hsm-integration-test.cpp
@@ -273,6 +273,8 @@ int main(void)
     // Don't hardcode the pin in your application, this is just for demonstration purposes
     std::string pin("1234");
     HsmEngine hsmEngine(id, modulePath, tokenLabel, pin);
+    // Test that this doesn't invalidate Pin from hsmEngine
+    HsmEngine hsmEngine2(id, modulePath, tokenLabel, "0000000");
     utility::stringCleanse(pin);
     std::vector<uint8_t> message = utility::fromHex("deadbeef");
     // Default specs are used in numerous places

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -51,6 +51,7 @@ protected:
         return openssl::OpenSSLLibMockManager::getMockInterface();
     }
 
+    std::string pin = "1234";
     std::unique_ptr<HsmEngine> initialiseEngine();
 };
 
@@ -95,7 +96,6 @@ std::unique_ptr<HsmEngine> HSMTest::initialiseEngine()
     std::string engineID("engine_id");
     std::string modulePath("/test_path.so");
     std::string tokenLabel("token-label");
-    std::string pin("1234");
     auto engine = ::testutils::someEnginePtr();
 
     EXPECT_CALL(_mock(), SSL_ENGINE_by_id(StrEq(engineID.c_str()))).WillOnce(Return(engine));
@@ -104,11 +104,6 @@ std::unique_ptr<HsmEngine> HSMTest::initialiseEngine()
             _mock(),
             SSL_ENGINE_ctrl_cmd_string(
                     engine, StrEq("MODULE_PATH"), StrEq(modulePath.c_str()), 0 /*non-optional*/))
-            .WillOnce(Return(1));
-
-    EXPECT_CALL(_mock(),
-                SSL_ENGINE_ctrl_cmd_string(
-                        engine, StrEq("PIN"), StrEq(pin.c_str()), 0 /*non-optional*/))
             .WillOnce(Return(1));
 
     EXPECT_CALL(_mock(), SSL_ENGINE_init(engine)).WillOnce(Return(1));
@@ -126,6 +121,12 @@ TEST_F(HSMTest, testHSMKeygen)
     auto hsm = initialiseEngine();
     std::string keyLabel{"key-label"};
     std::vector<uint8_t> keyId{0x12};
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_ctrl_cmd_string(
+                        engine, StrEq("PIN"), StrEq(pin.c_str()), 0 /*non-optional*/))
+            .WillOnce(Return(1))
+            .WillOnce(Return(1))
+            .WillOnce(Return(1));
     EXPECT_CALL(_mock(),
                 SSL_ENGINE_load_private_key(
                         engine, StrEq("pkcs11:token=token-label;id=%12"), nullptr, nullptr))
@@ -156,6 +157,10 @@ TEST_F(HSMTest, testHSMLoadUnknownPublicKey)
     auto hsm = initialiseEngine();
     const std::string keyLabel{"key-label"};
     const std::vector<uint8_t> keyId{0x12};
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_ctrl_cmd_string(
+                        engine, StrEq("PIN"), StrEq(pin.c_str()), 0 /*non-optional*/))
+            .WillOnce(Return(1));
     EXPECT_CALL(
             _mock(),
             SSL_ENGINE_load_public_key(engine,
@@ -177,6 +182,10 @@ TEST_F(HSMTest, testHSMLoadUnknownPrivateKey)
     auto hsm = initialiseEngine();
     const std::string keyLabel{"key-label"};
     const std::vector<uint8_t> keyId{0x12};
+    EXPECT_CALL(_mock(),
+                SSL_ENGINE_ctrl_cmd_string(
+                        engine, StrEq("PIN"), StrEq(pin.c_str()), 0 /*non-optional*/))
+            .WillOnce(Return(1));
     EXPECT_CALL(
             _mock(),
             SSL_ENGINE_load_private_key(engine,


### PR DESCRIPTION
Specifying multiple HsmEngine objects in a row overwrites
set pin that is stored in libp11 for the previous HsmEngine objects.
This means that when loading or generating keys, login to the token
fails for all the HsmEngine objects except for the last one defined.
To combat that, pin is stored in HsmEngine object and set in libp11
right before loading/generating keys.