### PR TITLE
Use Builder Pattern for HsmKeyParams

### DIFF
--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -216,8 +216,8 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
     pkcs11RSASpec.bits = spec.numberOfBits();
 
     PKCS11_params _params;
-    _params.extractable = static_cast<unsigned char>(params.cka_extractable);
-    _params.sensitive = static_cast<unsigned char>(params.cka_sensitive);
+    _params.extractable = static_cast<unsigned char>(params.isExtractable());
+    _params.sensitive = static_cast<unsigned char>(params.isSensitive());
 
     PKCS11_KGEN_ATTRS pkcs11RSAKeygen;
     pkcs11RSAKeygen.type = EVP_PKEY_RSA;
@@ -263,8 +263,8 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
     pkcs11ECCSpec.curve = curve.c_str();
 
     PKCS11_params _params;
-    _params.extractable = static_cast<unsigned char>(params.cka_extractable);
-    _params.sensitive = static_cast<unsigned char>(params.cka_sensitive);
+    _params.extractable = static_cast<unsigned char>(params.isExtractable());
+    _params.sensitive = static_cast<unsigned char>(params.isSensitive());
 
     PKCS11_KGEN_ATTRS pkcs11ECCKeygen;
     pkcs11ECCKeygen.type = EVP_PKEY_EC;

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -188,7 +188,8 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
                                                  const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID)
 {
-    HsmKeyParams hsmKeyParams;
+    HsmKeyParams hsmKeyParams =
+            HsmKeyParams::Builder().setCkaExtractable(false).setCkaSensitive(true).build();
     return generateKey(spec, keyLabel, keyID, hsmKeyParams);
 }
 
@@ -233,7 +234,8 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
                                                  const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID)
 {
-    HsmKeyParams hsmKeyParams;
+    HsmKeyParams hsmKeyParams =
+            HsmKeyParams::Builder().setCkaExtractable(false).setCkaSensitive(true).build();
     return generateKey(spec, keyLabel, keyID, hsmKeyParams);
 }
 

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -189,7 +189,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
                                                  const std::vector<uint8_t> &keyID)
 {
     HsmKeyParams hsmKeyParams =
-            HsmKeyParams::Builder().setCkaExtractable(false).setCkaSensitive(true).build();
+            HsmKeyParams::Builder{}.setExtractable(false).build();
     return generateKey(spec, keyLabel, keyID, hsmKeyParams);
 }
 
@@ -217,7 +217,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
 
     PKCS11_params _params;
     _params.extractable = static_cast<unsigned char>(params.isExtractable());
-    _params.sensitive = static_cast<unsigned char>(params.isSensitive());
+    _params.sensitive = static_cast<unsigned char>(!params.isExtractable());
 
     PKCS11_KGEN_ATTRS pkcs11RSAKeygen;
     pkcs11RSAKeygen.type = EVP_PKEY_RSA;
@@ -235,7 +235,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
                                                  const std::vector<uint8_t> &keyID)
 {
     HsmKeyParams hsmKeyParams =
-            HsmKeyParams::Builder().setCkaExtractable(false).setCkaSensitive(true).build();
+            HsmKeyParams::Builder{}.setExtractable(false).build();
     return generateKey(spec, keyLabel, keyID, hsmKeyParams);
 }
 
@@ -263,8 +263,9 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
     pkcs11ECCSpec.curve = curve.c_str();
 
     PKCS11_params _params;
+    // If the key is extractable it shouldn't be sensitive and vice versa
     _params.extractable = static_cast<unsigned char>(params.isExtractable());
-    _params.sensitive = static_cast<unsigned char>(params.isSensitive());
+    _params.sensitive = static_cast<unsigned char>(!params.isExtractable());
 
     PKCS11_KGEN_ATTRS pkcs11ECCKeygen;
     pkcs11ECCKeygen.type = EVP_PKEY_EC;

--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -188,8 +188,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
                                                  const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID)
 {
-    HsmKeyParams hsmKeyParams =
-            HsmKeyParams::Builder{}.setExtractable(false).build();
+    HsmKeyParams hsmKeyParams = HsmKeyParams::Builder{}.setExtractable(false).build();
     return generateKey(spec, keyLabel, keyID, hsmKeyParams);
 }
 
@@ -234,8 +233,7 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
                                                  const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID)
 {
-    HsmKeyParams hsmKeyParams =
-            HsmKeyParams::Builder{}.setExtractable(false).build();
+    HsmKeyParams hsmKeyParams = HsmKeyParams::Builder{}.setExtractable(false).build();
     return generateKey(spec, keyLabel, keyID, hsmKeyParams);
 }
 

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -43,7 +43,7 @@ private:
      * Check https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html
      * for more details.
      */
-    HsmKeyParams() : cka_extractable(false) {}
+    HsmKeyParams() : extractable(false) {}
 };
 
 class HsmKeyParams::Builder

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -34,13 +34,9 @@ class HsmKeyParams
 public:
     class Builder;
 
-    bool isExtractable() const {
-        return cka_extractable;
-    }
+    bool isExtractable() const { return cka_extractable; }
 
-    bool isSensitive() const {
-        return cka_sensitive;
-    }
+    bool isSensitive() const { return cka_sensitive; }
 
 private:
     bool cka_extractable;
@@ -69,9 +65,7 @@ public:
         return *this;
     }
 
-    HsmKeyParams build() {
-        return params_;
-    }
+    HsmKeyParams build() { return params_; }
 
 private:
     HsmKeyParams params_;

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -34,11 +34,11 @@ class HsmKeyParams
 public:
     class Builder;
 
-    bool isExtractable() {
+    bool isExtractable() const {
         return cka_extractable;
     }
 
-    bool isSensitive() {
+    bool isSensitive() const {
         return cka_sensitive;
     }
 

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -34,7 +34,7 @@ class HsmKeyParams
 public:
     class Builder;
 
-    bool isExtractable() const { return cka_extractable; }
+    bool isExtractable() const { return extractable; }
 
 private:
     bool extractable;

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -34,6 +34,14 @@ class HsmKeyParams
 public:
     class Builder;
 
+    bool isExtractable() {
+        return cka_extractable;
+    }
+
+    bool isSensitive() {
+        return cka_sensitive;
+    }
+
 private:
     bool cka_extractable;
     bool cka_sensitive;

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -26,17 +26,47 @@ class ECCSpec;
 class RSASpec;
 
 /**
- * This struct currently contains PKCS#11 attributes which are changeable on key creation.
+ * This class currently contains PKCS#11 attributes which are changeable on key creation.
  * In the future also parameters for other keystorage interfaces can be added.
  */
-struct HsmKeyParams
+class HsmKeyParams
 {
+public:
+    class Builder;
+
+private:
+    bool cka_extractable;
+    bool cka_sensitive;
+
     /* Default is that the key cannot be extracted and is marked as sensitive.
      * Check https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html
      * for more details.
      */
-    bool cka_extractable = false;
-    bool cka_sensitive = true;
+    HsmKeyParams() : cka_extractable(false), cka_sensitive(true) {}
+};
+
+class HsmKeyParams::Builder
+{
+public:
+    Builder() {}
+    Builder &setCkaExtractable(bool extractable)
+    {
+        params_.cka_extractable = extractable;
+        return *this;
+    }
+
+    Builder &setCkaSensitive(bool sensitive)
+    {
+        params_.cka_sensitive = sensitive;
+        return *this;
+    }
+
+    HsmKeyParams build() {
+        return params_;
+    }
+
+private:
+    HsmKeyParams params_;
 };
 
 /**

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -36,32 +36,23 @@ public:
 
     bool isExtractable() const { return cka_extractable; }
 
-    bool isSensitive() const { return cka_sensitive; }
-
 private:
-    bool cka_extractable;
-    bool cka_sensitive;
+    bool extractable;
 
     /* Default is that the key cannot be extracted and is marked as sensitive.
      * Check https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html
      * for more details.
      */
-    HsmKeyParams() : cka_extractable(false), cka_sensitive(true) {}
+    HsmKeyParams() : cka_extractable(false) {}
 };
 
 class HsmKeyParams::Builder
 {
 public:
     Builder() {}
-    Builder &setCkaExtractable(bool extractable)
+    Builder &setExtractable(bool extractable)
     {
-        params_.cka_extractable = extractable;
-        return *this;
-    }
-
-    Builder &setCkaSensitive(bool sensitive)
-    {
-        params_.cka_sensitive = sensitive;
+        params_.extractable = extractable;
         return *this;
     }
 

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -34,16 +34,16 @@ class HsmKeyParams
 public:
     class Builder;
 
-    bool isExtractable() const { return extractable; }
+    bool isExtractable() const { return _extractable; }
 
 private:
-    bool extractable;
+    bool _extractable;
 
     /* Default is that the key cannot be extracted and is marked as sensitive.
      * Check https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html
      * for more details.
      */
-    HsmKeyParams() : extractable(false) {}
+    HsmKeyParams() : _extractable(false) {}
 };
 
 class HsmKeyParams::Builder
@@ -52,7 +52,7 @@ public:
     Builder() {}
     Builder &setExtractable(bool extractable)
     {
-        params_.extractable = extractable;
+        params_._extractable = extractable;
         return *this;
     }
 

--- a/tests/integration/hsm-integration-test.cpp
+++ b/tests/integration/hsm-integration-test.cpp
@@ -453,9 +453,9 @@ int main(void)
          * Generate extractable and non-extractable keys for ECC and RSA
          */
         HsmKeyParams hsmKeyParamsExtract =
-                HsmKeyParams::Builder().setCkaExtractable(true).setCkaSensitive(false).build();
+                HsmKeyParams::Builder{}.setExtractable(true).build();
 
-        HsmKeyParams hsmKeyParamsDefault = HsmKeyParams::Builder().build();
+        HsmKeyParams hsmKeyParamsDefault = HsmKeyParams::Builder{}.build();
 
         /* We need a new token otherwise the keys generated before litter the slot */
 

--- a/tests/integration/hsm-integration-test.cpp
+++ b/tests/integration/hsm-integration-test.cpp
@@ -452,9 +452,11 @@ int main(void)
         /**
          * Generate extractable and non-extractable keys for ECC and RSA
          */
-        HsmKeyParams hsmKeyParamsExtract = {/*.cka_extractable =*/true,
-                                            /* .cka_sensitive = */ false};
-        HsmKeyParams hsmKeyParamsDefault;
+        HsmKeyParams hsmKeyParamsExtract =
+                HsmKeyParams::Builder().setCkaExtractable(true).setCkaSensitive(false).build();
+
+        HsmKeyParams hsmKeyParamsDefault =
+                HsmKeyParams::Builder().build();
 
         /* We need a new token otherwise the keys generated before litter the slot */
 

--- a/tests/integration/hsm-integration-test.cpp
+++ b/tests/integration/hsm-integration-test.cpp
@@ -455,8 +455,7 @@ int main(void)
         HsmKeyParams hsmKeyParamsExtract =
                 HsmKeyParams::Builder().setCkaExtractable(true).setCkaSensitive(false).build();
 
-        HsmKeyParams hsmKeyParamsDefault =
-                HsmKeyParams::Builder().build();
+        HsmKeyParams hsmKeyParamsDefault = HsmKeyParams::Builder().build();
 
         /* We need a new token otherwise the keys generated before litter the slot */
 

--- a/tests/integration/hsm-integration-test.cpp
+++ b/tests/integration/hsm-integration-test.cpp
@@ -452,8 +452,7 @@ int main(void)
         /**
          * Generate extractable and non-extractable keys for ECC and RSA
          */
-        HsmKeyParams hsmKeyParamsExtract =
-                HsmKeyParams::Builder{}.setExtractable(true).build();
+        HsmKeyParams hsmKeyParamsExtract = HsmKeyParams::Builder{}.setExtractable(true).build();
 
         HsmKeyParams hsmKeyParamsDefault = HsmKeyParams::Builder{}.build();
 

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -153,7 +153,8 @@ TEST_F(HSMTest, testHSMKeygenWithParams)
     auto hsm = initialiseEngine();
     std::string keyLabel{"key-label"};
     std::vector<uint8_t> keyId{0x12};
-    HsmKeyParams params{true, false};
+    HsmKeyParams params =
+            HsmKeyParams::Builder().setCkaExtractable(true).setCkaSensitive(false).build();
     EXPECT_CALL(_mock(),
                 SSL_ENGINE_ctrl_cmd_string(
                         engine, StrEq("PIN"), StrEq(pin.c_str()), 0 /*non-optional*/))

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -153,8 +153,7 @@ TEST_F(HSMTest, testHSMKeygenWithParams)
     auto hsm = initialiseEngine();
     std::string keyLabel{"key-label"};
     std::vector<uint8_t> keyId{0x12};
-    HsmKeyParams params =
-            HsmKeyParams::Builder{}.setExtractable(true).build();
+    HsmKeyParams params = HsmKeyParams::Builder{}.setExtractable(true).build();
     EXPECT_CALL(_mock(),
                 SSL_ENGINE_ctrl_cmd_string(
                         engine, StrEq("PIN"), StrEq(pin.c_str()), 0 /*non-optional*/))

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -154,7 +154,7 @@ TEST_F(HSMTest, testHSMKeygenWithParams)
     std::string keyLabel{"key-label"};
     std::vector<uint8_t> keyId{0x12};
     HsmKeyParams params =
-            HsmKeyParams::Builder().setCkaExtractable(true).setCkaSensitive(false).build();
+            HsmKeyParams::Builder{}.setExtractable(true).build();
     EXPECT_CALL(_mock(),
                 SSL_ENGINE_ctrl_cmd_string(
                         engine, StrEq("PIN"), StrEq(pin.c_str()), 0 /*non-optional*/))


### PR DESCRIPTION
Adapt the HsmKeyParams to use a Builder Pattern instead of a struct