### PR TITLE
Properly escape PKCS#11 URIs

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -34,7 +34,6 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     if(MOCOCRW_HSM_ENABLED)
         add_executable(hsmtest test_hsm.cpp
                             "${SRC_DIR}/key.cpp"
-                            "${SRC_DIR}/hsm.cpp"
                             "${SRC_DIR}/util.cpp"
                              ${MOCK_SOURCES})
     endif()


### PR DESCRIPTION
Our code transforms the token name, key id and key label into a PKCS#11 URI that is passed into libp11. So far we only escaped the key id as it naturally consists of non-printable characters. However, the URIs have some reserved characters that have a special meaning in the URI. As we currently just forward the token name and key label to the URI this could lead to accidental or malicious URI misinterpretation/injection.

In order to mitigate this problem, this patch provides pct encoding for the special characters. The list of special characters is taken from RFC 7512 (PKCS#11 URI scheme).