### PR TITLE
gtest: Rename deprecated ...TEST_CASE API

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-rec
         g++ \
         git \
         googletest \
+        libgtest-dev \
+        libgmock-dev \
         libboost-all-dev \
         libssl-dev \
         # For llvm-symbolizer (used by A/LSAN).

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,19 +2,8 @@ project(mococrw)
 
 if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     if(NOT GMOCK_BOTH_LIBRARIES)
-        find_path(GMOCK_SRC_DIR
-            NAMES src/gmock-all.cc
-            PATHS /usr/src/gmock /usr/src/googletest/googlemock
-            NO_DEFAULT_PATH
-            ONLY_CMAKE_FIND_ROOT_PATH)
-        if(GMOCK_SRC_DIR)
-            message(STATUS "Found GMock sources in ${GMOCK_SRC_DIR}")
-            set(INSTALL_GTEST OFF CACHE BOOL "Enable installation of googletest." FORCE)
-            add_subdirectory("${GMOCK_SRC_DIR}" gmock)
-            set(GMOCK_BOTH_LIBRARIES "gmock_main")
-        else()
-            message(FATAL_ERROR "GMock sources not found build -DBUILD_TESTING=On requested!")
-        endif()
+        find_package(GTest REQUIRED) 
+        set(GMOCK_BOTH_LIBRARIES GTest::gmock_main)
     endif()
 
     add_compile_options(

--- a/tests/unit/test_asymmetric_encryption.cpp
+++ b/tests/unit/test_asymmetric_encryption.cpp
@@ -342,7 +342,7 @@ TEST_P(AsymmetricEncryptionTest, testSuccessfulEncryption)
     EXPECT_EQ(decrypted, message);
 }
 
-INSTANTIATE_TEST_CASE_P(testSuccessfulEncryptionDecryption,
+INSTANTIATE_TEST_SUITE_P(testSuccessfulEncryptionDecryption,
                         AsymmetricEncryptionTest,
                         testing::ValuesIn(AsymmetricEncryptionTest::nominalDataSet));
 

--- a/tests/unit/test_ca.cpp
+++ b/tests/unit/test_ca.cpp
@@ -338,7 +338,7 @@ TEST_P(CATest, testSignedNoCACertificatesCantSignOtherCertificates)
     ASSERT_THROW(newCA.signCSR(csr), MoCOCrWException);
 }
 
-INSTANTIATE_TEST_CASE_P(CATest, CATest, testing::ValuesIn(CATest::_certKeyList));
+INSTANTIATE_TEST_SUITE_P(CATest, CATest, testing::ValuesIn(CATest::_certKeyList));
 
 TEST_F(CATest, testInitializeCAWithNonMatchingKey)
 {

--- a/tests/unit/test_cmac.cpp
+++ b/tests/unit/test_cmac.cpp
@@ -128,7 +128,7 @@ class CalculateCmacValues : public testing::TestWithParam<Testdata>
 {
 };
 
-INSTANTIATE_TEST_CASE_P(cmac,
+INSTANTIATE_TEST_SUITE_P(cmac,
                         CalculateCmacValues,
                         testing::ValuesIn(prepareTestdataForCmacTests()));
 

--- a/tests/unit/test_csr.cpp
+++ b/tests/unit/test_csr.cpp
@@ -279,4 +279,4 @@ TEST_P(CSRTest, testCsrSignatureDigest)
     }
 }
 
-INSTANTIATE_TEST_CASE_P(CSRTest, CSRTest, testing::ValuesIn(CSRTest::_asymmetricKeys));
+INSTANTIATE_TEST_SUITE_P(CSRTest, CSRTest, testing::ValuesIn(CSRTest::_asymmetricKeys));

--- a/tests/unit/test_ecies.cpp
+++ b/tests/unit/test_ecies.cpp
@@ -275,7 +275,7 @@ void testECIES(struct testData data)
 class ECIESTest : public testing::TestWithParam<testData>
 {
 };
-INSTANTIATE_TEST_CASE_P(ecies, ECIESTest, testing::ValuesIn(prepareTestDataForECIESTests()));
+INSTANTIATE_TEST_SUITE_P(ecies, ECIESTest, testing::ValuesIn(prepareTestDataForECIESTests()));
 
 TEST_P(ECIESTest, testWithTestVectors) { testECIES(GetParam()); }
 

--- a/tests/unit/test_hmac.cpp
+++ b/tests/unit/test_hmac.cpp
@@ -118,7 +118,7 @@ static std::vector<inputData> prepareTestDataForHmacTests()
 class HmacTests : public testing::TestWithParam<inputData>
 {
 };
-INSTANTIATE_TEST_CASE_P(hmac, HmacTests, testing::ValuesIn(prepareTestDataForHmacTests()));
+INSTANTIATE_TEST_SUITE_P(hmac, HmacTests, testing::ValuesIn(prepareTestDataForHmacTests()));
 
 TEST_P(HmacTests, tests) { testHmac(GetParam()); }
 

--- a/tests/unit/test_kdf.cpp
+++ b/tests/unit/test_kdf.cpp
@@ -89,7 +89,7 @@ static std::vector<inputData> prepareTestDataForPbkdf2Tests()
 class Pbkdf2Tests : public testing::TestWithParam<inputData>
 {
 };
-INSTANTIATE_TEST_CASE_P(pbkdf2, Pbkdf2Tests, testing::ValuesIn(prepareTestDataForPbkdf2Tests()));
+INSTANTIATE_TEST_SUITE_P(pbkdf2, Pbkdf2Tests, testing::ValuesIn(prepareTestDataForPbkdf2Tests()));
 
 TEST_P(Pbkdf2Tests, tests) { testPbkfd2(GetParam()); }
 
@@ -168,6 +168,6 @@ static std::vector<inputData> prepareTestDataForX963Tests()
 class X963Tests : public testing::TestWithParam<inputData>
 {
 };
-INSTANTIATE_TEST_CASE_P(x9_63, X963Tests, testing::ValuesIn(prepareTestDataForX963Tests()));
+INSTANTIATE_TEST_SUITE_P(x9_63, X963Tests, testing::ValuesIn(prepareTestDataForX963Tests()));
 
 TEST_P(X963Tests, tests) { testX963kdf(GetParam()); }

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -539,7 +539,7 @@ void testKeyTransformation(openssl::ellipticCurveNid nid)
 class KeyGenerationFromPointTests : public testing::TestWithParam<openssl::ellipticCurveNid>
 {
 };
-INSTANTIATE_TEST_CASE_P(keyGenFromPointTest,
+INSTANTIATE_TEST_SUITE_P(keyGenFromPointTest,
                         KeyGenerationFromPointTests,
                         testing::ValuesIn(getEllipticCurveNids()));
 

--- a/tests/unit/test_padding_mode.cpp
+++ b/tests/unit/test_padding_mode.cpp
@@ -248,6 +248,6 @@ TEST_P(PaddingModeTest, testMessageSize)
     }
 }
 
-INSTANTIATE_TEST_CASE_P(testMessageSize,
+INSTANTIATE_TEST_SUITE_P(testMessageSize,
                         PaddingModeTest,
                         testing::ValuesIn(PaddingModeTest::messageSizeDataSet));

--- a/tests/unit/test_signature.cpp
+++ b/tests/unit/test_signature.cpp
@@ -711,15 +711,15 @@ TEST_P(SignatureTest, testSuccessfullVerificationOfKnownValidSignature)
     EXPECT_NO_THROW(param.verifyCtx->verifyMessage(param.validSignature, signVerifyTestMessage));
 }
 
-INSTANTIATE_TEST_CASE_P(testSuccessfulSigningAndVerification,
+INSTANTIATE_TEST_SUITE_P(testSuccessfulSigningAndVerification,
                         SignatureTest,
                         testing::ValuesIn(SignatureTest::SignatureTestData));
 
-INSTANTIATE_TEST_CASE_P(testUnsuccessfulSignatureAndVerificationWithModifiedSignature,
+INSTANTIATE_TEST_SUITE_P(testUnsuccessfulSignatureAndVerificationWithModifiedSignature,
                         SignatureTest,
                         testing::ValuesIn(SignatureTest::SignatureTestData));
 
-INSTANTIATE_TEST_CASE_P(testSuccessfullVerificationOfKnownValidSignature,
+INSTANTIATE_TEST_SUITE_P(testSuccessfullVerificationOfKnownValidSignature,
                         SignatureTest,
                         testing::ValuesIn(SignatureTest::SignatureTestData));
 

--- a/tests/unit/test_symmetric_crypto.cpp
+++ b/tests/unit/test_symmetric_crypto.cpp
@@ -126,7 +126,7 @@ static std::vector<SymmetricCipherReferenceTestData> prepareTestDataForReference
     return testData;
 }
 
-INSTANTIATE_TEST_CASE_P(ReferenceDecryption,
+INSTANTIATE_TEST_SUITE_P(ReferenceDecryption,
                         SymmetricCipherReferenceTest,
                         testing::ValuesIn(prepareTestDataForReferenceDecryption()));
 
@@ -257,15 +257,15 @@ static std::vector<EncrytDecryptTestData> prepareTestDataForMode(SymmetricCipher
     return testData;
 }
 
-INSTANTIATE_TEST_CASE_P(GCM,
+INSTANTIATE_TEST_SUITE_P(GCM,
                         SymmetricCipherTest,
                         testing::ValuesIn(prepareTestDataForMode(SymmetricCipherMode::GCM)));
 
-INSTANTIATE_TEST_CASE_P(CBC,
+INSTANTIATE_TEST_SUITE_P(CBC,
                         SymmetricCipherTest,
                         testing::ValuesIn(prepareTestDataForMode(SymmetricCipherMode::CBC)));
 
-INSTANTIATE_TEST_CASE_P(CTR,
+INSTANTIATE_TEST_SUITE_P(CTR,
                         SymmetricCipherTest,
                         testing::ValuesIn(prepareTestDataForMode(SymmetricCipherMode::CTR)));
 
@@ -321,7 +321,7 @@ TEST_P(SymmetricCipherWrongParametersTest, throwsIfBuilderDoesNotMatchMode)
     }
 }
 
-INSTANTIATE_TEST_CASE_P(AllModes,
+INSTANTIATE_TEST_SUITE_P(AllModes,
                         SymmetricCipherWrongParametersTest,
                         testing::ValuesIn(AllSupportedCipherModesToTest));
 
@@ -436,7 +436,7 @@ TEST_P(SymmetricCipherAdvancedTest, readDecryptedTextInChunks)
     ASSERT_THAT(decryptedText, ::testing::ElementsAreArray(_plaintext));
 }
 
-INSTANTIATE_TEST_CASE_P(Chunks,
+INSTANTIATE_TEST_SUITE_P(Chunks,
                         SymmetricCipherAdvancedTest,
                         testing::ValuesIn(AllSupportedCipherModesToTest));
 


### PR DESCRIPTION
With version 1.10.0 gtest renames its ...TEST_CASE methods to ...TEST_SUITE.
(https://github.com/google/googletest/releases/tag/release-1.10.0)

This commit adapts the new naming, it replaces all INSTANTIATE_TEST_CASE_P in favor of INSTANTIATE_TEST_SUITE_P and uses the find_package methode in the CMake file to find the gtest lib on the system.