### PR TITLE
Reintroduce deprecated cka api for compatibility

### DIFF
--- a/src/hsm.cpp
+++ b/src/hsm.cpp
@@ -188,14 +188,14 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
                                                  const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID)
 {
-    HsmKeyParams hsmKeyParams = HsmKeyParams::Builder{}.setExtractable(false).build();
+    HsmKeyParameters hsmKeyParams = HsmKeyParameters::Builder{}.setExtractable(false).build();
     return generateKey(spec, keyLabel, keyID, hsmKeyParams);
 }
 
 openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const RSASpec &spec,
                                                  const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID,
-                                                 const HsmKeyParams &params)
+                                                 const HsmKeyParameters &params)
 {
     try {
         // We need to make sure that we don't have 2 keys with the same ID.
@@ -233,14 +233,14 @@ openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
                                                  const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID)
 {
-    HsmKeyParams hsmKeyParams = HsmKeyParams::Builder{}.setExtractable(false).build();
+    HsmKeyParameters hsmKeyParams = HsmKeyParameters::Builder{}.setExtractable(false).build();
     return generateKey(spec, keyLabel, keyID, hsmKeyParams);
 }
 
 openssl::SSL_EVP_PKEY_Ptr HsmEngine::generateKey(const ECCSpec &spec,
                                                  const std::string &keyLabel,
                                                  const std::vector<uint8_t> &keyID,
-                                                 const HsmKeyParams &params)
+                                                 const HsmKeyParameters &params)
 {
     try {
         // We need to make sure that we don't have 2 keys with the same ID.

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -246,6 +246,27 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
 }
 
 AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
+                                                      const RSASpec &spec,
+                                                      const std::string &keyLabel,
+                                                      const std::vector<uint8_t> &keyID,
+                                                      const HsmKeyParams &params)
+{
+    // libp11 uses 128 byte buffer
+    if (keyID.size() >= 64) {
+        throw MoCOCrWException("Invalid keyID - key longer than 63 bytes");
+    }
+    try {
+        HsmKeyParameters parameters = HsmKeyParameters::Builder{}.setExtractable(params.cka_extractable).build();
+        return AsymmetricKeypair{hsm.generateKey(spec, keyLabel, keyID, parameters)};
+    } catch (const openssl::OpenSSLException &e) {
+        throw MoCOCrWException(
+                // wrong token-label? using unsupported ECC curve? HSM module implementation?
+                std::string("Key generation failed for unknown reason. OpenSSL error: ") +
+                e.what());
+    }
+}
+
+AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
                                                       const ECCSpec &spec,
                                                       const std::string &keyLabel,
                                                       const std::vector<uint8_t> &keyID)
@@ -283,6 +304,28 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
                 e.what());
     }
 }
+
+AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
+                                                      const ECCSpec &spec,
+                                                      const std::string &keyLabel,
+                                                      const std::vector<uint8_t> &keyID,
+                                                      const HsmKeyParams &params)
+{
+    // libp11 uses 128 byte buffer
+    if (keyID.size() >= 64) {
+        throw MoCOCrWException("Invalid keyID - key longer than 63 bytes");
+    }
+    try {
+        HsmKeyParameters parameters = HsmKeyParameters::Builder{}.setExtractable(params.cka_extractable).build();
+        return AsymmetricKeypair{hsm.generateKey(spec, keyLabel, keyID, parameters)};
+    } catch (const openssl::OpenSSLException &e) {
+        throw MoCOCrWException(
+                // wrong token-label? using unsupported ECC curve? HSM module implementation?
+                std::string("Key generation failed for unknown reason. OpenSSL error: ") +
+                e.what());
+    }
+}
+
 #endif
 
 AsymmetricKey RSASpec::generate() const

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -211,7 +211,6 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
                                                       const std::string &keyLabel,
                                                       const std::vector<uint8_t> &keyID)
 {
-    // libp11 uses 128 byte buffer
     if (keyID.size() >= 64) {
         throw MoCOCrWException("Invalid keyID - key longer than 63 bytes");
     }
@@ -231,7 +230,6 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
                                                       const std::vector<uint8_t> &keyID,
                                                       const HsmKeyParameters &params)
 {
-    // libp11 uses 128 byte buffer
     if (keyID.size() >= 64) {
         throw MoCOCrWException("Invalid keyID - key longer than 63 bytes");
     }
@@ -251,7 +249,6 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
                                                       const std::vector<uint8_t> &keyID,
                                                       const HsmKeyParams &params)
 {
-    // libp11 uses 128 byte buffer
     if (keyID.size() >= 64) {
         throw MoCOCrWException("Invalid keyID - key longer than 63 bytes");
     }
@@ -271,7 +268,6 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
                                                       const std::string &keyLabel,
                                                       const std::vector<uint8_t> &keyID)
 {
-    // libp11 uses 128 byte buffer
     if (keyID.size() >= 64) {
         throw MoCOCrWException("Invalid keyID - key longer than 63 bytes");
     }
@@ -291,7 +287,6 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
                                                       const std::vector<uint8_t> &keyID,
                                                       const HsmKeyParameters &params)
 {
-    // libp11 uses 128 byte buffer
     if (keyID.size() >= 64) {
         throw MoCOCrWException("Invalid keyID - key longer than 63 bytes");
     }
@@ -311,7 +306,6 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
                                                       const std::vector<uint8_t> &keyID,
                                                       const HsmKeyParams &params)
 {
-    // libp11 uses 128 byte buffer
     if (keyID.size() >= 64) {
         throw MoCOCrWException("Invalid keyID - key longer than 63 bytes");
     }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -229,7 +229,7 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
                                                       const RSASpec &spec,
                                                       const std::string &keyLabel,
                                                       const std::vector<uint8_t> &keyID,
-                                                      const HsmKeyParams &params)
+                                                      const HsmKeyParameters &params)
 {
     // libp11 uses 128 byte buffer
     if (keyID.size() >= 64) {
@@ -268,7 +268,7 @@ AsymmetricKeypair AsymmetricKeypair::generateKeyOnHSM(HSM &hsm,
                                                       const ECCSpec &spec,
                                                       const std::string &keyLabel,
                                                       const std::vector<uint8_t> &keyID,
-                                                      const HsmKeyParams &params)
+                                                      const HsmKeyParameters &params)
 {
     // libp11 uses 128 byte buffer
     if (keyID.size() >= 64) {

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -26,7 +26,12 @@ class ECCSpec;
 class RSASpec;
 
 
-
+// Needed for old deprecated API
+struct HsmKeyParams
+{
+    bool cka_extractable = false;
+    bool cka_sensitive = true;
+};
 
 /**
  * This class currently contains PKCS#11 attributes which are changeable on key creation.

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -25,6 +25,9 @@ namespace mococrw
 class ECCSpec;
 class RSASpec;
 
+
+
+
 /**
  * This class currently contains PKCS#11 attributes which are changeable on key creation.
  * In the future also parameters for other keystorage interfaces can be added.
@@ -218,12 +221,14 @@ protected:
     openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
                                           const std::string &keyLabel,
                                           const std::vector<uint8_t> &keyID,
-                                          const HsmKeyParams &params) override;
+                                          const HsmKeyParameters &params) override;
 
     openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
                                           const std::string &keyLabel,
                                           const std::vector<uint8_t> &keyID,
-                                          const HsmKeyParams &params) override;
+                                          const HsmKeyParameters &params) override;
+
+
 
 private:
     /**

--- a/src/mococrw/hsm.h
+++ b/src/mococrw/hsm.h
@@ -29,7 +29,7 @@ class RSASpec;
  * This class currently contains PKCS#11 attributes which are changeable on key creation.
  * In the future also parameters for other keystorage interfaces can be added.
  */
-class HsmKeyParams
+class HsmKeyParameters
 {
 public:
     class Builder;
@@ -43,10 +43,10 @@ private:
      * Check https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html
      * for more details.
      */
-    HsmKeyParams() : _extractable(false) {}
+    HsmKeyParameters() : _extractable(false) {}
 };
 
-class HsmKeyParams::Builder
+class HsmKeyParameters::Builder
 {
 public:
     Builder() {}
@@ -56,10 +56,10 @@ public:
         return *this;
     }
 
-    HsmKeyParams build() { return params_; }
+    HsmKeyParameters build() { return params_; }
 
 private:
-    HsmKeyParams params_;
+    HsmKeyParameters params_;
 };
 
 /**
@@ -143,7 +143,7 @@ protected:
     virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const RSASpec &spec,
                                                   const std::string &keyLabel,
                                                   const std::vector<uint8_t> &keyID,
-                                                  const HsmKeyParams &params) = 0;
+                                                  const HsmKeyParameters &params) = 0;
 
     /**
      * @brief Generate a ECC key pair on the HSM
@@ -158,7 +158,7 @@ protected:
     virtual openssl::SSL_EVP_PKEY_Ptr generateKey(const ECCSpec &spec,
                                                   const std::string &keyLabel,
                                                   const std::vector<uint8_t> &keyID,
-                                                  const HsmKeyParams &params) = 0;
+                                                  const HsmKeyParameters &params) = 0;
 };
 
 /**

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -341,7 +341,7 @@ public:
                                               const std::vector<uint8_t> &keyID,
                                               const HsmKeyParameters &params);
 
-    /** Deprecated func
+    /**
      * @brief Generates RSA keypair on HSM token according to the spec given.
      * @note PKCS#11 standard has no rule to avoid having keys with duplicate labels and/or ids.
      * Therefore care should be taken when generating keys with other tools on the same token.
@@ -356,6 +356,7 @@ public:
      * libp11 and HSM module implementation, we can't know exactly what went wrong. libp11 does log
      * some things to stderr, check if there's more context there
      */
+    [[deprecated]]
     static AsymmetricKeypair generateKeyOnHSM(HSM &hsm,
                                               const RSASpec &spec,
                                               const std::string &keyLabel,
@@ -402,7 +403,7 @@ public:
                                               const std::vector<uint8_t> &keyID,
                                               const HsmKeyParameters &params);
 
-    /** Deprecated func
+    /**
      * @brief Generates ECC keypair on HSM token according to the spec given.
      * @note PKCS#11 standard has no rule to avoid having keys with duplicate labels and/or ids.
      * Therefore care should be taken when generating keys with other tools on the same token.
@@ -417,6 +418,7 @@ public:
      * libp11 and HSM module implementation, we can't know exactly what went wrong. libp11 does log
      * some things to stderr, check if there's more context there
      */
+    [[deprecated]]
     static AsymmetricKeypair generateKeyOnHSM(HSM &hsm,
                                               const ECCSpec &spec,
                                               const std::string &keyLabel,

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -341,6 +341,27 @@ public:
                                               const std::vector<uint8_t> &keyID,
                                               const HsmKeyParameters &params);
 
+    /** Deprecated func
+     * @brief Generates RSA keypair on HSM token according to the spec given.
+     * @note PKCS#11 standard has no rule to avoid having keys with duplicate labels and/or ids.
+     * Therefore care should be taken when generating keys with other tools on the same token.
+     * @param hsm HSM engine handle
+     * @param spec @ref RSASpec
+     * @param keyLabel String based description of an object on the token. It
+     * can be used in combination with keyID to identify an object.
+     * @param keyID raw bytes based key identifer
+     * @param Struct to set key generation attributes
+     * @return AsymmetricKeypair @ref AsymmetricKeypair
+     * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
+     * libp11 and HSM module implementation, we can't know exactly what went wrong. libp11 does log
+     * some things to stderr, check if there's more context there
+     */
+    static AsymmetricKeypair generateKeyOnHSM(HSM &hsm,
+                                              const RSASpec &spec,
+                                              const std::string &keyLabel,
+                                              const std::vector<uint8_t> &keyID,
+                                              const HsmKeyParams &params);
+
     /**
      * @brief Generates ECC keypair on HSM token according to the spec given.
      * @note PKCS#11 standard has no rule to avoid having keys with duplicate labels and/or ids.
@@ -380,6 +401,27 @@ public:
                                               const std::string &keyLabel,
                                               const std::vector<uint8_t> &keyID,
                                               const HsmKeyParameters &params);
+
+    /** Deprecated func
+     * @brief Generates ECC keypair on HSM token according to the spec given.
+     * @note PKCS#11 standard has no rule to avoid having keys with duplicate labels and/or ids.
+     * Therefore care should be taken when generating keys with other tools on the same token.
+     * @param hsm HSM engine handle
+     * @param spec @ref ECCSpec
+     * @param keyLabel String based description of an object on the token. It
+     * can be used in combination with keyID to identify an object.
+     * @param keyID raw bytes based key identifer
+     * @param Struct to set key generation attributes
+     * @return AsymmetricKeypair @ref AsymmetricKeypair
+     * @throw MoCOCrWException Since most of the logic is happening outside of OpenSSL and inside
+     * libp11 and HSM module implementation, we can't know exactly what went wrong. libp11 does log
+     * some things to stderr, check if there's more context there
+     */
+    static AsymmetricKeypair generateKeyOnHSM(HSM &hsm,
+                                              const ECCSpec &spec,
+                                              const std::string &keyLabel,
+                                              const std::vector<uint8_t> &keyID,
+                                              const HsmKeyParams &params);
 #endif
 
 private:

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -339,7 +339,7 @@ public:
                                               const RSASpec &spec,
                                               const std::string &keyLabel,
                                               const std::vector<uint8_t> &keyID,
-                                              const HsmKeyParams &params);
+                                              const HsmKeyParameters &params);
 
     /**
      * @brief Generates ECC keypair on HSM token according to the spec given.
@@ -379,7 +379,7 @@ public:
                                               const ECCSpec &spec,
                                               const std::string &keyLabel,
                                               const std::vector<uint8_t> &keyID,
-                                              const HsmKeyParams &params);
+                                              const HsmKeyParameters &params);
 #endif
 
 private:

--- a/tests/integration/hsm-integration-test.cpp
+++ b/tests/integration/hsm-integration-test.cpp
@@ -452,9 +452,9 @@ int main(void)
         /**
          * Generate extractable and non-extractable keys for ECC and RSA
          */
-        HsmKeyParams hsmKeyParamsExtract = HsmKeyParams::Builder{}.setExtractable(true).build();
+        HsmKeyParameters hsmKeyParamsExtract = HsmKeyParameters::Builder{}.setExtractable(true).build();
 
-        HsmKeyParams hsmKeyParamsDefault = HsmKeyParams::Builder{}.build();
+        HsmKeyParameters hsmKeyParamsDefault = HsmKeyParameters::Builder{}.build();
 
         /* We need a new token otherwise the keys generated before litter the slot */
 

--- a/tests/unit/hsm_mock.h
+++ b/tests/unit/hsm_mock.h
@@ -54,12 +54,12 @@ public:
                  openssl::SSL_EVP_PKEY_Ptr(const RSASpec &spec,
                                            const std::string &keyLabel,
                                            const std::vector<uint8_t> &keyID,
-                                           const HsmKeyParams &params));
+                                           const HsmKeyParameters &params));
     MOCK_METHOD4(generateKey,
                  openssl::SSL_EVP_PKEY_Ptr(const ECCSpec &spec,
                                            const std::string &keyLabel,
                                            const std::vector<uint8_t> &keyID,
-                                           const HsmKeyParams &params));
+                                           const HsmKeyParameters &params));
 };
 
 }  // namespace mococrw

--- a/tests/unit/test_hsm.cpp
+++ b/tests/unit/test_hsm.cpp
@@ -153,7 +153,7 @@ TEST_F(HSMTest, testHSMKeygenWithParams)
     auto hsm = initialiseEngine();
     std::string keyLabel{"key-label"};
     std::vector<uint8_t> keyId{0x12};
-    HsmKeyParams params = HsmKeyParams::Builder{}.setExtractable(true).build();
+    HsmKeyParameters params = HsmKeyParameters::Builder{}.setExtractable(true).build();
     EXPECT_CALL(_mock(),
                 SSL_ENGINE_ctrl_cmd_string(
                         engine, StrEq("PIN"), StrEq(pin.c_str()), 0 /*non-optional*/))


### PR DESCRIPTION
This PR reintroduces the API using HsmKeyParams that was removed in #156 . We want to keep it around and then remove it in a subsequent release.