### PR TITLE
aes: fix iv length resetting for aes-gcm encryption

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -11,9 +11,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Load Docker cache"
-      uses: satackey/action-docker-layer-caching@v0.0.11
-
     - name: "Build Docker image"
       shell: bash
       run: |

--- a/examples/aes-example.cpp
+++ b/examples/aes-example.cpp
@@ -23,6 +23,7 @@
 using namespace mococrw;
 
 static const std::vector<uint8_t> plaintext = utility::fromHex("deadbeef");
+static const std::vector<uint8_t> expectedCiphertext = utility::fromHex("c0bdb9ef");
 static const SymmetricCipherMode aeOperationMode = SymmetricCipherMode::GCM;
 static const SymmetricCipherMode plainOperationMode = SymmetricCipherMode::CBC;
 static const SymmetricCipherPadding padding = SymmetricCipherPadding::PKCS;
@@ -195,6 +196,10 @@ int main(void)
 {
     /* Authenticated encryption and decryption */
     auto aeResult = aesAuthenticatedEncryption();
+    if (expectedCiphertext != aeResult.ciphertext) {
+        std::cerr << "Something is wrong with AEAD encryption." << std::endl;
+        return -1;
+    }
     auto decryptionResult = aesAuthenticatedDecryption(aeResult);
     if (plaintext != decryptionResult) {
         std::cerr << "Failure decrypting AEAD data." << std::endl;


### PR DESCRIPTION
For AES GCM, iv length is set in EVP_CIPHER_CTX data structure. This was mistakenly reset to default length of 12 with the calls to EVP_CIPHER_CTX_reset and EVP_CipherInit_ex. This leads to wrong ciphertext because only lower 12 bytes of the IV are used.