### PR TITLE
hsm.h: Change key attrs names to lower case

### DIFF
--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -215,8 +215,8 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
     pkcs11RSASpec.bits = spec.numberOfBits();
 
     PKCS11_params _params;
-    _params.extractable = static_cast<unsigned char>(params.CKA_EXTRACTABLE);
-    _params.sensitive = static_cast<unsigned char>(params.CKA_SENSITIVE);
+    _params.extractable = static_cast<unsigned char>(params.cka_extractable);
+    _params.sensitive = static_cast<unsigned char>(params.cka_sensitive);
 
     PKCS11_KGEN_ATTRS pkcs11RSAKeygen;
     pkcs11RSAKeygen.type = EVP_PKEY_RSA;
@@ -261,8 +261,8 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
     pkcs11ECCSpec.curve = curve.c_str();
 
     PKCS11_params _params;
-    _params.extractable = static_cast<unsigned char>(params.CKA_EXTRACTABLE);
-    _params.sensitive = static_cast<unsigned char>(params.CKA_SENSITIVE);
+    _params.extractable = static_cast<unsigned char>(params.cka_extractable);
+    _params.sensitive = static_cast<unsigned char>(params.cka_sensitive);
 
     PKCS11_KGEN_ATTRS pkcs11ECCKeygen;
     pkcs11ECCKeygen.type = EVP_PKEY_EC;

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -35,8 +35,8 @@ struct HsmKeyParams
      * Check https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html
      * for more details.
      */
-    bool CKA_EXTRACTABLE = false;
-    bool CKA_SENSITIVE = true;
+    bool cka_extractable = false;
+    bool cka_sensitive = true;
 };
 
 /**

--- a/tests/integration/hsm-integration-test.cpp
+++ b/tests/integration/hsm-integration-test.cpp
@@ -452,8 +452,8 @@ int main(void)
         /**
          * Generate extractable and non-extractable keys for ECC and RSA
          */
-        HsmKeyParams hsmKeyParamsExtract = {/*.CKA_EXTRACTABLE =*/true,
-                                            /* .CKA_SENSITIVE = */ false};
+        HsmKeyParams hsmKeyParamsExtract = {/*.cka_extractable =*/true,
+                                            /* .cka_sensitive = */ false};
         HsmKeyParams hsmKeyParamsDefault;
 
         /* We need a new token otherwise the keys generated before litter the slot */


### PR DESCRIPTION
If pkcs11.h is included together with hsm.h the definition of CKA_EXTRACTABLE and CKA_SENSITIVE in the HsmKeyParams struct and in pkcs11.h (

* #define CKA_EXTRACTABLE (0x162UL)
* #define CKA_SENSITIVE (0x103UL)

) at the same time leads to compile failures.

Fix this by changing to lowercase.